### PR TITLE
🛡️ Sentinel: [Security Enhancement] Enforce .ini extension in readIniFile

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** `UITools` methods (e.g., `createMenu`, `createTooltip`) constructed console commands using string interpolation with user-provided text (like button labels). This allowed attackers to break out of quoted strings and potentially inject additional commands or arguments (e.g., `"; Quit; "`).
 **Learning:** Relying on basic string quoting for console commands is unsafe if the input itself can contain quotes. `CommandValidator` only checks for known dangerous commands but doesn't prevent argument injection or syntax breaking within valid commands.
 **Prevention:** Implement and use a dedicated `sanitizeConsoleString` utility that escapes or replaces quotes (`"`) and removes newlines before interpolating user input into command strings. Always treat user-facing text as untrusted when building command lines.
+
+## 2026-01-29 - [Unvalidated File Read in Utility Functions]
+**Vulnerability:** The `readIniFile` utility allowed reading arbitrary files because it lacked validation of the file extension or path. While existing callers might have been safe, the utility itself was insecure by design.
+**Learning:** Utility functions that perform file I/O must enforce strict validation (e.g., file extensions, allowed directories) internally, rather than relying solely on callers. This provides defense-in-depth.
+**Prevention:** Enforce file extension checks (e.g., must end in `.ini`) and path allowlisting within the low-level utility function itself.

--- a/src/utils/ini-reader.ts
+++ b/src/utils/ini-reader.ts
@@ -3,6 +3,10 @@ import path from 'path';
 
 export async function readIniFile(filePath: string): Promise<Record<string, Record<string, string>>> {
   try {
+    if (!filePath.toLowerCase().endsWith('.ini')) {
+      throw new Error('Invalid file extension: must be .ini');
+    }
+
     const content = await fs.readFile(filePath, 'utf-8');
     const result: Record<string, Record<string, string>> = {};
     let currentSection = '';

--- a/src/utils/read_ini_file_security.test.ts
+++ b/src/utils/read_ini_file_security.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { readIniFile } from './ini-reader.js';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+
+describe('readIniFile Security', () => {
+    let tmpDir: string;
+    let textFile: string;
+
+    beforeEach(async () => {
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ue-mcp-test-ini-'));
+        textFile = path.join(tmpDir, 'sensitive.txt');
+        await fs.writeFile(textFile, 'This is a sensitive file');
+    });
+
+    afterEach(async () => {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('should reject files without .ini extension', async () => {
+        await expect(readIniFile(textFile)).rejects.toThrow(/must be \.ini/i);
+    });
+});


### PR DESCRIPTION
Enforced `.ini` file extension in `readIniFile` utility to prevent arbitrary file reads. Added a new security unit test to verify this constraint. Verified that existing tests pass.

---
*PR created automatically by Jules for task [9694046976908172515](https://jules.google.com/task/9694046976908172515) started by @ChiR24*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Implemented file extension validation for configuration file reading operations to prevent unvalidated file access.

* **Tests**
  * Added security tests to validate proper rejection of non-configuration files.

* **Documentation**
  * Updated changelog documenting security improvements and preventive measures for file validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->