### PR TITLE
fix: add missing includes for McpAutomationBridge UE5.7 build

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpHandlerUtils.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpHandlerUtils.cpp
@@ -7,6 +7,7 @@
 #include "McpHandlerUtils.h"
 #include "McpAutomationBridgeHelpers.h"
 #include "McpSafeOperations.h"
+#include "EngineUtils.h"
 
 // Define log category declared in McpSafeOperations.h
 DEFINE_LOG_CATEGORY(LogMcpSafeOperations);

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpPropertyReflection.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpPropertyReflection.cpp
@@ -6,6 +6,7 @@
 
 #include "McpPropertyReflection.h"
 #include "Runtime/Launch/Resources/Version.h"
+#include "UObject/TextProperty.h"
 
 #if WITH_EDITOR
 #include "Editor.h"


### PR DESCRIPTION
## Summary

Fixes compilation errors in McpAutomationBridge plugin when building against UE 5.7. The plugin source was missing required header includes for FTextProperty and TActorIterator, causing build failures with undefined type errors.

## Changes

Added #include "UObject/TextProperty.h" to McpPropertyReflection.cpp
Fixes C2027 error: use of undefined type 'FTextProperty'
Added #include "EngineUtils.h" to McpHandlerUtils.cpp
Fixes C2079 error: use of undefined class 'TActorIterator'

- 

## Type of Change

<!-- Check all that apply -->

- [√] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how to test these changes -->

- [√] Tested with Unreal Engine (version: 5.7.3)

## Pre-Merge Checklist

- [√] Code follows project style guidelines
- [√] Self-reviewed the code

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chir24/unreal_mcp/pull/295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
