### PR TITLE
fix: enable searchText filtering in search_assets action

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_AssetQueryHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_AssetQueryHandlers.cpp
@@ -405,8 +405,12 @@ bool UMcpAutomationBridgeSubsystem::HandleAssetQueryAction(
             Filter.PackagePaths.Add(FName(TEXT("/Game")));
         }
 
-        // Parse recursion (default to false for safety)
-        bool bRecursivePaths = false;
+        // Parse searchText for name-based filtering
+        FString SearchText;
+        Payload->TryGetStringField(TEXT("searchText"), SearchText);
+
+        // Parse recursion (default to false for safety, but true when searchText is provided)
+        bool bRecursivePaths = !SearchText.IsEmpty(); // default true for text search
         if (Payload->HasField(TEXT("recursivePaths")))
         {
             Payload->TryGetBoolField(TEXT("recursivePaths"), bRecursivePaths);
@@ -421,12 +425,21 @@ bool UMcpAutomationBridgeSubsystem::HandleAssetQueryAction(
         Filter.bRecursiveClasses = bRecursiveClasses;
 
         // Execute query (uses cached AssetRegistry data)
-        FAssetRegistryModule& AssetRegistryModule = 
+        FAssetRegistryModule& AssetRegistryModule =
             FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
         IAssetRegistry& AssetRegistry = AssetRegistryModule.Get();
 
         TArray<FAssetData> AssetDataList;
         AssetRegistry.GetAssets(Filter, AssetDataList);
+
+        // Filter by searchText (case-insensitive substring match on asset name)
+        if (!SearchText.IsEmpty())
+        {
+            AssetDataList.RemoveAll([&SearchText](const FAssetData& Data)
+            {
+                return !Data.AssetName.ToString().Contains(SearchText, ESearchCase::IgnoreCase);
+            });
+        }
 
         // Apply limit
         int32 Limit = 100;

--- a/src/tools/handlers/asset-handlers.ts
+++ b/src/tools/handlers/asset-handlers.ts
@@ -547,15 +547,18 @@ export async function handleAssetTools(action: string, args: HandlerArgs, tools:
       }
       case 'search_assets': {
         const params = normalizeArgs(args, [
+          { key: 'searchText' },
           { key: 'classNames' },
           { key: 'packagePaths' },
           { key: 'recursivePaths' },
           { key: 'recursiveClasses' },
           { key: 'limit' }
         ]);
+        const searchText = extractOptionalString(params, 'searchText');
         const classNames = extractOptionalArray<string>(params, 'classNames');
         const packagePaths = extractOptionalArray<string>(params, 'packagePaths');
-        const recursivePaths = extractOptionalBoolean(params, 'recursivePaths');
+        // When searchText is provided, default recursivePaths to true for broad search
+        const recursivePaths = extractOptionalBoolean(params, 'recursivePaths') ?? (searchText ? true : undefined);
         const recursiveClasses = extractOptionalBoolean(params, 'recursiveClasses');
         const limit = extractOptionalNumber(params, 'limit');
 
@@ -564,6 +567,7 @@ export async function handleAssetTools(action: string, args: HandlerArgs, tools:
         if (pathSecurityError) return pathSecurityError;
 
         const res = await executeAutomationRequest(tools, 'asset_query', {
+          searchText,
           classNames,
           packagePaths,
           recursivePaths,

--- a/tests/integration.mjs
+++ b/tests/integration.mjs
@@ -75,6 +75,13 @@ const testCases = [
   { scenario: 'Splines: Get specific spline info', toolName: 'manage_splines', arguments: { action: 'get_splines_info', actorName: 'IT_SplineActor' }, expected: 'success|not found' },
   { scenario: 'Cleanup: delete spline actors', toolName: 'control_actor', arguments: { action: 'delete', actorName: 'IT_SplineActor' }, expected: 'success|not found' },
   { scenario: 'Cleanup: delete road spline', toolName: 'control_actor', arguments: { action: 'delete', actorName: 'IT_RoadSpline' }, expected: 'success|not found' },
+  // search_assets: searchText filtering (fix for Issue #233)
+  { scenario: 'Asset: search by text (exact name)', toolName: 'manage_asset', arguments: { action: 'search_assets', searchText: 'BP_IntegrationTest' }, expected: 'success' },
+  { scenario: 'Asset: search by text (partial, case-insensitive)', toolName: 'manage_asset', arguments: { action: 'search_assets', searchText: 'integrationtest' }, expected: 'success' },
+  { scenario: 'Asset: search by text + class filter', toolName: 'manage_asset', arguments: { action: 'search_assets', searchText: 'IntegrationTest', classNames: ['Blueprint'] }, expected: 'success' },
+  { scenario: 'Asset: search by text + path filter', toolName: 'manage_asset', arguments: { action: 'search_assets', searchText: 'IntegrationTest', packagePaths: ['/Game/IntegrationTest'], recursivePaths: true }, expected: 'success' },
+  { scenario: 'Asset: search with no matches', toolName: 'manage_asset', arguments: { action: 'search_assets', searchText: 'ZZZZZ_NonExistent_Asset_12345' }, expected: 'success' },
+  { scenario: 'Asset: search without searchText (structured query)', toolName: 'manage_asset', arguments: { action: 'search_assets', classNames: ['Blueprint'], packagePaths: ['/Game/IntegrationTest'] }, expected: 'success' },
   { scenario: 'Cleanup: delete test actor', toolName: 'control_actor', arguments: { action: 'delete', actorName: 'IT_Cube' }, expected: 'success|not found' },
   { scenario: 'Cleanup: delete test folder', toolName: 'manage_asset', arguments: { action: 'delete', path: TEST_FOLDER, force: true }, expected: 'success|not found' },
   { scenario: 'Cleanup: delete advanced test folder', toolName: 'manage_asset', arguments: { action: 'delete', path: ADV_TEST_FOLDER, force: true }, expected: 'success|not found' }


### PR DESCRIPTION
## Summary

The `search_assets` action accepted `searchText` in the tool schema but silently ignored it — the TS handler did not extract it and the C++ handler had no name-based filtering. This caused all text-based asset searches to return 0 results.

## Changes

- **TS handler** (`asset-handlers.ts`): Add `searchText` to `normalizeArgs`, default `recursivePaths` to `true` when `searchText` is provided, pass `searchText` through to the automation request
- **C++ handler** (`McpAutomationBridge_AssetQueryHandlers.cpp`): Parse `searchText` from payload, apply case-insensitive substring filter on `AssetName` after `FARFilter` query, default `bRecursivePaths` to `true` when `searchText` is non-empty
- **Tests** (`integration.mjs`): Add 6 integration test cases — exact match, partial case-insensitive match, class+text combo, path+text combo, no-match, and backward compatibility (structured query without searchText)

## Related Issues

Fixes #233

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🧪 Test addition/update

## Testing

- [x] Tested with Unreal Engine (version: 5.7)
- [x] Tested MCP client integration (client: Claude Code)
- [x] Added/updated tests

**Manual verification:**
- `search_assets` with `searchText: "BP_Dungeon_Generator"` → correctly returns matching blueprint
- `search_assets` with `searchText: "Dungeon"` → returns 48 matching assets across all subdirectories
- `search_assets` with `searchText: "Generator"` → returns 13 assets including blueprints, materials, textures
- `search_assets` without `searchText` (existing usage) → behavior unchanged

**Integration test results:** 6/6 new search_assets test cases passed. All existing tests unaffected.

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Updated relevant documentation (if needed)
- [x] Added/updated tests (if applicable)
- [ ] CI passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chir24/unreal_mcp/pull/308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
