### PR TITLE
fix: guard GeometryScript AppendCapsule segment steps for < UE 5.5

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_GeometryHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_GeometryHandlers.cpp
@@ -4520,7 +4520,10 @@ static bool HandleLoft(UMcpAutomationBridgeSubsystem* Self, const FString& Reque
                             UGeometryScriptLibrary_MeshPrimitiveFunctions::AppendCapsule(
                                 Mesh, PrimOptions, SegmentTransform,
                                 ProfileRadius * 0.5, SegmentLength,
-                                2, 8, 0,
+                                2, 8,
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5
+                                0, // SegmentSteps parameter added in UE 5.5
+#endif
                                 EGeometryScriptPrimitiveOriginMode::Center, nullptr);
                         }
                     }


### PR DESCRIPTION
 ## Summary

  Fixes a Geometry Scripting API compatibility issue in the Unreal plugin by guarding the AppendCapsule call so Unreal
  Engine 5.3 and 5.4 use the older signature, while Unreal Engine 5.5+ passes the newer SegmentSteps parameter. This
  prevents compile failures on older engine versions without changing behavior on newer versions.

  ## Changes

  - Added an engine-version guard around the UGeometryScriptLibrary_MeshPrimitiveFunctions::AppendCapsule call in
    McpAutomationBridge_GeometryHandlers.cpp
  - Use the 9-argument AppendCapsule signature for UE 5.3 and UE 5.4
  - Use the 10-argument AppendCapsule signature with SegmentSteps for UE 5.5+
  - Kept the change scoped to the affected call site only

  ## Related Issues

  Related to UE 5.3/5.4 plugin compile failure caused by AppendCapsule signature mismatch.

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)

  ## Testing

  - [x] Tested with Unreal Engine (version: 5.3)
  - [x] Tested MCP client integration (client: Codex)
  - [ ] Added/updated tests

  Additional validation:

  - Confirmed UE 5.3 local engine header uses the older AppendCapsule signature
  - Confirmed UE 5.4 source also uses the older signature
  - Ran npm run build
  - Ran npm run test:smoke
  - Ran npm run lint
  - Ran npm run test:all, which connected to a live Unreal session and exercised many tools, but it did not finish
    cleanly due to at least one unrelated integration test failure (PARENT_FOLDER_NOT_FOUND in material authoring)

  ## Pre-Merge Checklist

  - [x] Code follows project style guidelines
  - [x] Self-reviewed the code
  - [ ] Updated relevant documentation (if needed)
  - [ ] Added/updated tests (if applicable)
  - [ ] CI passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chir24/unreal_mcp/pull/274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
