### PR TITLE
fix: resolve npm install failure from release archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,40 +79,42 @@ jobs:
             LICENSE
           
           # Source archive (for rebuilding)
+          OPTIONAL_PATHS=""
+          [ -d "wasm" ] && OPTIONAL_PATHS="$OPTIONAL_PATHS wasm/"
+          [ -f "server.json" ] && OPTIONAL_PATHS="$OPTIONAL_PATHS server.json"
+          
           tar -czvf release-artifacts/unreal-engine-mcp-server-${{ steps.version.outputs.version }}-source.tar.gz \
             dist/ \
             src/ \
-            wasm/ \
             package.json \
             package-lock.json \
             tsconfig.json \
             eslint.config.mjs \
-            server.json \
             README.md \
             CHANGELOG.md \
-            LICENSE
+            LICENSE \
+            $OPTIONAL_PATHS
           
           zip -r release-artifacts/unreal-engine-mcp-server-${{ steps.version.outputs.version }}-source.zip \
             dist/ \
             src/ \
-            wasm/ \
             package.json \
             package-lock.json \
             tsconfig.json \
             eslint.config.mjs \
-            server.json \
             README.md \
             CHANGELOG.md \
-            LICENSE
+            LICENSE \
+            $OPTIONAL_PATHS
 
       - name: Create Plugin archive
         run: |
-          if [ -d "Plugins/McpAutomationBridge" ]; then
+          if [ -d "plugins/McpAutomationBridge" ]; then
             tar -czvf release-artifacts/McpAutomationBridge-plugin-${{ steps.version.outputs.version }}.tar.gz \
-              Plugins/McpAutomationBridge/
+              plugins/McpAutomationBridge/
             
             zip -r release-artifacts/McpAutomationBridge-plugin-${{ steps.version.outputs.version }}.zip \
-              Plugins/McpAutomationBridge/
+              plugins/McpAutomationBridge/
             
             echo "Plugin archive created"
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
         run: |
           mkdir -p release-artifacts
           
+          # Pre-built archive (ready to run)
           tar -czvf release-artifacts/unreal-engine-mcp-server-${{ steps.version.outputs.version }}.tar.gz \
             dist/ \
             package.json \
@@ -76,15 +77,42 @@ jobs:
             README.md \
             CHANGELOG.md \
             LICENSE
+          
+          # Source archive (for rebuilding)
+          tar -czvf release-artifacts/unreal-engine-mcp-server-${{ steps.version.outputs.version }}-source.tar.gz \
+            dist/ \
+            src/ \
+            wasm/ \
+            package.json \
+            package-lock.json \
+            tsconfig.json \
+            eslint.config.mjs \
+            server.json \
+            README.md \
+            CHANGELOG.md \
+            LICENSE
+          
+          zip -r release-artifacts/unreal-engine-mcp-server-${{ steps.version.outputs.version }}-source.zip \
+            dist/ \
+            src/ \
+            wasm/ \
+            package.json \
+            package-lock.json \
+            tsconfig.json \
+            eslint.config.mjs \
+            server.json \
+            README.md \
+            CHANGELOG.md \
+            LICENSE
 
       - name: Create Plugin archive
         run: |
-          if [ -d "plugins/McpAutomationBridge" ]; then
+          if [ -d "Plugins/McpAutomationBridge" ]; then
             tar -czvf release-artifacts/McpAutomationBridge-plugin-${{ steps.version.outputs.version }}.tar.gz \
-              plugins/McpAutomationBridge/
+              Plugins/McpAutomationBridge/
             
             zip -r release-artifacts/McpAutomationBridge-plugin-${{ steps.version.outputs.version }}.zip \
-              plugins/McpAutomationBridge/
+              Plugins/McpAutomationBridge/
             
             echo "Plugin archive created"
           else

--- a/README.md
+++ b/README.md
@@ -255,9 +255,12 @@ Optional WASM acceleration for computationally intensive operations. **Enabled b
 
 ### Building WASM (Optional)
 
+**Prerequisites:**
+1. Install Rust: https://rust-lang.org/tools/install/
+2. Install wasm-pack: `cargo install wasm-pack`
+
 ```bash
-cargo install wasm-pack  # Once per machine
-npm run build:wasm       # Builds  WASM
+npm run build:wasm       # Builds WASM
 ```
 
 To disable: `WASM_ENABLED=false`

--- a/package.json
+++ b/package.json
@@ -19,17 +19,17 @@
   ],
   "scripts": {
     "build:core": "tsc -p tsconfig.json",
-    "build": "npm run build:core && (npm run build:wasm || echo \"WASM build failed or wasm-pack missing; continuing with TypeScript-only build. To enable WASM, install wasm-pack and re-run npm run build.\")",
+    "build": "npm run clean && npm run build:core && (npm run build:wasm || echo \"WASM build failed or wasm-pack missing; continuing with TypeScript-only build. To enable WASM, install wasm-pack and re-run npm run build.\")",
     "build:watch": "tsc -p tsconfig.json --watch",
     "start": "node dist/cli.js",
     "dev": "ts-node-esm src/cli.ts",
-    "lint": "echo \"Lint: typescript/javascript, C, C++, C#\" && eslint . --ext .ts",
-    "lint:fix": "eslint . --ext .ts --fix",
+    "lint": "echo \"Lint: typescript/javascript, C, C++, C#\" && eslint .",
+    "lint:fix": "eslint . --fix",
     "lint:cpp": "echo \"Running C/C++ lint (cpplint)\" && (python -m cpplint --recursive plugins || echo 'cpplint not found; skipping C/C++ lint')",
     "lint:c": "echo \"Running C lint (cpplint)\" && (python -m cpplint --recursive plugins || echo 'cpplint not found; skipping C lint')",
     "lint:csharp": "echo \"Running C# lint (dotnet format)\" && (dotnet tool run dotnet-format --verify-no-changes || echo 'dotnet-format not available or formatting required; skipping C# lint')",
     "clean": "rimraf dist",
-    "prepare": "npm run build",
+    "prepare": "node -e \"require('fs').existsSync('dist') || require('child_process').execSync('npm run build',{stdio:'inherit'})\"",
     "automation:sync": "node scripts/sync-mcp-plugin.js",
     "clean:tmp": "node scripts/clean-tmp.js",
     "test": "node tests/integration.mjs",
@@ -39,8 +39,7 @@
     "test:all": "node tests/integration.mjs",
     "test:smoke": "node --loader ts-node/esm scripts/smoke-test.ts",
     "build:wasm": "echo 'Building WebAssembly module...' && cd wasm && wasm-pack build --target web --out-dir ../src/wasm/pkg && cd .. && node scripts/patch-wasm.js",
-    "type-check": "tsc --noEmit",
-    "prebuild": "npm run lint && npm run clean"
+    "type-check": "tsc --noEmit"
   },
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint:c": "echo \"Running C lint (cpplint)\" && (python -m cpplint --recursive plugins || echo 'cpplint not found; skipping C lint')",
     "lint:csharp": "echo \"Running C# lint (dotnet format)\" && (dotnet tool run dotnet-format --verify-no-changes || echo 'dotnet-format not available or formatting required; skipping C# lint')",
     "clean": "rimraf dist",
-    "prepare": "node -e \"require('fs').existsSync('dist') || require('child_process').execSync('npm run build',{stdio:'inherit'})\"",
+    "prepare": "node -e \"const fs=require('fs');(fs.existsSync('dist')&&fs.existsSync('dist/cli.js')&&fs.existsSync('dist/index.js'))||require('child_process').execSync('npm run build',{stdio:'inherit'})\"",
     "automation:sync": "node scripts/sync-mcp-plugin.js",
     "clean:tmp": "node scripts/clean-tmp.js",
     "test": "node tests/integration.mjs",


### PR DESCRIPTION
## Summary
- Fixes npm install failure when downloading release archives (Discussion #214)
- Release archives were missing `eslint.config.mjs` and other build files
- `prepare` script now skips build if `dist/` already exists

## Changes
| File | Change |
|------|--------|
| `package.json` | Removed `prebuild` script, fixed `prepare` to skip if dist exists, removed deprecated `--ext .ts` |
| `release.yml` | Added `-source` archives with all build files, fixed plugin path |
| `README.md` | Added Rust/wasm-pack prerequisites for WASM building |

## Test Plan
- [x] `npm run lint` works (ESLint 9.x compat)
- [x] `npm run build:core` works
- [x] `prepare` skips build when `dist/` exists

Fixes #214
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chir24/unreal_mcp/pull/215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflow now produces source archives (tar.gz and zip) alongside pre-built binaries; plugin archive handling updated (path capitalization fixes and clear skip message when absent)
  * Build process now cleans before compiling; lint rules simplified; conditional prepare step added; prebuild removed

* **Tests**
  * New test scripts for unit, coverage, integration, and smoke testing

* **Documentation**
  * Added WebAssembly build prerequisites and clarified WASM build steps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->