### PR TITLE
🛡️ Sentinel: Enforce .ini extension in readIniFile

### DIFF
--- a/src/utils/ini-reader.ts
+++ b/src/utils/ini-reader.ts
@@ -2,6 +2,11 @@ import fs from 'fs/promises';
 import path from 'path';
 
 export async function readIniFile(filePath: string): Promise<Record<string, Record<string, string>>> {
+  // Security check: strictly enforce .ini extension to prevent arbitrary file reads
+  if (!filePath.toLowerCase().endsWith('.ini')) {
+    throw new Error(`Invalid file extension: ${filePath}. Only .ini files are allowed.`);
+  }
+
   try {
     const content = await fs.readFile(filePath, 'utf-8');
     const result: Record<string, Record<string, string>> = {};

--- a/src/utils/read_ini_file_security.test.ts
+++ b/src/utils/read_ini_file_security.test.ts
@@ -1,0 +1,36 @@
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { readIniFile } from './ini-reader.js';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+
+describe('readIniFile Security', () => {
+    let tmpDir: string;
+    let txtFile: string;
+    let iniFile: string;
+
+    beforeEach(async () => {
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ue-mcp-test-ini-sec-'));
+        txtFile = path.join(tmpDir, 'test.txt');
+        iniFile = path.join(tmpDir, 'test.ini');
+
+        await fs.writeFile(txtFile, 'This is a text file');
+        await fs.writeFile(iniFile, '[Section]\nKey=Value');
+    });
+
+    afterEach(async () => {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('should block reading non-ini files', async () => {
+        await expect(readIniFile(txtFile)).rejects.toThrow(/Invalid file extension/);
+    });
+
+    it('should allow reading valid ini files', async () => {
+        const result = await readIniFile(iniFile);
+        expect(result).toBeDefined();
+        expect(result['Section']).toBeDefined();
+        expect(result['Section']['Key']).toBe('Value');
+    });
+});


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix Arbitrary File Read Risk in readIniFile

**Vulnerability:** The `readIniFile` utility previously allowed reading any file provided as a path, lacking validation of the file extension. While typical usage (e.g., `getProjectSetting`) sanitized inputs, the utility itself was insecure if exposed or misused.

**Fix:** Added strict validation to ensure `filePath` ends with `.ini` (case-insensitive) before reading.

**Verification:** Added `src/utils/read_ini_file_security.test.ts` to verify that non-`.ini` files are rejected and valid `.ini` files are read correctly. Existing tests pass.

---
*PR created automatically by Jules for task [12080584709150739826](https://jules.google.com/task/12080584709150739826) started by @ChiR24*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added file extension validation to prevent reading non-INI files. The system now throws an error when attempting to read files that don't have the `.ini` extension.

* **Tests**
  * Added comprehensive security test coverage for file validation behavior, verifying that invalid file types are rejected and valid INI files are processed correctly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->