### PR TITLE
Fix path validation to support Game Feature Plugin mount points

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_AIHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_AIHandlers.cpp
@@ -193,15 +193,12 @@ static bool SanitizeAIAssetPath(const FString& InputPath, FString& OutSanitizedP
         return false;
     }
     
-    // 5. Validate path starts with known mount points
-    // Only allow /Game/ or /Engine/ as valid mount points for AI assets
-    if (!OutSanitizedPath.StartsWith(TEXT("/Game/")) && 
-        !OutSanitizedPath.StartsWith(TEXT("/Engine/")) &&
-        OutSanitizedPath != TEXT("/Game") &&
-        OutSanitizedPath != TEXT("/Engine"))
+    // 5. Validate path against engine's registered mount points.
+    // This automatically supports /Game, /Engine, and all plugin mount points
+    // (e.g., Game Feature Plugins like /ShooterCore/, /TopDownArena/, etc.)
+    if (!FPackageName::IsValidLongPackageName(OutSanitizedPath, /*bIncludeReadOnlyRoots=*/true))
     {
-        // Could be a path traversal attempt like /etc/passwd/Test
-        OutError = FString::Printf(TEXT("Invalid path: must start with /Game/ or /Engine/ (got: %s)"), *InputPath);
+        OutError = FString::Printf(TEXT("Invalid path: not a registered mount point (got: %s)"), *InputPath);
         return false;
     }
     


### PR DESCRIPTION
## Summary

- Replace hardcoded path whitelist (`/Game`, `/Engine`, `/Script`) with `FPackageName::IsValidLongPackageName()` which dynamically validates against all engine-registered mount points
- This fixes `INVALID_PATH` errors when accessing assets in Game Feature Plugins (e.g., `/ShooterCore/`, `/TopDownArena/`, custom plugins) without requiring users to manually add each plugin's mount point

## Problem

Game Feature Plugins in UE5 mount their content at custom root paths (e.g., `/ShooterCore/`, `/TopDownArena/`). The current path validation rejects these paths because the whitelist only allows `/Game`, `/Engine`, and `/Script`.

The existing plugin path heuristic (`/PluginName/Content/...`) also fails for Game Feature Plugins because they don't follow the `/PluginName/Content/` convention.

## Solution

### C++ (McpAutomationBridge plugin)

Use `FPackageName::IsValidLongPackageName()` in both `SanitizeProjectRelativePath()` and `SanitizeAIAssetPath()`. This API queries the engine's mount point registry, which automatically includes all registered plugins.

**Before:**
```cpp
const bool bValidRoot = CleanPath.StartsWith(TEXT("/Game")) ||
                        CleanPath.StartsWith(TEXT("/Engine")) ||
                        CleanPath.StartsWith(TEXT("/Script"));
```

**After:**
```cpp
const bool bValidRoot = CleanPath.StartsWith(TEXT("/Script")) ||
    FPackageName::IsValidLongPackageName(CleanPath, true);
```

### TypeScript (path-security.ts)

Change `allowedRoots` default from `['/Game', '/Engine']` to `null`. When null, only basic security checks (traversal, invalid characters) are performed. Mount point validation is deferred to the C++ side which has access to the engine's registry.

## Files Changed

| File | Change |
|------|--------|
| `McpAutomationBridgeHelpers.h` | `SanitizeProjectRelativePath()` — use `FPackageName::IsValidLongPackageName()` |
| `McpAutomationBridge_AIHandlers.cpp` | `SanitizeAIAssetPath()` — same approach |
| `path-security.ts` | Remove hardcoded `allowedRoots`, defer to C++ validation |

## Test Plan

- [x] Verified `/Game/...` paths still work
- [x] Verified `/SBCore/...` (Game Feature Plugin) paths work
- [x] Verified `/ShooterCore/...` (Game Feature Plugin) paths work
- [x] Verified blueprint graph editing works for plugin assets
- [x] Verified path traversal (`..`) is still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chir24/unreal_mcp/pull/239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced path validation to dynamically support all engine-registered mount points and plugin paths, replacing previous hardcoded restrictions. This allows broader path acceptance across diverse project structures while maintaining security checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->