### PR TITLE
fix: align get_ai_info output with TS schema and implement blueprintPath

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_AIHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_AIHandlers.cpp
@@ -2437,6 +2437,14 @@ bool UMcpAutomationBridgeSubsystem::HandleManageAIAction(
         FString BlueprintPath = GetStringFieldAI(Payload, TEXT("blueprintPath"));
         if (!BlueprintPath.IsEmpty())
         {
+            BlueprintPath = SanitizeProjectRelativePath(BlueprintPath);
+            if (BlueprintPath.IsEmpty())
+            {
+                SendAutomationError(RequestingSocket, RequestId,
+                    TEXT("Invalid blueprintPath: must be a valid project-relative path"),
+                    TEXT("INVALID_PATH"));
+                return true;
+            }
             UBlueprint* BP = LoadObject<UBlueprint>(nullptr, *BlueprintPath);
             if (BP && BP->GeneratedClass)
             {
@@ -2482,8 +2490,11 @@ bool UMcpAutomationBridgeSubsystem::HandleManageAIAction(
                 AIInfo->SetStringField(TEXT("assignedBehaviorTree"), BT->GetName());
                 AIInfo->SetBoolField(TEXT("hasRootNode"), BT->RootNode != nullptr);
 
-                // Report associated blackboard from BT asset
-                if (BT->BlackboardAsset)
+                // Report associated blackboard from BT asset (only if
+                // blackboardPath was not explicitly provided, to avoid
+                // silently overwriting an explicit value)
+                FString ExplicitBBPath = GetStringFieldAI(Payload, TEXT("blackboardPath"));
+                if (BT->BlackboardAsset && ExplicitBBPath.IsEmpty())
                 {
                     AIInfo->SetStringField(TEXT("assignedBlackboard"),
                         BT->BlackboardAsset->GetName());

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_AIHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_AIHandlers.cpp
@@ -2510,6 +2510,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageAIAction(
                             if (Child.ChildTask)
                             {
                                 NodeCount++;
+                                NodeCount += Child.ChildTask->Services.Num();
                             }
                         }
                     }

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_AIHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_AIHandlers.cpp
@@ -2433,36 +2433,99 @@ bool UMcpAutomationBridgeSubsystem::HandleManageAIAction(
     {
         TSharedPtr<FJsonObject> AIInfo = McpHandlerUtils::CreateResultObject();
 
-        // Check for controller
+        // --- blueprintPath: auto-discover AI setup from Pawn/Character/AIController blueprint ---
+        FString BlueprintPath = GetStringFieldAI(Payload, TEXT("blueprintPath"));
+        if (!BlueprintPath.IsEmpty())
+        {
+            UBlueprint* BP = LoadObject<UBlueprint>(nullptr, *BlueprintPath);
+            if (BP && BP->GeneratedClass)
+            {
+                UObject* CDO = BP->GeneratedClass->GetDefaultObject();
+
+                // Pawn/Character: extract AIControllerClass
+                if (APawn* PawnCDO = Cast<APawn>(CDO))
+                {
+                    if (PawnCDO->AIControllerClass)
+                    {
+                        AIInfo->SetStringField(TEXT("controllerClass"),
+                            PawnCDO->AIControllerClass->GetName());
+                    }
+                }
+                // AIController: report directly
+                else if (Cast<AAIController>(CDO))
+                {
+                    AIInfo->SetStringField(TEXT("controllerClass"),
+                        BP->GeneratedClass->GetName());
+                }
+            }
+        }
+
+        // --- controllerPath: explicit controller blueprint (overrides blueprintPath discovery) ---
         FString ControllerPath = GetStringFieldAI(Payload, TEXT("controllerPath"));
         if (!ControllerPath.IsEmpty())
         {
             UBlueprint* Controller = LoadObject<UBlueprint>(nullptr, *ControllerPath);
             if (Controller)
             {
-                AIInfo->SetStringField(TEXT("controllerClass"), Controller->GeneratedClass ? Controller->GeneratedClass->GetName() : TEXT("Unknown"));
+                AIInfo->SetStringField(TEXT("controllerClass"),
+                    Controller->GeneratedClass ? Controller->GeneratedClass->GetName() : TEXT("Unknown"));
             }
         }
 
-        // Check for behavior tree
+        // --- behaviorTreePath ---
         FString BTPath = GetStringFieldAI(Payload, TEXT("behaviorTreePath"));
         if (!BTPath.IsEmpty())
         {
             UBehaviorTree* BT = LoadObject<UBehaviorTree>(nullptr, *BTPath);
             if (BT)
             {
-                AIInfo->SetStringField(TEXT("behaviorTreeName"), BT->GetName());
+                AIInfo->SetStringField(TEXT("assignedBehaviorTree"), BT->GetName());
                 AIInfo->SetBoolField(TEXT("hasRootNode"), BT->RootNode != nullptr);
+
+                // Report associated blackboard from BT asset
+                if (BT->BlackboardAsset)
+                {
+                    AIInfo->SetStringField(TEXT("assignedBlackboard"),
+                        BT->BlackboardAsset->GetName());
+                }
+
+                // Count BT nodes (composites + tasks + decorators + services)
+                if (BT->RootNode)
+                {
+                    int32 NodeCount = 0;
+                    TArray<UBTCompositeNode*> Stack;
+                    Stack.Add(BT->RootNode);
+                    while (Stack.Num() > 0)
+                    {
+                        UBTCompositeNode* Current = Stack.Pop();
+                        NodeCount++;
+                        NodeCount += Current->Services.Num();
+                        for (const FBTCompositeChild& Child : Current->Children)
+                        {
+                            NodeCount += Child.Decorators.Num();
+                            if (Child.ChildComposite)
+                            {
+                                Stack.Add(Child.ChildComposite);
+                            }
+                            if (Child.ChildTask)
+                            {
+                                NodeCount++;
+                            }
+                        }
+                    }
+                    AIInfo->SetNumberField(TEXT("btNodeCount"), NodeCount);
+                }
             }
         }
 
-        // Check for blackboard
+        // --- blackboardPath ---
         FString BBPath = GetStringFieldAI(Payload, TEXT("blackboardPath"));
         if (!BBPath.IsEmpty())
         {
             UBlackboardData* BB = LoadObject<UBlackboardData>(nullptr, *BBPath);
             if (BB)
             {
+                AIInfo->SetStringField(TEXT("assignedBlackboard"), BB->GetName());
                 AIInfo->SetNumberField(TEXT("keyCount"), BB->Keys.Num());
                 TArray<TSharedPtr<FJsonValue>> KeysArray;
                 for (const FBlackboardEntry& Entry : BB->Keys)
@@ -2473,11 +2536,11 @@ bool UMcpAutomationBridgeSubsystem::HandleManageAIAction(
                     KeyObj->SetBoolField(TEXT("instanceSynced"), Entry.bInstanceSynced);
                     KeysArray.Add(MakeShared<FJsonValueObject>(KeyObj));
                 }
-                AIInfo->SetArrayField(TEXT("keys"), KeysArray);
+                AIInfo->SetArrayField(TEXT("blackboardKeys"), KeysArray);
             }
         }
 
-        // Check for EQS query
+        // --- queryPath ---
         FString QueryPath = GetStringFieldAI(Payload, TEXT("queryPath"));
         if (!QueryPath.IsEmpty())
         {


### PR DESCRIPTION
## Summary

The TS handler for `get_ai_info` accepted `blueprintPath` and `stateTreePath` as valid parameters and passed TS-side validation, but the C++ handler never read them — resulting in a silent empty `{aiInfo: {}}` response with `success: true`. Additionally, the C++ output field names diverged from the TS output schema defined in `consolidated-tool-definitions.ts`.

## Changes

- **Add `blueprintPath` support**: auto-discover `AIControllerClass` from Pawn/Character CDO, or report directly for AIController blueprints
- **Rename output fields** to match TS schema:
  - `behaviorTreeName` → `assignedBehaviorTree`
  - `keys` → `blackboardKeys`
- **Add `assignedBlackboard`**: automatically extracted from `UBehaviorTree::BlackboardAsset` when `behaviorTreePath` is provided
- **Add `btNodeCount`**: traverses BT root node to count all composites, tasks, decorators, and services
- `controllerPath` still overrides `blueprintPath` discovery when both are provided

## Related Issues

<!-- No specific issue tracked for this -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration/build change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test addition/update

## Testing

- [x] Tested with Unreal Engine (version: 5.7)
- [x] Tested MCP client integration (client: Claude Code)
- [ ] Added/updated tests

**Test cases verified in-editor:**
1. `get_ai_info` with `blueprintPath` pointing to a Pawn blueprint → returns `controllerClass` from CDO's `AIControllerClass`
2. `get_ai_info` with `blueprintPath` pointing to an AIController blueprint → returns `controllerClass` directly
3. `get_ai_info` with `behaviorTreePath` → returns `assignedBehaviorTree`, `assignedBlackboard`, `btNodeCount`, `hasRootNode`
4. `get_ai_info` with `controllerPath` → returns `controllerClass` (regression, unchanged)
5. `get_ai_info` with `blueprintPath` pointing to a non-AI blueprint (e.g., ActorComponent) → returns empty `aiInfo` (correct behavior)
6. Combined `blueprintPath` + `behaviorTreePath` → returns full AI chain info in a single call

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [ ] Updated relevant documentation (if needed)
- [ ] Added/updated tests (if applicable)
- [x] CI passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chir24/unreal_mcp/pull/310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
