### PR TITLE
feat(bridge): add IPv6 support and hostname validation

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpBridgeWebSocket.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpBridgeWebSocket.cpp
@@ -869,15 +869,16 @@ uint32 FMcpBridgeWebSocket::RunServer() {
              TEXT("IPv6 loopback '::1' not supported on this system. Falling back to 127.0.0.1."));
       
       // Re-create socket as IPv4 since we're falling back to IPv4 address
-      ListenSocket->Close();
-      ISocketSubsystem *SocketSubsystem = ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM);
+      SocketSubsystem->DestroySocket(ListenSocket);
       ListenSocket = SocketSubsystem->CreateSocket(
           NAME_Stream, TEXT("McpAutomationBridgeListenSocket"), FName());
-      if (ListenSocket) {
-        ListenSocket->SetReuseAddr(true);
-        ListenSocket->SetNonBlocking(false);
-        UE_LOG(LogMcpAutomationBridgeSubsystem, Log, TEXT("Re-created socket for IPv4 fallback."));
+      if (!ListenSocket) {
+        UE_LOG(LogMcpAutomationBridgeSubsystem, Error, TEXT("Failed to re-create IPv4 socket for fallback."));
+        return 0;
       }
+      ListenSocket->SetReuseAddr(true);
+      ListenSocket->SetNonBlocking(false);
+      UE_LOG(LogMcpAutomationBridgeSubsystem, Log, TEXT("Re-created socket for IPv4 fallback."));
       
       bool bFallbackIsValidIp = false;
       ListenAddr->SetIp(TEXT("127.0.0.1"), bFallbackIsValidIp);

--- a/src/automation/bridge.test.ts
+++ b/src/automation/bridge.test.ts
@@ -133,7 +133,7 @@ describe('AutomationBridge Host Validation', () => {
                 port: 8091, 
                 allowNonLoopback: true 
             });
-            expect(bridge.getStatus().host).toBe('[fe80::1]');
+            expect(bridge.getStatus().host).toBe('fe80::1');
         });
     });
 
@@ -150,15 +150,6 @@ describe('AutomationBridge Host Validation', () => {
         it('should reject out-of-range IPv4 octets', () => {
             const bridge = new AutomationBridge({ 
                 host: '256.1.1.1', 
-                port: 8091, 
-                allowNonLoopback: true 
-            });
-            expect(bridge.getStatus().host).toBe('127.0.0.1');
-        });
-
-        it('should reject invalid hostname format', () => {
-            const bridge = new AutomationBridge({ 
-                host: '-invalid-hostname', 
                 port: 8091, 
                 allowNonLoopback: true 
             });

--- a/src/automation/bridge.test.ts
+++ b/src/automation/bridge.test.ts
@@ -155,6 +155,15 @@ describe('AutomationBridge Host Validation', () => {
             });
             expect(bridge.getStatus().host).toBe('127.0.0.1');
         });
+
+        it('should reject hostname with consecutive dots', () => {
+            const bridge = new AutomationBridge({ 
+                host: 'example..com', 
+                port: 8091, 
+                allowNonLoopback: true 
+            });
+            expect(bridge.getStatus().host).toBe('127.0.0.1');
+        });
     });
 
     describe('Domain names/hostnames with allowNonLoopback=true', () => {

--- a/src/automation/bridge.ts
+++ b/src/automation/bridge.ts
@@ -516,10 +516,12 @@ export class AutomationBridge extends EventEmitter {
         if (!host.includes(':')) {
             return host;
         }
-        // Percent-encode zone ID delimiter (%) per RFC 6874
-        // e.g., fe80::1%eth0 becomes [fe80::1%25eth0]
-        const encodedHost = host.replace(/%/g, '%25');
-        return `[${encodedHost}]`;
+        // Strip zone ID if present (e.g., fe80::1%eth0 -> fe80::1)
+        // Zone IDs are not supported by Node.js URL parser and are only
+        // meaningful for link-local addresses on the local machine
+        const zoneIndex = host.indexOf('%');
+        const hostWithoutZone = zoneIndex >= 0 ? host.slice(0, zoneIndex) : host;
+        return `[${hostWithoutZone}]`;
     }
 
     private getClientUrl(): string {

--- a/src/automation/bridge.ts
+++ b/src/automation/bridge.ts
@@ -123,8 +123,9 @@ export class AutomationBridge extends EventEmitter {
                         `SECURITY: ${label} set to non-loopback address '${trimmed}'. ` +
                         'The automation bridge will be accessible from your local network.'
                     );
-                    // Return original trimmed value (preserving brackets/zone if provided)
-                    return trimmed;
+                    // Return address without brackets (consistent with loopback handling)
+                    // Brackets will be re-added by formatHostForUrl if needed
+                    return addressToValidate;
                 }
                 
                 // Check if it's a valid hostname (domain name)

--- a/src/automation/bridge.ts
+++ b/src/automation/bridge.ts
@@ -133,7 +133,7 @@ export class AutomationBridge extends EventEmitter {
                 const hasLetters = /[a-zA-Z]/.test(trimmed);
                 if (hasLetters) {
                     // Simple hostname validation: no spaces, no leading/trailing hyphens or dots
-                    const isValidHostname = /^[a-zA-Z0-9][a-zA-Z0-9\-\.]*[a-zA-Z0-9]$/.test(trimmed) ||
+                    const isValidHostname = /^[a-zA-Z0-9][a-zA-Z0-9-.]*[a-zA-Z0-9]$/.test(trimmed) ||
                                            /^[a-zA-Z0-9]$/.test(trimmed);
                     if (isValidHostname && !trimmed.includes('..')) {
                         this.log.warn(


### PR DESCRIPTION

## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact. -->
This pull request introduces significant improvements to host validation logic for the `AutomationBridge`, adds comprehensive test coverage, and enhances IPv6 and hostname support. The main changes are a refactor of the validation mechanism to use Node.js's built-in IP validation, improved handling for IPv6 addresses and hostnames, and a new test suite covering a wide range of edge cases.

Host validation improvements:

* Refactored host validation logic in `AutomationBridge` to use Node.js `net.isIP` for IPv4 and IPv6 detection, including support for bracketed IPv6 addresses and zone IDs. Hostnames are now validated with stricter rules, and invalid formats fall back to the default loopback address. (`src/automation/bridge.ts`, [src/automation/bridge.tsL105-R150](diffhunk://#diff-ca9341212a22ab684c45e5dfa4564ee0941ea87c138b0e5bb4113edf4f8973f1L105-R150))
* Improved logging to clarify when non-loopback addresses or hostnames are accepted and when fallback occurs due to invalid input. (`src/automation/bridge.ts`, [src/automation/bridge.tsL105-R150](diffhunk://#diff-ca9341212a22ab684c45e5dfa4564ee0941ea87c138b0e5bb4113edf4f8973f1L105-R150))

IPv6 and hostname support:

* Added support for bracketed IPv6 addresses and zone IDs in host validation, preserving the original format when valid. (`src/automation/bridge.ts`, [src/automation/bridge.tsL105-R150](diffhunk://#diff-ca9341212a22ab684c45e5dfa4564ee0941ea87c138b0e5bb4113edf4f8973f1L105-R150))
* Enhanced hostname validation to allow domain names, subdomains, and simple hostnames, while rejecting invalid formats and consecutive dots. (`src/automation/bridge.ts`, [src/automation/bridge.tsL105-R150](diffhunk://#diff-ca9341212a22ab684c45e5dfa4564ee0941ea87c138b0e5bb4113edf4f8973f1L105-R150))

Test coverage:

* Added a comprehensive test suite for host validation in `src/automation/bridge.test.ts`, covering loopback, non-loopback, IPv4, IPv6, hostnames, environment variable overrides, edge cases, and zone IDs. (`src/automation/bridge.test.ts`, [src/automation/bridge.test.tsR1-R292](diffhunk://#diff-e630ce0686d812fe382a38a07cefb0789588caf8e92ba8df03e2388a7695bb20R1-R292))
* Updated existing tests to use more representative invalid hostnames and clarified test descriptions. (`tests/unit/automation/bridge_host_validation.test.ts`, [tests/unit/automation/bridge_host_validation.test.tsL86-R88](diffhunk://#diff-d1fa943759a1b547291fcbba7099ee01e4fb0af986579650ce99e02a262e5e80L86-R88))

Unreal Engine server improvements:

* Updated Unreal Engine socket creation logic to select IPv6 protocol family based on host address, improving support for IPv6 sockets. (`plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpBridgeWebSocket.cpp`, [plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpBridgeWebSocket.cppL813-R825](diffhunk://#diff-4cb04732f4278786d0807ac8c05aff3b928b1c806e159f35fb41ca6280daebfbL813-R825))
* Enhanced server address resolution to attempt DNS lookup for non-IP hosts, with clear logging for fallback scenarios. (`plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpBridgeWebSocket.cpp`, [plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpBridgeWebSocket.cppR885-R914](diffhunk://#diff-4cb04732f4278786d0807ac8c05aff3b928b1c806e159f35fb41ca6280daebfbR885-R914))
## Changes

<!-- List the key changes made in this PR. -->
- Enhance the automation bridge to support IPv6 addresses and hostname resolution. The backend now detects IPv6 hosts by checking for colons in the address, uses the non-deprecated FName-based protocol specification for socket creation, and implements proper DNS resolution via GetAddressInfo instead of falling back to 127.0.0.1. The frontend validation now handles IPv6 addresses with brackets and zone IDs, validates hostnames with letters, and provides clearer error messages for invalid addresses.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). 
     If only related, use: Related to #123 -->
#191 
## Type of Change

<!-- Check all that apply -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration/build change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test addition/update

## Testing

<!-- Describe how to test these changes -->

- [ ] Tested with Unreal Engine (version: ___)
- [ ] Tested MCP client integration (client: ___)
- [ ] Added/updated tests

## Pre-Merge Checklist

- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Updated relevant documentation (if needed)
- [ ] Added/updated tests (if applicable)
- [ ] CI passes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chir24/unreal_mcp/pull/194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects IPv6 at startup and shows clearer IPv6 status in logs
  * Resolves hostnames via DNS with fallback to localhost when resolution fails
  * Accepts domain names for host configuration and preserves IPv6 zone IDs
  * Config/env option to allow non-loopback addresses

* **Tests**
  * Comprehensive host-validation test suite covering loopback/non-loopback, IPv4/IPv6, DNS, env var behavior, and edge cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->