### PR TITLE
fix: add missing eslint config to Docker and include header

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ COPY package*.json ./
 # Install ALL dependencies (including dev) for building - skip prepare script
 RUN npm ci --ignore-scripts
 
-# Copy TypeScript config and source files
-COPY tsconfig.json ./
+# Copy TypeScript config, ESLint config, and source files
+COPY tsconfig.json eslint.config.mjs ./
 COPY src ./src
 
 # Build the TypeScript project

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_NetworkingHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_NetworkingHandlers.cpp
@@ -12,6 +12,7 @@
 // - Utility (info queries)
 
 #include "McpAutomationBridgeSubsystem.h"
+#include "McpAutomationBridgeHelpers.h"
 #include "McpBridgeWebSocket.h"
 #include "Misc/EngineVersionComparison.h"
 


### PR DESCRIPTION
## Summary

Fix minor build issues: missing ESLint config in Docker build and missing header include in C++ plugin.

## Changes

- Add `eslint.config.mjs` to Dockerfile COPY command to ensure ESLint config is available during Docker builds
- Add missing `#include "McpAutomationBridgeHelpers.h"` in NetworkingHandlers

## Related Issues

None

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [x] 🔧 Configuration/build change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test addition/update

## Testing

- [x] Tested with Unreal Engine (version: 5.7)
- [ ] Tested MCP client integration (client: ___)
- [ ] Added/updated tests

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [ ] Updated relevant documentation (if needed)
- [ ] Added/updated tests (if applicable)
- [x] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to include ESLint configuration in the Docker image build context.
  * Internal code organization improvements to enhance code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->