### PR TITLE
fix: D3D12RHI viewport crash during blueprint compile in UE 5.7

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridgeHelpers.h
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridgeHelpers.h
@@ -186,6 +186,7 @@
 #include "Editor/EditorAssetLibrary.h"
 #endif
 #include "Engine/Blueprint.h"
+#include "KismetCompilerModule.h"
 #include "Engine/World.h"
 #include "Engine/LevelStreaming.h"
 #include "GameFramework/WorldSettings.h"
@@ -1103,6 +1104,32 @@ static inline UMaterialInterface* McpLoadMaterialWithFallback(
  * @param bForceCleanup If true, perform aggressive cleanup before loading (default: true)
  * @return bool True if the map was loaded successfully
  */
+
+/**
+ * Safe compilation helper to avoid D3D12RHI viewport crashes in UE 5.7
+ * 
+ * Compiling blueprints can trigger Slate UI updates (progress bars, compiler logs)
+ * When invoked from the automation bridge, this can race with the render thread
+ * and cause Fatal Error 80070005 in WindowsD3D12Viewport.cpp
+ */
+static inline void McpSafeCompileBlueprint(UBlueprint* Blueprint)
+{
+    if (!Blueprint) return;
+    
+#if WITH_EDITOR
+    // 1. Flush rendering commands to ensure GPU is idle before compilation UI opens
+    FlushRenderingCommands();
+    
+    // 2. Compile without forcing garbage collection (can cause issues during automation)
+    // Need to include KismetCompilerModule for this enum, but if it's not available 
+    // we can use standard CompileBlueprint which is fine as long as we flushed rendering
+    FKismetEditorUtilities::CompileBlueprint(Blueprint, EBlueprintCompileOptions::SkipGarbageCollection);
+    
+    // 3. Flush again to ensure any UI updates from compilation are complete
+    FlushRenderingCommands();
+#endif
+}
+
 static inline bool McpSafeLoadMap(const FString& MapPath, bool bForceCleanup = true)
 {
     if (!GEditor)

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_BlueprintHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_BlueprintHandlers.cpp
@@ -2024,7 +2024,7 @@ bool UMcpAutomationBridgeSubsystem::HandleBlueprintAction(
 #if WITH_EDITOR
                   FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(
                       LocalBP);
-                  FKismetEditorUtilities::CompileBlueprint(LocalBP);
+                  McpSafeCompileBlueprint(LocalBP);
                   SaveLoadedAssetThrottled(LocalBP);
 #endif
                   bAddedViaSubsystem = true;
@@ -2231,7 +2231,7 @@ bool UMcpAutomationBridgeSubsystem::HandleBlueprintAction(
     }
     if (bCompile && LocalBP) {
 #if WITH_EDITOR
-      FKismetEditorUtilities::CompileBlueprint(LocalBP);
+      McpSafeCompileBlueprint(LocalBP);
 #endif
     }
 
@@ -2534,7 +2534,7 @@ bool UMcpAutomationBridgeSubsystem::HandleBlueprintAction(
     }
 
     FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-    FKismetEditorUtilities::CompileBlueprint(Blueprint);
+    McpSafeCompileBlueprint(Blueprint);
     const bool bSaved = SaveLoadedAssetThrottled(Blueprint);
 
     const TSharedPtr<FJsonObject> Snapshot =
@@ -2872,7 +2872,7 @@ bool UMcpAutomationBridgeSubsystem::HandleBlueprintAction(
 
     Blueprint->NewVariables.Add(NewVar);
     FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-    FKismetEditorUtilities::CompileBlueprint(Blueprint);
+    McpSafeCompileBlueprint(Blueprint);
     const bool bSaved = SaveLoadedAssetThrottled(Blueprint);
 
     // Real test: Verify the variable actually exists in the compiled class or
@@ -3062,7 +3062,7 @@ bool UMcpAutomationBridgeSubsystem::HandleBlueprintAction(
         ExportPropertyToJsonValue(TargetContainer, Property);
 
     FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-    FKismetEditorUtilities::CompileBlueprint(Blueprint);
+    McpSafeCompileBlueprint(Blueprint);
     const bool bSaved = SaveLoadedAssetThrottled(Blueprint);
 
     TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
@@ -3148,7 +3148,7 @@ bool UMcpAutomationBridgeSubsystem::HandleBlueprintAction(
 
     FBlueprintEditorUtils::RemoveMemberVariable(Blueprint, TargetVarName);
     FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-    FKismetEditorUtilities::CompileBlueprint(Blueprint);
+    McpSafeCompileBlueprint(Blueprint);
     const bool bSaved = SaveLoadedAssetThrottled(Blueprint);
 
     UE_LOG(LogMcpAutomationBridgeSubsystem, Log,
@@ -3239,7 +3239,7 @@ bool UMcpAutomationBridgeSubsystem::HandleBlueprintAction(
     FBlueprintEditorUtils::RenameMemberVariable(Blueprint, OldVarName,
                                                 FName(*NewName));
     FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-    FKismetEditorUtilities::CompileBlueprint(Blueprint);
+    McpSafeCompileBlueprint(Blueprint);
     const bool bSaved = SaveLoadedAssetThrottled(Blueprint);
 
     UE_LOG(LogMcpAutomationBridgeSubsystem, Log,
@@ -3499,7 +3499,7 @@ bool UMcpAutomationBridgeSubsystem::HandleBlueprintAction(
     }
 
     FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(BP);
-    FKismetEditorUtilities::CompileBlueprint(BP);
+    McpSafeCompileBlueprint(BP);
     const bool bSaved = SaveLoadedAssetThrottled(BP);
 
     // Update Registry (Persistent list of events)
@@ -3668,7 +3668,7 @@ bool UMcpAutomationBridgeSubsystem::HandleBlueprintAction(
         if (NodesToRemove.Num() > 0) {
           FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(
               RemoveBlueprint);
-          FKismetEditorUtilities::CompileBlueprint(RemoveBlueprint);
+          McpSafeCompileBlueprint(RemoveBlueprint);
           SaveLoadedAssetThrottled(RemoveBlueprint);
         }
       }
@@ -3910,7 +3910,7 @@ bool UMcpAutomationBridgeSubsystem::HandleBlueprintAction(
     }
 
     FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-    FKismetEditorUtilities::CompileBlueprint(Blueprint);
+    McpSafeCompileBlueprint(Blueprint);
     const bool bSaved = UEditorAssetLibrary::SaveLoadedAsset(Blueprint);
 
     TSharedPtr<FJsonObject> Entry =
@@ -4147,7 +4147,7 @@ bool UMcpAutomationBridgeSubsystem::HandleBlueprintAction(
           }
 
           FBlueprintEditorUtils::MarkBlueprintAsModified(BP);
-          FKismetEditorUtilities::CompileBlueprint(BP);
+          McpSafeCompileBlueprint(BP);
           bool bSaved = SaveLoadedAssetThrottled(BP);
 
           TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
@@ -4188,7 +4188,7 @@ bool UMcpAutomationBridgeSubsystem::HandleBlueprintAction(
 
     if (bSuccess) {
       FBlueprintEditorUtils::MarkBlueprintAsModified(BP);
-      FKismetEditorUtilities::CompileBlueprint(BP);
+      McpSafeCompileBlueprint(BP);
 
       // Save the blueprint to persist changes
       bool bSaved = SaveLoadedAssetThrottled(BP);
@@ -4250,7 +4250,7 @@ bool UMcpAutomationBridgeSubsystem::HandleBlueprintAction(
                              Err, TEXT("NOT_FOUND"));
       return true;
     }
-    FKismetEditorUtilities::CompileBlueprint(BP);
+    McpSafeCompileBlueprint(BP);
     bool bSaved = false;
     if (bSaveAfterCompile) {
       bSaved = SaveLoadedAssetThrottled(BP);
@@ -4773,7 +4773,7 @@ bool UMcpAutomationBridgeSubsystem::HandleBlueprintAction(
 
     FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(BP);
 
-    FKismetEditorUtilities::CompileBlueprint(BP);
+    McpSafeCompileBlueprint(BP);
     bSaved = SaveLoadedAssetThrottled(BP);
 
     TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
@@ -5415,7 +5415,7 @@ bool UMcpAutomationBridgeSubsystem::HandleSCSAction(
       bool bCompiled = false;
       bool bSaved = false;
       FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-      FKismetEditorUtilities::CompileBlueprint(Blueprint);
+      McpSafeCompileBlueprint(Blueprint);
       bCompiled = true;
       bSaved = SaveLoadedAssetThrottled(Blueprint);
 
@@ -5523,7 +5523,7 @@ bool UMcpAutomationBridgeSubsystem::HandleSCSAction(
         bool bSaved = false;
         if (bModified) {
           FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-          FKismetEditorUtilities::CompileBlueprint(Blueprint);
+          McpSafeCompileBlueprint(Blueprint);
           bCompiled = true;
           bSaved = SaveLoadedAssetThrottled(Blueprint);
         }
@@ -5594,7 +5594,7 @@ bool UMcpAutomationBridgeSubsystem::HandleSCSAction(
         bool bCompiled = false;
         bool bSaved = false;
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
         bCompiled = true;
         bSaved = SaveLoadedAssetThrottled(Blueprint);
 
@@ -5773,7 +5773,7 @@ bool UMcpAutomationBridgeSubsystem::HandleSCSAction(
         bool bCompiled = false;
         bool bSaved = false;
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
         bCompiled = true;
         bSaved = SaveLoadedAssetThrottled(Blueprint);
 
@@ -6040,7 +6040,7 @@ bool UMcpAutomationBridgeSubsystem::HandleSCSAction(
       bool bCompiled = false;
       bool bSaved = false;
       FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-      FKismetEditorUtilities::CompileBlueprint(Blueprint);
+      McpSafeCompileBlueprint(Blueprint);
       bCompiled = true;
       bSaved = SaveLoadedAssetThrottled(Blueprint);
 

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_CombatHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_CombatHandlers.cpp
@@ -309,7 +309,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         AddBlueprintVariableCombat(Blueprint, TEXT("Spread"), MakeFloatPinType());
         
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
         
         // Set default values for the variables using CDO
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
@@ -380,7 +380,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
             }
         }
 
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
         McpSafeAssetSave(Blueprint);
 
         TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject());
@@ -416,7 +416,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         AddBlueprintVariableCombat(Blueprint, TEXT("EjectionSocketName"), MakeNamePinType());
         
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         // Set default values
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
@@ -474,7 +474,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         AddBlueprintVariableCombat(Blueprint, TEXT("Spread"), MakeFloatPinType());
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         // Set values via CDO
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
@@ -544,7 +544,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         AddBlueprintVariableCombat(Blueprint, TEXT("HitscanRange"), MakeFloatPinType());
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         // Set values
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
@@ -603,7 +603,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         AddBlueprintVariableCombat(Blueprint, TEXT("ProjectileSpeed"), MakeFloatPinType());
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         // Set values
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
@@ -660,7 +660,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         AddBlueprintVariableCombat(Blueprint, TEXT("CurrentSpread"), MakeFloatPinType());
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         // Set values
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
@@ -725,7 +725,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         AddBlueprintVariableCombat(Blueprint, TEXT("RecoilRecoverySpeed"), MakeFloatPinType());
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         // Set values
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
@@ -789,7 +789,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         AddBlueprintVariableCombat(Blueprint, TEXT("bIsAiming"), MakeBoolPinType());
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         // Set values
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
@@ -890,7 +890,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
             MovementComp->ProjectileGravityScale = static_cast<float>(GravityScale);
         }
 
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
         McpSafeAssetSave(Blueprint);
 
         TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject());
@@ -929,7 +929,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
             MovementComp->ProjectileGravityScale = static_cast<float>(GravityScale);
         }
 
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
         McpSafeAssetSave(Blueprint);
 
         TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject());
@@ -976,7 +976,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
             }
         }
 
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
         McpSafeAssetSave(Blueprint);
 
         TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject());
@@ -1012,7 +1012,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
             MovementComp->HomingAccelerationMagnitude = static_cast<float>(HomingAcceleration);
         }
 
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
         McpSafeAssetSave(Blueprint);
 
         TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject());
@@ -1084,7 +1084,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
             Blueprint->MarkPackageDirty();
         }
 
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
         McpSafeAssetSave(Blueprint);
 
         TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject());
@@ -1121,7 +1121,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         AddBlueprintVariableCombat(Blueprint, TEXT("HeadshotMultiplier"), MakeFloatPinType());
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         // Set values
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
@@ -1229,7 +1229,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         AddBlueprintVariableCombat(Blueprint, TEXT("HitboxDamageMultiplier"), MakeFloatPinType());
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         // Set values
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
@@ -1307,7 +1307,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
 
         // Mark modified and compile
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         // Set default values via CDO after compile
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
@@ -1385,7 +1385,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         AddBlueprintVariableCombat(Blueprint, TEXT("bInfiniteAmmo"), MakeBoolPinType());
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         // Set values
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
@@ -1505,7 +1505,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         }
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
         McpSafeAssetSave(Blueprint);
 
         TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject());
@@ -1579,7 +1579,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         }
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         // Set values
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
@@ -1688,7 +1688,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         }
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         // Set values
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
@@ -1748,7 +1748,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         AddBlueprintVariableCombat(Blueprint, TEXT("bUseTracers"), MakeBoolPinType());
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         // Set values
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
@@ -1807,7 +1807,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         AddBlueprintVariableCombat(Blueprint, TEXT("ImpactDecalPath"), MakeStringPinType());
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         // Set values
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
@@ -1868,7 +1868,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         AddBlueprintVariableCombat(Blueprint, TEXT("bEjectShells"), MakeBoolPinType());
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         // Set values
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
@@ -1937,7 +1937,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         AddBlueprintVariableCombat(Blueprint, TEXT("bIsTracing"), MakeBoolPinType());
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         // Set values
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
@@ -2001,7 +2001,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         AddBlueprintVariableCombat(Blueprint, TEXT("bInComboWindow"), MakeBoolPinType());
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         // Set values
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
@@ -2063,7 +2063,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         AddBlueprintVariableCombat(Blueprint, TEXT("bEnableHitPause"), MakeBoolPinType());
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         // Set values
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
@@ -2133,7 +2133,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         }
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         // Set values
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
@@ -2210,7 +2210,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         }
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         // Set values
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
@@ -2295,7 +2295,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         AddBlueprintVariableCombat(Blueprint, TEXT("bShowWeaponTrail"), MakeBoolPinType());
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         // Set values
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
@@ -2431,7 +2431,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
             return true;
         }
 
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
         McpSafeAssetSave(Blueprint);
 
         TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject());
@@ -2475,7 +2475,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
 
         AddBlueprintVariableCombat(Blueprint, TEXT("HitboxDamageMultiplier"), MakeFloatPinType());
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
         McpSafeAssetSave(Blueprint);
 
         TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject());
@@ -2549,7 +2549,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         AddBlueprintVariableCombat(Blueprint, TEXT("bIsActive"), MakeBoolPinType());
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
         {
@@ -2598,7 +2598,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         AddBlueprintVariableCombat(Blueprint, TEXT("AppliedDamageType"), MakeStringPinType());
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
         {
@@ -2645,7 +2645,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         AddBlueprintVariableCombat(Blueprint, TEXT("HealAmount"), MakeFloatPinType());
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
         {
@@ -2698,7 +2698,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         AddBlueprintVariableCombat(Blueprint, TEXT("bShieldActive"), MakeBoolPinType());
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
         {
@@ -2751,7 +2751,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageCombatAction(
         AddBlueprintVariableCombat(Blueprint, TEXT("ArmorDamageReduction"), MakeFloatPinType());
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         if (UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(Blueprint->GeneratedClass))
         {

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_GASHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_GASHandlers.cpp
@@ -557,7 +557,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageGASAction(
         }
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
         McpSafeAssetSave(Blueprint);
 
         TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject());
@@ -905,7 +905,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageGASAction(
         FBlueprintEditorUtils::SetBlueprintVariableCategory(Blueprint, TEXT("TargetLocation"), nullptr, FText::FromString(TEXT("Targeting")));
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
         McpSafeAssetSave(Blueprint);
 
         TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject());
@@ -1077,7 +1077,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageGASAction(
         VariablesAdded.Add(TaskNameVarName);
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
         McpSafeAssetSave(Blueprint);
 
         TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject());
@@ -2583,7 +2583,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageGASAction(
             FText::FromString(TEXT("Execution Calculation")));
 
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
         McpSafeAssetSave(Blueprint);
 
         // Use the actual blueprint name (which may have been sanitized) in the response

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_GameFrameworkHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_GameFrameworkHandlers.cpp
@@ -55,7 +55,7 @@ static void SetBPVarDefaultValueGF(UBlueprint* Blueprint, FName VarName, const F
     }
     
     // Compile the blueprint first to ensure GeneratedClass exists
-    FKismetEditorUtilities::CompileBlueprint(Blueprint);
+    McpSafeCompileBlueprint(Blueprint);
     
     if (Blueprint->GeneratedClass)
     {
@@ -213,7 +213,7 @@ namespace GameFrameworkHelpers
         Blueprint->MarkPackageDirty();
         
         // Compile the blueprint
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
         
         return Blueprint;
     }
@@ -752,7 +752,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageGameFrameworkAction(
             return true;
         }
 
-        FKismetEditorUtilities::CompileBlueprint(BP);
+        McpSafeCompileBlueprint(BP);
         
         if (bSave)
         {
@@ -802,7 +802,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageGameFrameworkAction(
             return true;
         }
 
-        FKismetEditorUtilities::CompileBlueprint(BP);
+        McpSafeCompileBlueprint(BP);
 
         if (bSave)
         {
@@ -852,7 +852,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageGameFrameworkAction(
             return true;
         }
 
-        FKismetEditorUtilities::CompileBlueprint(BP);
+        McpSafeCompileBlueprint(BP);
 
         if (bSave)
         {
@@ -902,7 +902,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageGameFrameworkAction(
             return true;
         }
 
-        FKismetEditorUtilities::CompileBlueprint(BP);
+        McpSafeCompileBlueprint(BP);
 
         if (bSave)
         {
@@ -963,7 +963,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageGameFrameworkAction(
         if (bModified)
         {
             CDO->MarkPackageDirty();
-            FKismetEditorUtilities::CompileBlueprint(BP);
+            McpSafeCompileBlueprint(BP);
         }
 
         if (bSave)
@@ -1056,7 +1056,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageGameFrameworkAction(
             VarsAdded++;
         }
 
-        FKismetEditorUtilities::CompileBlueprint(BP);
+        McpSafeCompileBlueprint(BP);
         BP->MarkPackageDirty();
 
         if (bSave)
@@ -1155,7 +1155,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageGameFrameworkAction(
             VarsAdded++;
         }
 
-        FKismetEditorUtilities::CompileBlueprint(BP);
+        McpSafeCompileBlueprint(BP);
         BP->MarkPackageDirty();
 
         if (bSave)
@@ -1246,7 +1246,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageGameFrameworkAction(
             VarsAdded++;
         }
 
-        FKismetEditorUtilities::CompileBlueprint(BP);
+        McpSafeCompileBlueprint(BP);
         BP->MarkPackageDirty();
 
         if (bSave)
@@ -1332,7 +1332,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageGameFrameworkAction(
             VarsAdded++;
         }
 
-        FKismetEditorUtilities::CompileBlueprint(BP);
+        McpSafeCompileBlueprint(BP);
         BP->MarkPackageDirty();
 
         if (bSave)
@@ -1436,7 +1436,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageGameFrameworkAction(
             }
         }
 
-        FKismetEditorUtilities::CompileBlueprint(BP);
+        McpSafeCompileBlueprint(BP);
         BP->MarkPackageDirty();
 
         if (bSave)
@@ -1630,7 +1630,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageGameFrameworkAction(
             VarsAdded++;
         }
 
-        FKismetEditorUtilities::CompileBlueprint(BP);
+        McpSafeCompileBlueprint(BP);
         BP->MarkPackageDirty();
 
         if (bSave)
@@ -1684,7 +1684,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageGameFrameworkAction(
             }
         }
 
-        FKismetEditorUtilities::CompileBlueprint(BP);
+        McpSafeCompileBlueprint(BP);
         BP->MarkPackageDirty();
 
         if (bSave)

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_MiscHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_MiscHandlers.cpp
@@ -859,7 +859,7 @@ static bool HandleCreateRPC(
 
         Blueprint->Modify();
         FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
     }
 
     TSharedPtr<FJsonObject> ResponseJson = MakeShareable(new FJsonObject());

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_NetworkingHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_NetworkingHandlers.cpp
@@ -339,7 +339,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageNetworkingAction(
 
         Blueprint->Modify();
         FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         ResultJson->SetBoolField(TEXT("success"), true);
         ResultJson->SetStringField(TEXT("message"), FString::Printf(TEXT("Replication condition set to %s"), *Condition));
@@ -588,7 +588,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageNetworkingAction(
 
             Blueprint->Modify();
             FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
-            FKismetEditorUtilities::CompileBlueprint(Blueprint);
+            McpSafeCompileBlueprint(Blueprint);
 
             ResultJson->SetBoolField(TEXT("success"), true);
             ResultJson->SetStringField(TEXT("functionName"), FunctionName);
@@ -668,7 +668,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageNetworkingAction(
 
         Blueprint->Modify();
         FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         ResultJson->SetBoolField(TEXT("success"), true);
         ResultJson->SetBoolField(TEXT("withValidation"), bWithValidation);
@@ -741,7 +741,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageNetworkingAction(
 
         Blueprint->Modify();
         FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         ResultJson->SetBoolField(TEXT("success"), true);
         ResultJson->SetBoolField(TEXT("reliable"), bReliable);
@@ -837,7 +837,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageNetworkingAction(
         {
             Blueprint->Modify();
             FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
-            FKismetEditorUtilities::CompileBlueprint(Blueprint);
+            McpSafeCompileBlueprint(Blueprint);
         }
 
         ResultJson->SetBoolField(TEXT("success"), true);
@@ -1132,7 +1132,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageNetworkingAction(
 
         Blueprint->Modify();
         FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         ResultJson->SetBoolField(TEXT("success"), true);
         ResultJson->SetStringField(TEXT("message"), FString::Printf(TEXT("ReplicatedUsing set to %s for property %s"), *RepNotifyFunc, *PropertyName));
@@ -1184,7 +1184,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageNetworkingAction(
         {
             Blueprint->Modify();
             FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
-            FKismetEditorUtilities::CompileBlueprint(Blueprint);
+            McpSafeCompileBlueprint(Blueprint);
         }
 
         ResultJson->SetBoolField(TEXT("success"), true);
@@ -1357,7 +1357,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageNetworkingAction(
 
         Blueprint->Modify();
         FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
-        FKismetEditorUtilities::CompileBlueprint(Blueprint);
+        McpSafeCompileBlueprint(Blueprint);
 
         ResultJson->SetBoolField(TEXT("success"), bSuccess);
         ResultJson->SetStringField(TEXT("variableName"), VarName);

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_SCSHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_SCSHandlers.cpp
@@ -40,7 +40,7 @@ void FSCSHandlers::FinalizeBlueprintSCSChange(UBlueprint *Blueprint,
   }
 
   FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
-  FKismetEditorUtilities::CompileBlueprint(Blueprint);
+  McpSafeCompileBlueprint(Blueprint);
   bOutCompiled = true;
   
   // UE 5.7+ Fix: Use McpSafeAssetSave instead of SaveLoadedAssetThrottled.


### PR DESCRIPTION
## Summary
- Replaced direct calls to `FKismetEditorUtilities::CompileBlueprint` with a new helper `McpSafeCompileBlueprint`
- Added `FlushRenderingCommands()` before and after compilation to prevent race conditions with Slate UI updates
- Added `EBlueprintCompileOptions::SkipGarbageCollection` to prevent Editor hangs/GC hitches during bulk compilation

Fixes #217
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chir24/unreal_mcp/pull/250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
