### PR TITLE
fix: unify pin serialization across blueprint graph handlers

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_BlueprintGraphHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_BlueprintGraphHandlers.cpp
@@ -902,7 +902,7 @@ bool UMcpAutomationBridgeSubsystem::HandleBlueprintGraphAction(
           }
         }
 
-        TArray<TSharedPtr<FJsonValue>> LinkedToFileArray;
+        TArray<TSharedPtr<FJsonValue>> LinkedToArray;
         for (UEdGraphPin *LinkedPin : Pin->LinkedTo) {
           if (LinkedPin && LinkedPin->GetOwningNode()) {
             TSharedPtr<FJsonObject> LinkObj = McpHandlerUtils::CreateResultObject();
@@ -911,10 +911,10 @@ bool UMcpAutomationBridgeSubsystem::HandleBlueprintGraphAction(
                 LinkedPin->GetOwningNode()->NodeGuid.ToString());
             LinkObj->SetStringField(TEXT("pinName"),
                                     LinkedPin->PinName.ToString());
-            LinkedToFileArray.Add(MakeShared<FJsonValueObject>(LinkObj));
+            LinkedToArray.Add(MakeShared<FJsonValueObject>(LinkObj));
           }
         }
-        PinObj->SetArrayField(TEXT("linkedTo"), LinkedToFileArray);
+        PinObj->SetArrayField(TEXT("linkedTo"), LinkedToArray);
         PinsArray.Add(MakeShared<FJsonValueObject>(PinObj));
       }
       NodeObj->SetArrayField(TEXT("pins"), PinsArray);
@@ -1123,6 +1123,9 @@ bool UMcpAutomationBridgeSubsystem::HandleBlueprintGraphAction(
 
       TArray<TSharedPtr<FJsonValue>> Pins;
       for (UEdGraphPin *Pin : TargetNode->Pins) {
+        if (!Pin)
+          continue;
+
         TSharedPtr<FJsonObject> PinObj = McpHandlerUtils::CreateResultObject();
         PinObj->SetStringField(TEXT("pinName"), Pin->PinName.ToString());
         PinObj->SetStringField(TEXT("direction"), Pin->Direction == EGPD_Input
@@ -1130,6 +1133,44 @@ bool UMcpAutomationBridgeSubsystem::HandleBlueprintGraphAction(
                                                       : TEXT("Output"));
         PinObj->SetStringField(TEXT("pinType"),
                                Pin->PinType.PinCategory.ToString());
+
+        // Add pin sub-category object type if applicable
+        if (Pin->PinType.PinCategory == TEXT("object") ||
+            Pin->PinType.PinCategory == TEXT("class") ||
+            Pin->PinType.PinCategory == TEXT("struct")) {
+          if (Pin->PinType.PinSubCategoryObject.IsValid()) {
+            PinObj->SetStringField(
+                TEXT("pinSubType"),
+                Pin->PinType.PinSubCategoryObject->GetName());
+          }
+        }
+
+        // Serialize linked pins as JSON objects (consistent with get_nodes)
+        TArray<TSharedPtr<FJsonValue>> LinkedToArray;
+        for (UEdGraphPin *LinkedPin : Pin->LinkedTo) {
+          if (LinkedPin && LinkedPin->GetOwningNode()) {
+            TSharedPtr<FJsonObject> LinkObj =
+                McpHandlerUtils::CreateResultObject();
+            LinkObj->SetStringField(
+                TEXT("nodeId"),
+                LinkedPin->GetOwningNode()->NodeGuid.ToString());
+            LinkObj->SetStringField(TEXT("pinName"),
+                                    LinkedPin->PinName.ToString());
+            LinkedToArray.Add(MakeShared<FJsonValueObject>(LinkObj));
+          }
+        }
+        PinObj->SetArrayField(TEXT("linkedTo"), LinkedToArray);
+
+        if (!Pin->DefaultValue.IsEmpty()) {
+          PinObj->SetStringField(TEXT("defaultValue"), Pin->DefaultValue);
+        } else if (!Pin->DefaultTextValue.IsEmptyOrWhitespace()) {
+          PinObj->SetStringField(TEXT("defaultTextValue"),
+                                 Pin->DefaultTextValue.ToString());
+        } else if (Pin->DefaultObject) {
+          PinObj->SetStringField(TEXT("defaultObjectPath"),
+                                 Pin->DefaultObject->GetPathName());
+        }
+
         Pins.Add(MakeShared<FJsonValueObject>(PinObj));
       }
       Result->SetArrayField(TEXT("pins"), Pins);
@@ -1207,25 +1248,32 @@ bool UMcpAutomationBridgeSubsystem::HandleBlueprintGraphAction(
       PinObj->SetStringField(TEXT("pinType"),
                              Pin->PinType.PinCategory.ToString());
 
-      if (Pin->LinkedTo.Num() > 0) {
-        TArray<TSharedPtr<FJsonValue>> LinkedArray;
-        for (UEdGraphPin *LinkedPin : Pin->LinkedTo) {
-          if (!LinkedPin) {
-            continue;
-          }
-          FString LinkedNodeId =
-              LinkedPin->GetOwningNode()
-                  ? LinkedPin->GetOwningNode()->NodeGuid.ToString()
-                  : FString();
-          const FString LinkedLabel =
-              LinkedNodeId.IsEmpty()
-                  ? LinkedPin->PinName.ToString()
-                  : FString::Printf(TEXT("%s:%s"), *LinkedNodeId,
-                                    *LinkedPin->PinName.ToString());
-          LinkedArray.Add(MakeShared<FJsonValueString>(LinkedLabel));
+      // Add pin sub-category object type if applicable
+      if (Pin->PinType.PinCategory == TEXT("object") ||
+          Pin->PinType.PinCategory == TEXT("class") ||
+          Pin->PinType.PinCategory == TEXT("struct")) {
+        if (Pin->PinType.PinSubCategoryObject.IsValid()) {
+          PinObj->SetStringField(
+              TEXT("pinSubType"),
+              Pin->PinType.PinSubCategoryObject->GetName());
         }
-        PinObj->SetArrayField(TEXT("linkedTo"), LinkedArray);
       }
+
+      // Serialize linked pins as JSON objects (consistent with get_nodes)
+      TArray<TSharedPtr<FJsonValue>> LinkedToArray;
+      for (UEdGraphPin *LinkedPin : Pin->LinkedTo) {
+        if (LinkedPin && LinkedPin->GetOwningNode()) {
+          TSharedPtr<FJsonObject> LinkObj =
+              McpHandlerUtils::CreateResultObject();
+          LinkObj->SetStringField(
+              TEXT("nodeId"),
+              LinkedPin->GetOwningNode()->NodeGuid.ToString());
+          LinkObj->SetStringField(TEXT("pinName"),
+                                  LinkedPin->PinName.ToString());
+          LinkedToArray.Add(MakeShared<FJsonValueObject>(LinkObj));
+        }
+      }
+      PinObj->SetArrayField(TEXT("linkedTo"), LinkedToArray);
 
       if (!Pin->DefaultValue.IsEmpty()) {
         PinObj->SetStringField(TEXT("defaultValue"), Pin->DefaultValue);


### PR DESCRIPTION
## Summary

`get_node_details`, `get_pin_details`, and `get_nodes` each serialize pin data in inconsistent formats. This PR standardizes them so all three handlers produce consistent JSON output, especially for `linkedTo` connection data.

## Changes

- **`get_node_details`**: Add `pinSubType`, `linkedTo` (as JSON object array), `defaultValue`/`defaultTextValue`/`defaultObjectPath`, and null pin guard. Previously only returned `pinName`/`direction`/`pinType` — less data than the bulk `get_nodes` handler.
- **`get_pin_details`**: Change `linkedTo` from string format (`"nodeId:pinName"`) to JSON object format (`[{nodeId, pinName}]`) matching `get_nodes`. Add `pinSubType` for object/class/struct pins.
- **`get_nodes`**: Rename misleading `LinkedToFileArray` variable to `LinkedToArray`. No functional change.

### Before / After

| Field | get_nodes | get_node_details (before) | get_node_details (after) | get_pin_details (before) | get_pin_details (after) |
|-------|-----------|--------------------------|-------------------------|-------------------------|------------------------|
| pinSubType | object | - | object | - | object |
| linkedTo | `[{nodeId, pinName}]` | - | `[{nodeId, pinName}]` | `["nodeId:pinName"]` | `[{nodeId, pinName}]` |
| defaultValue | - | - | string | string | string |

## Related Issues

Related to #296 (Blueprint bugs)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ♻️ Refactoring (no functional changes)

## Testing

- [ ] Tested with Unreal Engine (version: 5.7)
- [x] Tested MCP client integration (client: Claude Code)
- [ ] Added/updated tests

### How to verify
1. Open a blueprint with connected nodes in UE5 Editor
2. Call `get_node_details` with a nodeId — verify `linkedTo`, `pinSubType`, and `defaultValue` fields are present
3. Call `get_pin_details` on the same node — verify `linkedTo` returns `[{nodeId, pinName}]` objects, not `"nodeId:pinName"` strings
4. Call `get_nodes` — verify output is unchanged

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [ ] Updated relevant documentation (if needed)
- [ ] Added/updated tests (if applicable)
- [x] CI passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chir24/unreal_mcp/pull/309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
