### PR TITLE
docs: fix rate limiting defaults and missing GraphQL heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ Blueprints • Materials • Textures • Static Meshes • Skeletal Meshes • 
 
 ---
 
+## GraphQL API
 
 Optional GraphQL endpoint for complex queries. **Disabled by default.**
 

--- a/plugins/McpAutomationBridge/README.md
+++ b/plugins/McpAutomationBridge/README.md
@@ -166,7 +166,7 @@ Configure in **Edit → Project Settings → Plugins → MCP Automation Bridge**
 
 - **Loopback-only binding** by default (127.0.0.1)
 - **TLS/SSL support** for secure connections
-- **Rate limiting** (600 messages/min, 120 automation requests/min)
+- **Rate limiting** support (disabled by default; configurable via Project Settings)
 - **Handshake required** before automation requests
 - **Command validation** blocks dangerous console commands
 


### PR DESCRIPTION
## Summary

Fix two documentation inaccuracies: rate limiting defaults in plugin README and a missing section heading in root README.

## Changes

- **Plugin README** (`plugins/McpAutomationBridge/README.md`): Fix rate limiting description — code defaults `MaxMessagesPerMinute` and `MaxAutomationRequestsPerMinute` to `0` (disabled), but the README stated specific values (600/120) as if they were active defaults.
- **Root README** (`README.md`): Add missing `## GraphQL API` heading — the Table of Contents links to `#graphql-api` but the section heading was absent, causing a broken anchor.

### Rate limiting context

The C++ settings constructor (`McpAutomationBridgeSettings.cpp`) explicitly sets:
```cpp
// CRITICAL: Default to 0 (disabled) for development/testing
MaxMessagesPerMinute = 0;
MaxAutomationRequestsPerMinute = 0;
```

The old text `(600 messages/min, 120 automation requests/min)` implied these were active defaults, which could confuse users investigating connection issues.

## Related Issues

None

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📚 Documentation update
- [ ] 🔧 Configuration/build change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test addition/update

## Testing

- [ ] Tested with Unreal Engine (version: N/A — documentation-only change)
- [ ] Tested MCP client integration (client: N/A)
- [ ] Added/updated tests

Documentation-only changes:
- [ ] Verify TOC `#graphql-api` link navigates correctly on GitHub
- [ ] Confirm no other docs reference the old rate limiting values

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Updated relevant documentation (if needed)
- [ ] Added/updated tests (if applicable)
- [ ] CI passes