### PR TITLE
🛡️ Sentinel: Fix command injection in LandscapeTools

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** `UITools` methods (e.g., `createMenu`, `createTooltip`) constructed console commands using string interpolation with user-provided text (like button labels). This allowed attackers to break out of quoted strings and potentially inject additional commands or arguments (e.g., `"; Quit; "`).
 **Learning:** Relying on basic string quoting for console commands is unsafe if the input itself can contain quotes. `CommandValidator` only checks for known dangerous commands but doesn't prevent argument injection or syntax breaking within valid commands.
 **Prevention:** Implement and use a dedicated `sanitizeConsoleString` utility that escapes or replaces quotes (`"`) and removes newlines before interpolating user input into command strings. Always treat user-facing text as untrusted when building command lines.
+
+## 2025-05-26 - [Sanitization Strategy for Unreal Console Commands]
+**Vulnerability:** `LandscapeTools` used raw string interpolation for console commands, allowing command injection via separators (e.g., `;`). Applying `sanitizeAssetName` fixed injection but broke functionality for actors with spaces in their names by replacing spaces with underscores.
+**Learning:** `sanitizeAssetName` is appropriate for strict asset paths/names but too aggressive for Actor Labels (which allow spaces). The correct pattern for Actor Labels in console commands is to use `sanitizeConsoleString` (which escapes quotes) and wrap the argument in double quotes.
+**Prevention:** When constructing console commands for arguments that might contain spaces (like Actor names), use `"${sanitizeConsoleString(value)}"`. For strict identifiers, use `sanitizeAssetName`.

--- a/tests/unit/tools/landscape_security.test.ts
+++ b/tests/unit/tools/landscape_security.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LandscapeTools } from '../../../src/tools/landscape';
+import { UnrealBridge } from '../../../src/unreal-bridge';
+import { AutomationBridge } from '../../../src/automation';
+
+describe('LandscapeTools Security', () => {
+    let bridge: UnrealBridge;
+    let automationBridge: AutomationBridge;
+    let landscapeTools: LandscapeTools;
+
+    beforeEach(() => {
+        bridge = {
+            executeConsoleCommand: vi.fn().mockResolvedValue({ success: true, message: 'OK' }),
+            executeConsoleCommands: vi.fn().mockResolvedValue([{ success: true }])
+        } as unknown as UnrealBridge;
+
+        automationBridge = {
+             sendAutomationRequest: vi.fn().mockResolvedValue({ success: true })
+        } as unknown as AutomationBridge;
+
+        landscapeTools = new LandscapeTools(bridge, automationBridge);
+    });
+
+    it('should sanitize landscape name in createLandscapeGrass to prevent command injection', async () => {
+        const maliciousName = 'MyLandscape; quit';
+        const grassType = 'Grass_Type';
+
+        await landscapeTools.createLandscapeGrass({
+            landscapeName: maliciousName,
+            grassType: grassType
+        });
+
+        const executeCommandsMock = bridge.executeConsoleCommands as any;
+        expect(executeCommandsMock).toHaveBeenCalled();
+        const commands = executeCommandsMock.mock.calls[0][0];
+
+        // Should be quoted: CreateLandscapeGrass "MyLandscape; quit" "Grass_Type"
+        expect(commands[0]).toContain('"MyLandscape; quit"');
+    });
+
+    it('should sanitize grass type in createLandscapeGrass', async () => {
+        const landscapeName = 'MyLandscape';
+        const maliciousGrassType = 'GrassType; quit';
+
+        await landscapeTools.createLandscapeGrass({
+            landscapeName: landscapeName,
+            grassType: maliciousGrassType
+        });
+
+        const executeCommandsMock = bridge.executeConsoleCommands as any;
+        expect(executeCommandsMock).toHaveBeenCalled();
+        const commands = executeCommandsMock.mock.calls[0][0];
+
+        // Should be quoted: CreateLandscapeGrass "MyLandscape" "GrassType; quit"
+        expect(commands[0]).toContain('"GrassType; quit"');
+    });
+
+    it('should sanitize inputs in createWaterBody', async () => {
+        const maliciousName = 'WaterBody; quit';
+
+        await landscapeTools.createWaterBody({
+            type: 'Lake',
+            name: maliciousName
+        });
+
+        const executeCommandMock = bridge.executeConsoleCommand as any;
+        expect(executeCommandMock).toHaveBeenCalled();
+        const command = executeCommandMock.mock.calls[0][0];
+
+        // Should be quoted: CreateWaterBody "Lake" "WaterBody; quit" ...
+        expect(command).toContain('"WaterBody; quit"');
+    });
+
+    it('should sanitize landscape name in updateLandscapeCollision', async () => {
+        const maliciousName = 'Landscape; quit';
+
+        await landscapeTools.updateLandscapeCollision({
+            landscapeName: maliciousName,
+            simpleCollision: true
+        });
+
+        const executeCommandsMock = bridge.executeConsoleCommands as any;
+        expect(executeCommandsMock).toHaveBeenCalled();
+        const commands = executeCommandsMock.mock.calls[0][0];
+
+        // Check the UpdateLandscapeCollision command
+        const updateCmd = commands.find((cmd: string) => cmd.startsWith('UpdateLandscapeCollision'));
+        expect(updateCmd).toBeDefined();
+        // Should be quoted: UpdateLandscapeCollision "Landscape; quit"
+        expect(updateCmd).toContain('"Landscape; quit"');
+    });
+
+    it('should sanitize material path in setLandscapeMaterial', async () => {
+        const landscapeName = 'Landscape';
+        const maliciousPath = '/Game/Materials/MyMaterial; quit';
+
+        await landscapeTools.setLandscapeMaterial({
+            landscapeName,
+            materialPath: maliciousPath
+        });
+
+        const automationSpy = automationBridge.sendAutomationRequest as any;
+        expect(automationSpy).toHaveBeenCalled();
+        const payload = automationSpy.mock.calls[0][1];
+        // setLandscapeMaterial uses sanitizePath which replaces invalid chars with _
+        expect(payload.materialPath).toBe('/Game/Materials/MyMaterial_quit');
+    });
+
+    it('should sanitize type in createWaterBody', async () => {
+         const maliciousType = 'Ocean; quit' as any;
+
+         await landscapeTools.createWaterBody({
+             type: maliciousType,
+             name: 'Water'
+         });
+
+         const executeCommandMock = bridge.executeConsoleCommand as any;
+         expect(executeCommandMock).toHaveBeenCalled();
+         const command = executeCommandMock.mock.calls[0][0];
+
+         // Should be quoted: CreateWaterBody "Ocean; quit" ...
+         expect(command).toContain('"Ocean; quit"');
+    });
+});


### PR DESCRIPTION
Identified and fixed multiple command injection vulnerabilities in `LandscapeTools` where user input was interpolated directly into console commands.

Applied `sanitizeConsoleString` and double-quoting for arguments that support spaces (like Landscape Actor names) to prevent argument injection and command chaining (e.g., `; rm -rf`).

Also enforced `sanitizePath` for `setLandscapeMaterial` to prevent path traversal issues.

Verified with new security unit tests covering all modified methods.

---
*PR created automatically by Jules for task [10035753548034476039](https://jules.google.com/task/10035753548034476039) started by @ChiR24*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input sanitization in landscape tools to safely handle special characters and spaces in asset names and paths.

* **Tests**
  * Added security test suite validating proper sanitization of user inputs in landscape operations.

* **Documentation**
  * Updated sanitization guidance for Unreal console command handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->