### PR TITLE
fix: Potential fix for code scanning alert no. 28: Syntax error

### DIFF
--- a/tests/test-runner.mjs
+++ b/tests/test-runner.mjs
@@ -201,6 +201,7 @@ function evaluateExpectation(testCase, response) {
     'asset_exists', 'invalid_bp', 'cdo_failed', 'level_already_exists', 'asset_not_found',
     'texture_error', 'invalid_texture', 'source_invalid', 'lock_failed', 'node_not_found',
     'physics_failed', 'function_not_found'
+  ];
   const hasInfrastructureError = infrastructureErrorCodes.some(code => 
     errorStr === code || errorStr.includes(code) || messageStr.includes(code)
   );


### PR DESCRIPTION
Potential fix for [https://github.com/ChiR24/Unreal_mcp/security/code-scanning/28](https://github.com/ChiR24/Unreal_mcp/security/code-scanning/28)

In general, to fix this kind of syntax error you must properly terminate the array literal and statement before starting a new `const` declaration. Every `[` must have a matching `]`, and each declaration should end with a `;` (or at least a valid line terminator that ends the statement).

Concretely, in `tests/test-runner.mjs` you should add a closing `]` and `;` to the `infrastructureErrorCodes` array definition before the `const hasInfrastructureError` line. This will make `infrastructureErrorCodes` a valid array constant and keep `hasInfrastructureError` as a separate constant initialized by calling `.some` on that array. No additional imports or helper methods are required; the fix is purely syntactic. The region to change is around lines 198–204: only the `infrastructureErrorCodes` declaration needs to be updated to include `];` at the end of the list of strings.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chir24/unreal_mcp/pull/237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Corrected syntax in test infrastructure to ensure proper test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->