### PR TITLE
fix: Resolve UE 5.5 compilation errors with backward compatibility for UE 5.3/5.4Fix UE 5.5 compilation errors with backward compatibility for UE 5.3/5.4

### DIFF
--- a/plugins/McpAutomationBridge/McpAutomationBridge.uplugin
+++ b/plugins/McpAutomationBridge/McpAutomationBridge.uplugin
@@ -50,7 +50,8 @@
     },
     {
       "Name": "InterchangeOpenUSD",
-      "Enabled": true
+      "Enabled": true,
+      "Optional": true
     },
     {
       "Name": "DataValidation",

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_LevelStructureHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_LevelStructureHandlers.cpp
@@ -900,7 +900,12 @@ static bool HandleCreateDataLayer(
     }
 
     // Configure initial visibility and loaded state
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5
+    // UE 5.5+: SetDataLayerIsInitiallyVisible was removed, use SetDataLayerVisibility instead
+    DataLayerEditorSubsystem->SetDataLayerVisibility(NewDataLayerInstance, bIsInitiallyVisible);
+#else
     DataLayerEditorSubsystem->SetDataLayerIsInitiallyVisible(NewDataLayerInstance, bIsInitiallyVisible);
+#endif
     DataLayerEditorSubsystem->SetDataLayerIsLoadedInEditor(NewDataLayerInstance, bIsInitiallyLoaded, false);
 
     // Mark world dirty

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_MaterialAuthoringHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_MaterialAuthoringHandlers.cpp
@@ -22,6 +22,10 @@
 #include "Factories/MaterialInstanceConstantFactoryNew.h"
 #include "IAssetTools.h"
 #include "Materials/Material.h"
+// MaterialDomain.h is required in UE 5.5+ for EMaterialDomain enum
+#if __has_include("MaterialDomain.h")
+#include "MaterialDomain.h"
+#endif
 #include "Materials/MaterialExpression.h"
 #include "Materials/MaterialExpressionAdd.h"
 #include "Materials/MaterialExpressionAppendVector.h"

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_NiagaraAuthoringHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_NiagaraAuthoringHandlers.cpp
@@ -162,9 +162,9 @@ bool UMcpAutomationBridgeSubsystem::HandleManageNiagaraAuthoringAction(
             return true;
         }
 
-        UNiagaraSystemFactoryNew* Factory = NewObject<UNiagaraSystemFactoryNew>();
-        UNiagaraSystem* NewSystem = Cast<UNiagaraSystem>(Factory->FactoryCreateNew(
-            UNiagaraSystem::StaticClass(), Package, FName(*Name), RF_Public | RF_Standalone, nullptr, GWarn));
+        // Use AssetTools for cross-version compatibility (UE 5.5+ factory linking changes)
+        IAssetTools& AssetTools = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools").Get();
+        UNiagaraSystem* NewSystem = Cast<UNiagaraSystem>(AssetTools.CreateAsset(Name, Path, UNiagaraSystem::StaticClass(), nullptr));
 
         if (!NewSystem)
         {

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_NiagaraHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_NiagaraHandlers.cpp
@@ -91,20 +91,13 @@ bool UMcpAutomationBridgeSubsystem::HandleCreateNiagaraSystem(
     return true;
   }
 
-  UNiagaraSystemFactoryNew *Factory = NewObject<UNiagaraSystemFactoryNew>();
-  if (!Factory) {
-    SendAutomationError(RequestingSocket, RequestId,
-                        TEXT("Failed to create Niagara system factory"),
-                        TEXT("FACTORY_FAILED"));
-    return true;
-  }
-
   FString PackagePath = SavePath;
   FString AssetName = SystemName;
   FAssetToolsModule &AssetToolsModule =
       FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools");
+  // Use nullptr for factory - AssetTools will use the default factory for UNiagaraSystem
   UObject *NewAsset = AssetToolsModule.Get().CreateAsset(
-      AssetName, PackagePath, UNiagaraSystem::StaticClass(), Factory);
+      AssetName, PackagePath, UNiagaraSystem::StaticClass(), nullptr);
   UNiagaraSystem *NiagaraSystem = Cast<UNiagaraSystem>(NewAsset);
   McpSafeAssetSave(NiagaraSystem);
 


### PR DESCRIPTION
- Make InterchangeOpenUSD plugin dependency optional
- Add version guards for FMetaData -> UMetaData API change in UE 5.5
- Add conditional include for MaterialDomain.h (required in UE 5.5+)
- Guard SetDataLayerIsInitiallyVisible call (removed in UE 5.5)
- Replace direct UNiagaraSystemFactoryNew usage with AssetTools.CreateAsset() for cross-version compatibility

  ---
  Summary

  Fix compilation errors when building the McpAutomationBridge plugin on Unreal Engine 5.5, while maintaining backward compatibility with UE 5.3 and 5.4.

  Changes

  - Make InterchangeOpenUSD plugin dependency optional (not installed by default in all UE 5.5 installations)
  - Add version guards for FMetaData → UMetaData* API change in UE 5.5
  - Add conditional include for MaterialDomain.h (required in UE 5.5+ for EMaterialDomain enum)
  - Guard SetDataLayerIsInitiallyVisible call which was removed in UE 5.5
  - Replace direct UNiagaraSystemFactoryNew factory instantiation with AssetTools.CreateAsset() to fix linker errors

  Related Issues

  Type of Change

  - 🐛 Bug fix (non-breaking change that fixes an issue)

  Testing

  - Tested with Unreal Engine (version: 5.5)
  - Tested MCP client integration (client: ___)
  - Added/updated tests

  Pre-Merge Checklist

  - Code follows project style guidelines
  - Self-reviewed the code
  - Updated relevant documentation (if needed)
  - Added/updated tests (if applicable)
  - CI passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Unreal Engine 5.5+ by updating metadata handling, data layer visibility, and material domain includes.

* **Chores**
  * Refined Niagara and effect asset creation to use the standardized asset tools pipeline.
  * Adjusted plugin manifest to mark the InterchangeOpenUSD entry as optional.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->