### PR TITLE
fix(security): sanitize user inputs to prevent command injection

### DIFF
--- a/src/tools/animation.ts
+++ b/src/tools/animation.ts
@@ -220,9 +220,12 @@ export class AnimationTools {
           );
           if (transition.condition) {
             const safeCondition = sanitizeCommandArgument(transition.condition);
-            commands.push(
-              `SetAnimTransitionRule ${safeBlueprintPath} ${safeMachineName} ${safeSourceState} ${safeTargetState} ${safeCondition}`
-            );
+            // SECURITY: Only push command if condition is non-empty after sanitization
+            if (safeCondition) {
+              commands.push(
+                `SetAnimTransitionRule ${safeBlueprintPath} ${safeMachineName} ${safeSourceState} ${safeTargetState} ${safeCondition}`
+              );
+            }
           }
         }
       }

--- a/src/tools/physics.ts
+++ b/src/tools/physics.ts
@@ -307,15 +307,14 @@ export class PhysicsTools {
       // SECURITY: Sanitize user inputs to prevent command injection
       const safeName = sanitizeCommandArgument(params.destructionName);
       const safeMeshPath = sanitizeCommandArgument(params.meshPath);
+      const safeSavePath = sanitizeCommandArgument(params.savePath || '/Game/Destruction');
 
-      if (!safeName || !safeMeshPath) {
-        return { success: false, error: 'Destruction name and mesh path must be valid and non-empty.' };
+      if (!safeName || !safeMeshPath || !safeSavePath) {
+        return { success: false, error: 'Destruction name, mesh path, and save path must be valid and non-empty.' };
       }
 
-      const path = params.savePath || '/Game/Destruction';
-
       const commands = [
-        `CreateGeometryCollection ${safeName} ${safeMeshPath} ${path}`
+        `CreateGeometryCollection ${safeName} ${safeMeshPath} ${safeSavePath}`
       ];
 
       // Configure fracture
@@ -341,7 +340,7 @@ export class PhysicsTools {
       return {
         success: true,
         message: `Chaos destruction ${safeName} created`,
-        path: `${path}/${safeName}`
+        path: `${safeSavePath}/${safeName}`
       };
     } catch (err) {
       return { success: false, error: `Failed to setup destruction: ${err}` };
@@ -387,12 +386,17 @@ export class PhysicsTools {
 
     const hasExplicitEmptyWheels = Array.isArray(params.wheels) && params.wheels.length === 0;
 
-    const effectiveVehicleType = typeof params.vehicleType === 'string' && params.vehicleType.trim().length > 0
+    // SECURITY: Sanitize vehicle type to prevent command injection
+    const rawVehicleType = typeof params.vehicleType === 'string' && params.vehicleType.trim().length > 0
       ? params.vehicleType
       : 'Car';
+    const safeVehicleType = sanitizeCommandArgument(rawVehicleType);
+    if (!safeVehicleType) {
+      return { success: false, error: 'Vehicle type must be valid and non-empty.' };
+    }
 
     const commands = [
-      `CreateVehicle ${safeVehicleName} ${effectiveVehicleType}`
+      `CreateVehicle ${safeVehicleName} ${safeVehicleType}`
     ];
 
     // Configure wheels when provided
@@ -405,8 +409,16 @@ export class PhysicsTools {
           warnings.push('Skipped wheel with invalid name.');
           continue;
         }
+        // SECURITY: Validate numeric wheel parameters
+        const radius = typeof wheel.radius === 'number' && isFinite(wheel.radius) ? wheel.radius : NaN;
+        const width = typeof wheel.width === 'number' && isFinite(wheel.width) ? wheel.width : NaN;
+        const mass = typeof wheel.mass === 'number' && isFinite(wheel.mass) ? wheel.mass : NaN;
+        if (!isFinite(radius) || !isFinite(width) || !isFinite(mass)) {
+          warnings.push(`Skipped wheel '${safeWheelName}' with invalid numeric parameters.`);
+          continue;
+        }
         commands.push(
-          `AddVehicleWheel ${safeVehicleName} ${safeWheelName} ${wheel.radius} ${wheel.width} ${wheel.mass}`
+          `AddVehicleWheel ${safeVehicleName} ${safeWheelName} ${radius} ${width} ${mass}`
         );
 
         if (wheel.isSteering) {


### PR DESCRIPTION
## Summary

Fixes command injection vulnerability by applying `sanitizeCommandArgument()` to all functions that interpolate user-supplied string parameters into console commands.

## Vulnerability

User-supplied strings were being directly interpolated into console commands without sanitization. This could allow command chaining attacks where malicious input like `"name;quit"` would execute arbitrary console commands.

## Changes

**physics.ts:**
| Function | Sanitized Parameters |
|----------|---------------------|
| `createConstraint` | `name`, `actor1`, `actor2` |
| `setupDestruction` | `destructionName`, `meshPath` |
| `configureVehicle` | `vehicleName`, `wheel.name` |
| `setupCloth` | `meshName` |
| `createFluidSimulation` | `name` |

**animation.ts:**
| Function | Sanitized Parameters |
|----------|---------------------|
| `addStateMachine` | `blueprintPath`, `machineName`, `state.name`, `state.animation`, `transition.sourceState`, `transition.targetState`, `transition.condition` |

## Security Pattern

Each fix follows the same pattern:
1. Sanitize all string parameters with `sanitizeCommandArgument()`
2. Validate that sanitized values are non-empty
3. Use sanitized values in command interpolation
4. Use sanitized values in response messages (prevents reflected XSS)

## Verification

- ✅ Lint: No errors
- ✅ Type-check: No errors
- ✅ Build: Compiled successfully
- ✅ Unit tests: 201 tests passed

Fixes #284
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chir24/unreal_mcp/pull/288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
