### PR TITLE
feat: Movie Render Queue (MRQ) handler — 11 actions

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/McpAutomationBridge.Build.cs
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/McpAutomationBridge.Build.cs
@@ -239,6 +239,12 @@ PublicDependencyModuleNames.AddRange(new string[]
             AddOptionalDynamicModule(Target, EngineDir, "ChaosVehicles", "ChaosVehicles");
             AddOptionalDynamicModule(Target, EngineDir, "AnimationData", "AnimationData");
 
+            // Movie Render Queue / Pipeline (optional plugin) - for MRQ automation
+            AddOptionalDynamicModule(Target, EngineDir, "MovieRenderPipelineCore", "MovieRenderPipelineCore");
+            AddOptionalDynamicModule(Target, EngineDir, "MovieRenderPipelineSettings", "MovieRenderPipelineSettings");
+            AddOptionalDynamicModule(Target, EngineDir, "MovieRenderPipelineEditor", "MovieRenderPipelineEditor");
+            AddOptionalDynamicModule(Target, EngineDir, "MovieRenderPipelineRenderPasses", "MovieRenderPipelineRenderPasses");
+
             // Ensure editor builds expose full Blueprint graph editing APIs.
             PublicDefinitions.Add("MCP_HAS_K2NODE_HEADERS=1");
             PublicDefinitions.Add("MCP_HAS_EDGRAPH_SCHEMA_K2=1");

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridgeSubsystem.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridgeSubsystem.cpp
@@ -1282,6 +1282,14 @@ void UMcpAutomationBridgeSubsystem::InitializeHandlers() {
                     return true;
 #endif
                   });
+
+  // Movie Render Queue (MRQ)
+  RegisterHandler(TEXT("manage_mrq"),
+                  [this](const FString &R, const FString &A,
+                         const TSharedPtr<FJsonObject> &P,
+                         TSharedPtr<FMcpBridgeWebSocket> S) {
+                    return HandleMrqAction(R, A, P, S);
+                  });
 }
 
 // Drain and process any automation requests that were enqueued while the

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_MrqHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_MrqHandlers.cpp
@@ -97,7 +97,7 @@ bool UMcpAutomationBridgeSubsystem::HandleMrqAction(
     ErrorResult->SetStringField(TEXT("error"), TEXT("MRQ_NOT_AVAILABLE"));
     ErrorResult->SetStringField(TEXT("message"), TEXT("Movie Render Queue plugin is not available in this engine build"));
     SendAutomationResponse(RequestingSocket, RequestId, false,
-        TEXT("Movie Render Queue plugin is not available"), ErrorResult);
+        TEXT("Movie Render Queue plugin is not available"), ErrorResult, TEXT("MRQ_NOT_AVAILABLE"));
     return true;
 #else
     FString SubAction;
@@ -113,7 +113,7 @@ bool UMcpAutomationBridgeSubsystem::HandleMrqAction(
         TSharedPtr<FJsonObject> ErrorResult = MakeShared<FJsonObject>();
         ErrorResult->SetStringField(TEXT("error"), TEXT("SUBSYSTEM_NOT_FOUND"));
         SendAutomationResponse(RequestingSocket, RequestId, false,
-            TEXT("MRQ subsystem not available (editor only)"), ErrorResult);
+            TEXT("MRQ subsystem not available (editor only)"), ErrorResult, TEXT("SUBSYSTEM_NOT_FOUND"));
         return true;
     }
 
@@ -182,7 +182,7 @@ bool UMcpAutomationBridgeSubsystem::HandleMrqAction(
             TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
             Err->SetStringField(TEXT("error"), TEXT("INVALID_JOB_INDEX"));
             SendAutomationResponse(RequestingSocket, RequestId, false,
-                FString::Printf(TEXT("No job at index %d"), JobIndex), Err);
+                FString::Printf(TEXT("No job at index %d"), JobIndex), Err, TEXT("INVALID_JOB_INDEX"));
             return true;
         }
 
@@ -280,7 +280,7 @@ bool UMcpAutomationBridgeSubsystem::HandleMrqAction(
             TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
             Err->SetStringField(TEXT("error"), TEXT("INVALID_JOB_INDEX"));
             SendAutomationResponse(RequestingSocket, RequestId, false,
-                FString::Printf(TEXT("No job at index %d"), JobIndex), Err);
+                FString::Printf(TEXT("No job at index %d"), JobIndex), Err, TEXT("INVALID_JOB_INDEX"));
             return true;
         }
 
@@ -337,7 +337,7 @@ bool UMcpAutomationBridgeSubsystem::HandleMrqAction(
             TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
             Err->SetStringField(TEXT("error"), TEXT("INVALID_JOB_INDEX"));
             SendAutomationResponse(RequestingSocket, RequestId, false,
-                FString::Printf(TEXT("No job at index %d"), JobIndex), Err);
+                FString::Printf(TEXT("No job at index %d"), JobIndex), Err, TEXT("INVALID_JOB_INDEX"));
             return true;
         }
 
@@ -347,11 +347,19 @@ bool UMcpAutomationBridgeSubsystem::HandleMrqAction(
             TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
             Err->SetStringField(TEXT("error"), TEXT("NO_CONFIG"));
             SendAutomationResponse(RequestingSocket, RequestId, false,
-                TEXT("Job has no pipeline config"), Err);
+                TEXT("Job has no pipeline config"), Err, TEXT("NO_CONFIG"));
             return true;
         }
 
         UMoviePipelineConsoleVariableSetting* CVars = Cast<UMoviePipelineConsoleVariableSetting>(Config->FindOrAddSettingByClass(UMoviePipelineConsoleVariableSetting::StaticClass()));
+        if (!CVars)
+        {
+            TSharedPtr<FJsonObject> Err2 = MakeShared<FJsonObject>();
+            Err2->SetStringField(TEXT("error"), TEXT("SETTING_NOT_AVAILABLE"));
+            SendAutomationResponse(RequestingSocket, RequestId, false,
+                TEXT("Failed to find or create CVar setting"), Err2, TEXT("SETTING_NOT_AVAILABLE"));
+            return true;
+        }
 
         // Set CVars from payload
         const TSharedPtr<FJsonObject>* SetObj = nullptr;
@@ -430,7 +438,7 @@ bool UMcpAutomationBridgeSubsystem::HandleMrqAction(
             TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
             Err->SetStringField(TEXT("error"), TEXT("INVALID_JOB_INDEX"));
             SendAutomationResponse(RequestingSocket, RequestId, false,
-                FString::Printf(TEXT("No job at index %d"), JobIndex), Err);
+                FString::Printf(TEXT("No job at index %d"), JobIndex), Err, TEXT("INVALID_JOB_INDEX"));
             return true;
         }
 
@@ -477,7 +485,7 @@ bool UMcpAutomationBridgeSubsystem::HandleMrqAction(
             TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
             Err->SetStringField(TEXT("error"), TEXT("INVALID_JOB_INDEX"));
             SendAutomationResponse(RequestingSocket, RequestId, false,
-                FString::Printf(TEXT("No job at index %d"), JobIndex), Err);
+                FString::Printf(TEXT("No job at index %d"), JobIndex), Err, TEXT("INVALID_JOB_INDEX"));
             return true;
         }
 
@@ -487,18 +495,40 @@ bool UMcpAutomationBridgeSubsystem::HandleMrqAction(
             TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
             Err->SetStringField(TEXT("error"), TEXT("NO_CONFIG"));
             SendAutomationResponse(RequestingSocket, RequestId, false,
-                TEXT("Job has no pipeline config"), Err);
+                TEXT("Job has no pipeline config"), Err, TEXT("NO_CONFIG"));
             return true;
         }
 
         UMoviePipelineOutputSetting* Output = Cast<UMoviePipelineOutputSetting>(Config->FindOrAddSettingByClass(UMoviePipelineOutputSetting::StaticClass()));
+        if (!Output)
+        {
+            TSharedPtr<FJsonObject> Err2 = MakeShared<FJsonObject>();
+            Err2->SetStringField(TEXT("error"), TEXT("SETTING_NOT_AVAILABLE"));
+            SendAutomationResponse(RequestingSocket, RequestId, false,
+                TEXT("Failed to find or create output setting"), Err2, TEXT("SETTING_NOT_AVAILABLE"));
+            return true;
+        }
 
         FString StrVal;
         double NumVal;
         bool BoolVal;
 
         if (Payload->TryGetStringField(TEXT("outputDirectory"), StrVal))
-            Output->OutputDirectory.Path = StrVal;
+        {
+            // Normalize and reject path traversal
+            FString CleanDir = StrVal;
+            FPaths::NormalizeFilename(CleanDir);
+            FPaths::CollapseRelativeDirectories(CleanDir);
+            if (CleanDir.Contains(TEXT("..")))
+            {
+                TSharedPtr<FJsonObject> Err2 = MakeShared<FJsonObject>();
+                Err2->SetStringField(TEXT("error"), TEXT("INVALID_PATH"));
+                SendAutomationResponse(RequestingSocket, RequestId, false,
+                    TEXT("outputDirectory rejected: path traversal (..) not allowed"), Err2, TEXT("INVALID_PATH"));
+                return true;
+            }
+            Output->OutputDirectory.Path = CleanDir;
+        }
         if (Payload->TryGetNumberField(TEXT("resolutionX"), NumVal))
             Output->OutputResolution.X = (int32)NumVal;
         if (Payload->TryGetNumberField(TEXT("resolutionY"), NumVal))
@@ -539,11 +569,9 @@ bool UMcpAutomationBridgeSubsystem::HandleMrqAction(
             TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
             Err->SetStringField(TEXT("error"), TEXT("NO_QUEUE"));
             SendAutomationResponse(RequestingSocket, RequestId, false,
-                TEXT("No MRQ queue available"), Err);
+                TEXT("No MRQ queue available"), Err, TEXT("NO_QUEUE"));
             return true;
         }
-
-        UMoviePipelineExecutorJob* NewJob = Queue->AllocateNewJob(UMoviePipelineExecutorJob::StaticClass());
 
         FString MapPath, SequencePath, JobName;
         if (Payload.IsValid())
@@ -553,10 +581,18 @@ bool UMcpAutomationBridgeSubsystem::HandleMrqAction(
             Payload->TryGetStringField(TEXT("jobName"), JobName);
         }
 
-        if (!MapPath.IsEmpty())
-            NewJob->Map = FSoftObjectPath(MapPath);
-        if (!SequencePath.IsEmpty())
-            NewJob->Sequence = FSoftObjectPath(SequencePath);
+        if (MapPath.IsEmpty() || SequencePath.IsEmpty())
+        {
+            TSharedPtr<FJsonObject> Err2 = MakeShared<FJsonObject>();
+            Err2->SetStringField(TEXT("error"), TEXT("MISSING_REQUIRED_FIELDS"));
+            SendAutomationResponse(RequestingSocket, RequestId, false,
+                TEXT("create_job requires both 'map' and 'sequence'"), Err2, TEXT("MISSING_REQUIRED_FIELDS"));
+            return true;
+        }
+
+        UMoviePipelineExecutorJob* NewJob = Queue->AllocateNewJob(UMoviePipelineExecutorJob::StaticClass());
+        NewJob->Map = FSoftObjectPath(MapPath);
+        NewJob->Sequence = FSoftObjectPath(SequencePath);
         if (!JobName.IsEmpty())
             NewJob->JobName = JobName;
         else
@@ -582,7 +618,7 @@ bool UMcpAutomationBridgeSubsystem::HandleMrqAction(
             TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
             Err->SetStringField(TEXT("error"), TEXT("INVALID_JOB_INDEX"));
             SendAutomationResponse(RequestingSocket, RequestId, false,
-                FString::Printf(TEXT("No job at index %d"), JobIndex), Err);
+                FString::Printf(TEXT("No job at index %d"), JobIndex), Err, TEXT("INVALID_JOB_INDEX"));
             return true;
         }
 
@@ -603,7 +639,7 @@ bool UMcpAutomationBridgeSubsystem::HandleMrqAction(
             TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
             Err->SetStringField(TEXT("error"), TEXT("ALREADY_RENDERING"));
             SendAutomationResponse(RequestingSocket, RequestId, false,
-                TEXT("A render is already in progress"), Err);
+                TEXT("A render is already in progress"), Err, TEXT("ALREADY_RENDERING"));
             return true;
         }
 
@@ -612,7 +648,7 @@ bool UMcpAutomationBridgeSubsystem::HandleMrqAction(
             TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
             Err->SetStringField(TEXT("error"), TEXT("EMPTY_QUEUE"));
             SendAutomationResponse(RequestingSocket, RequestId, false,
-                TEXT("Queue is empty — add jobs before rendering"), Err);
+                TEXT("Queue is empty — add jobs before rendering"), Err, TEXT("EMPTY_QUEUE"));
             return true;
         }
 
@@ -660,7 +696,7 @@ bool UMcpAutomationBridgeSubsystem::HandleMrqAction(
             TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
             Err->SetStringField(TEXT("error"), TEXT("MISSING_PRESET_PATH"));
             SendAutomationResponse(RequestingSocket, RequestId, false,
-                TEXT("presetPath is required"), Err);
+                TEXT("presetPath is required"), Err, TEXT("MISSING_PRESET_PATH"));
             return true;
         }
 
@@ -670,7 +706,7 @@ bool UMcpAutomationBridgeSubsystem::HandleMrqAction(
             TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
             Err->SetStringField(TEXT("error"), TEXT("INVALID_JOB_INDEX"));
             SendAutomationResponse(RequestingSocket, RequestId, false,
-                FString::Printf(TEXT("No job at index %d"), JobIndex), Err);
+                FString::Printf(TEXT("No job at index %d"), JobIndex), Err, TEXT("INVALID_JOB_INDEX"));
             return true;
         }
 
@@ -681,7 +717,7 @@ bool UMcpAutomationBridgeSubsystem::HandleMrqAction(
             TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
             Err->SetStringField(TEXT("error"), TEXT("PRESET_NOT_FOUND"));
             SendAutomationResponse(RequestingSocket, RequestId, false,
-                FString::Printf(TEXT("Preset not found: %s"), *PresetPath), Err);
+                FString::Printf(TEXT("Preset not found: %s"), *PresetPath), Err, TEXT("PRESET_NOT_FOUND"));
             return true;
         }
 
@@ -700,7 +736,7 @@ bool UMcpAutomationBridgeSubsystem::HandleMrqAction(
     Err->SetStringField(TEXT("error"), TEXT("UNKNOWN_ACTION"));
     Err->SetStringField(TEXT("action"), SubAction);
     SendAutomationResponse(RequestingSocket, RequestId, false,
-        FString::Printf(TEXT("Unknown MRQ action: %s"), *SubAction), Err);
+        FString::Printf(TEXT("Unknown MRQ action: %s"), *SubAction), Err, TEXT("UNKNOWN_ACTION"));
     return true;
 #endif // MCP_HAS_MRQ
 }

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_MrqHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_MrqHandlers.cpp
@@ -19,7 +19,6 @@
 //
 // Section 3: Preset Management
 //   - load_preset                  : Load a preset config asset
-//   - save_preset                  : Save config as preset asset
 //
 // Section 4: Render Execution
 //   - render                       : Execute the queue

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_MrqHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_MrqHandlers.cpp
@@ -328,8 +328,16 @@ bool UMcpAutomationBridgeSubsystem::HandleMrqAction(
     // ─── set_cvars ────────────────────────────────────────────────────────────
     if (Lower == TEXT("set_cvars"))
     {
+        if (!Payload.IsValid())
+        {
+            TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
+            Err->SetStringField(TEXT("error"), TEXT("INVALID_PAYLOAD"));
+            SendAutomationResponse(RequestingSocket, RequestId, false,
+                TEXT("set_cvars requires a valid payload"), Err, TEXT("INVALID_PAYLOAD"));
+            return true;
+        }
         int32 JobIndex = 0;
-        if (Payload.IsValid()) Payload->TryGetNumberField(TEXT("jobIndex"), JobIndex);
+        Payload->TryGetNumberField(TEXT("jobIndex"), JobIndex);
 
         UMoviePipelineExecutorJob* Job = GetJobByIndex(Queue, JobIndex);
         if (!Job)
@@ -476,8 +484,16 @@ bool UMcpAutomationBridgeSubsystem::HandleMrqAction(
     // ─── set_output_settings ──────────────────────────────────────────────────
     if (Lower == TEXT("set_output_settings"))
     {
+        if (!Payload.IsValid())
+        {
+            TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
+            Err->SetStringField(TEXT("error"), TEXT("INVALID_PAYLOAD"));
+            SendAutomationResponse(RequestingSocket, RequestId, false,
+                TEXT("set_output_settings requires a valid payload"), Err, TEXT("INVALID_PAYLOAD"));
+            return true;
+        }
         int32 JobIndex = 0;
-        if (Payload.IsValid()) Payload->TryGetNumberField(TEXT("jobIndex"), JobIndex);
+        Payload->TryGetNumberField(TEXT("jobIndex"), JobIndex);
 
         UMoviePipelineExecutorJob* Job = GetJobByIndex(Queue, JobIndex);
         if (!Job)
@@ -610,7 +626,14 @@ bool UMcpAutomationBridgeSubsystem::HandleMrqAction(
     if (Lower == TEXT("delete_job"))
     {
         int32 JobIndex = 0;
-        if (Payload.IsValid()) Payload->TryGetNumberField(TEXT("jobIndex"), JobIndex);
+        if (!Payload.IsValid() || !Payload->TryGetNumberField(TEXT("jobIndex"), JobIndex))
+        {
+            TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
+            Err->SetStringField(TEXT("error"), TEXT("MISSING_JOB_INDEX"));
+            SendAutomationResponse(RequestingSocket, RequestId, false,
+                TEXT("delete_job requires explicit jobIndex"), Err, TEXT("MISSING_JOB_INDEX"));
+            return true;
+        }
 
         UMoviePipelineExecutorJob* Job = GetJobByIndex(Queue, JobIndex);
         if (!Job)

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_MrqHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_MrqHandlers.cpp
@@ -1,0 +1,706 @@
+// =============================================================================
+// McpAutomationBridge_MrqHandlers.cpp
+// =============================================================================
+// Movie Render Queue (MRQ) Handlers for MCP Automation Bridge
+//
+// HANDLERS IMPLEMENTED:
+// ---------------------
+// Section 1: Queue Management
+//   - get_queue                    : List all jobs in the MRQ queue
+//   - create_job                   : Create a new render job
+//   - delete_job                   : Remove a job from the queue
+//
+// Section 2: Job Configuration
+//   - get_job_config               : Read all settings for a job
+//   - get_cvars                    : Read CVar overrides
+//   - set_cvars                    : Add/modify/remove CVar overrides
+//   - get_output_settings          : Read output settings
+//   - set_output_settings          : Modify output settings
+//
+// Section 3: Preset Management
+//   - load_preset                  : Load a preset config asset
+//   - save_preset                  : Save config as preset asset
+//
+// Section 4: Render Execution
+//   - render                       : Execute the queue
+//   - get_render_status            : Check render progress
+//
+// VERSION COMPATIBILITY:
+// ----------------------
+// UE 5.0-5.1: UMoviePipelineMasterConfig
+// UE 5.2+: UMoviePipelinePrimaryConfig
+// Both are handled via __has_include checks.
+//
+// =============================================================================
+
+#include "McpVersionCompatibility.h"  // MUST be first
+#include "McpHandlerUtils.h"
+#include "Dom/JsonObject.h"
+#include "McpAutomationBridgeGlobals.h"
+#include "McpAutomationBridgeSubsystem.h"
+#include "Modules/ModuleManager.h"
+#include "Serialization/JsonSerializer.h"
+
+#if WITH_EDITOR
+#include "Editor.h"
+#endif
+
+// MRQ headers - guarded for optional availability
+#if __has_include("MoviePipelineQueueSubsystem.h")
+#define MCP_HAS_MRQ 1
+#include "MoviePipelineQueue.h"
+#include "MoviePipelineQueueSubsystem.h"
+#include "MoviePipelineExecutor.h"
+#include "MoviePipelinePrimaryConfig.h"
+#include "MoviePipelineSetting.h"
+#include "MoviePipelineOutputSetting.h"
+#include "MoviePipelineConsoleVariableSetting.h"
+#include "MoviePipelineDeferredPasses.h"
+#include "MoviePipelineAntiAliasingSetting.h"
+#include "MoviePipelinePIEExecutor.h"
+#include "MovieRenderPipelineDataTypes.h"
+#else
+#define MCP_HAS_MRQ 0
+#endif
+
+// ─── Helper: Get Queue Subsystem ──────────────────────────────────────────────
+#if MCP_HAS_MRQ
+static UMoviePipelineQueueSubsystem* GetMRQSubsystem()
+{
+#if WITH_EDITOR
+    if (GEditor)
+    {
+        return GEditor->GetEditorSubsystem<UMoviePipelineQueueSubsystem>();
+    }
+#endif
+    return nullptr;
+}
+
+static UMoviePipelineExecutorJob* GetJobByIndex(UMoviePipelineQueue* Queue, int32 JobIndex)
+{
+    if (!Queue) return nullptr;
+    const TArray<UMoviePipelineExecutorJob*>& Jobs = Queue->GetJobs();
+    if (!Jobs.IsValidIndex(JobIndex)) return nullptr;
+    return Jobs[JobIndex];
+}
+#endif
+
+// ─── MRQ Action Dispatcher ───────────────────────────────────────────────────
+
+bool UMcpAutomationBridgeSubsystem::HandleMrqAction(
+    const FString& RequestId, const FString& Action,
+    const TSharedPtr<FJsonObject>& Payload,
+    TSharedPtr<FMcpBridgeWebSocket> RequestingSocket)
+{
+#if !MCP_HAS_MRQ
+    TSharedPtr<FJsonObject> ErrorResult = MakeShared<FJsonObject>();
+    ErrorResult->SetStringField(TEXT("error"), TEXT("MRQ_NOT_AVAILABLE"));
+    ErrorResult->SetStringField(TEXT("message"), TEXT("Movie Render Queue plugin is not available in this engine build"));
+    SendAutomationResponse(RequestingSocket, RequestId, false,
+        TEXT("Movie Render Queue plugin is not available"), ErrorResult);
+    return true;
+#else
+    FString SubAction;
+    if (Payload.IsValid())
+    {
+        Payload->TryGetStringField(TEXT("action"), SubAction);
+    }
+    const FString Lower = SubAction.ToLower();
+
+    UMoviePipelineQueueSubsystem* Subsystem = GetMRQSubsystem();
+    if (!Subsystem)
+    {
+        TSharedPtr<FJsonObject> ErrorResult = MakeShared<FJsonObject>();
+        ErrorResult->SetStringField(TEXT("error"), TEXT("SUBSYSTEM_NOT_FOUND"));
+        SendAutomationResponse(RequestingSocket, RequestId, false,
+            TEXT("MRQ subsystem not available (editor only)"), ErrorResult);
+        return true;
+    }
+
+    UMoviePipelineQueue* Queue = Subsystem->GetQueue();
+
+    // ─── get_queue ────────────────────────────────────────────────────────────
+    if (Lower == TEXT("get_queue"))
+    {
+        TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+        TArray<TSharedPtr<FJsonValue>> JobsArray;
+
+        if (Queue)
+        {
+            const TArray<UMoviePipelineExecutorJob*>& Jobs = Queue->GetJobs();
+            for (int32 i = 0; i < Jobs.Num(); i++)
+            {
+                UMoviePipelineExecutorJob* Job = Jobs[i];
+                if (!Job) continue;
+
+                TSharedPtr<FJsonObject> JobObj = MakeShared<FJsonObject>();
+                JobObj->SetNumberField(TEXT("index"), i);
+                JobObj->SetStringField(TEXT("jobName"), Job->JobName);
+                JobObj->SetStringField(TEXT("map"), Job->Map.ToString());
+                JobObj->SetStringField(TEXT("sequence"), Job->Sequence.ToString());
+                JobObj->SetBoolField(TEXT("enabled"), Job->IsEnabled());
+
+                // Config summary
+                UMoviePipelinePrimaryConfig* Config = Cast<UMoviePipelinePrimaryConfig>(Job->GetConfiguration());
+                if (Config)
+                {
+                    TArray<UMoviePipelineSetting*> Settings = Config->GetUserSettings();
+                    JobObj->SetNumberField(TEXT("settingCount"), Settings.Num());
+
+                    TArray<TSharedPtr<FJsonValue>> SettingNames;
+                    for (UMoviePipelineSetting* Setting : Settings)
+                    {
+                        if (Setting)
+                        {
+                            SettingNames.Add(MakeShared<FJsonValueString>(Setting->GetClass()->GetName()));
+                        }
+                    }
+                    JobObj->SetArrayField(TEXT("settings"), SettingNames);
+                }
+
+                JobsArray.Add(MakeShared<FJsonValueObject>(JobObj));
+            }
+        }
+
+        Result->SetArrayField(TEXT("jobs"), JobsArray);
+        Result->SetNumberField(TEXT("jobCount"), JobsArray.Num());
+        Result->SetBoolField(TEXT("isRendering"), Subsystem->IsRendering());
+        SendAutomationResponse(RequestingSocket, RequestId, true,
+            FString::Printf(TEXT("Queue has %d jobs"), JobsArray.Num()), Result);
+        return true;
+    }
+
+    // ─── get_job_config ───────────────────────────────────────────────────────
+    if (Lower == TEXT("get_job_config"))
+    {
+        int32 JobIndex = 0;
+        if (Payload.IsValid()) Payload->TryGetNumberField(TEXT("jobIndex"), JobIndex);
+
+        UMoviePipelineExecutorJob* Job = GetJobByIndex(Queue, JobIndex);
+        if (!Job)
+        {
+            TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
+            Err->SetStringField(TEXT("error"), TEXT("INVALID_JOB_INDEX"));
+            SendAutomationResponse(RequestingSocket, RequestId, false,
+                FString::Printf(TEXT("No job at index %d"), JobIndex), Err);
+            return true;
+        }
+
+        TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+        Result->SetStringField(TEXT("jobName"), Job->JobName);
+        Result->SetStringField(TEXT("map"), Job->Map.ToString());
+        Result->SetStringField(TEXT("sequence"), Job->Sequence.ToString());
+
+        UMoviePipelinePrimaryConfig* Config = Cast<UMoviePipelinePrimaryConfig>(Job->GetConfiguration());
+        if (Config)
+        {
+            // Output settings
+            UMoviePipelineOutputSetting* Output = Config->FindSetting<UMoviePipelineOutputSetting>();
+            if (Output)
+            {
+                TSharedPtr<FJsonObject> OutputObj = MakeShared<FJsonObject>();
+                OutputObj->SetStringField(TEXT("outputDirectory"), Output->OutputDirectory.Path);
+                OutputObj->SetNumberField(TEXT("resolutionX"), Output->OutputResolution.X);
+                OutputObj->SetNumberField(TEXT("resolutionY"), Output->OutputResolution.Y);
+                OutputObj->SetStringField(TEXT("fileNameFormat"), Output->FileNameFormat);
+                OutputObj->SetBoolField(TEXT("overrideExisting"), Output->bOverrideExistingOutput);
+                OutputObj->SetNumberField(TEXT("zeroPadFrameNumbers"), Output->ZeroPadFrameNumbers);
+                OutputObj->SetNumberField(TEXT("frameNumberOffset"), Output->FrameNumberOffset);
+                OutputObj->SetNumberField(TEXT("handleFrameCount"), Output->HandleFrameCount);
+                Result->SetObjectField(TEXT("outputSettings"), OutputObj);
+            }
+
+            // CVar overrides
+            UMoviePipelineConsoleVariableSetting* CVars = Config->FindSetting<UMoviePipelineConsoleVariableSetting>();
+            if (CVars)
+            {
+                TSharedPtr<FJsonObject> CVarObj = MakeShared<FJsonObject>();
+                TArray<FMoviePipelineConsoleVariableEntry> CVarEntries = CVars->GetConsoleVariables();
+                for (const FMoviePipelineConsoleVariableEntry& Entry : CVarEntries)
+                {
+                    CVarObj->SetNumberField(Entry.Name, Entry.Value);
+                }
+                Result->SetObjectField(TEXT("consoleVariables"), CVarObj);
+
+                TArray<TSharedPtr<FJsonValue>> StartCmds;
+                for (const FString& Cmd : CVars->StartConsoleCommands)
+                {
+                    StartCmds.Add(MakeShared<FJsonValueString>(Cmd));
+                }
+                Result->SetArrayField(TEXT("startConsoleCommands"), StartCmds);
+
+                TArray<TSharedPtr<FJsonValue>> EndCmds;
+                for (const FString& Cmd : CVars->EndConsoleCommands)
+                {
+                    EndCmds.Add(MakeShared<FJsonValueString>(Cmd));
+                }
+                Result->SetArrayField(TEXT("endConsoleCommands"), EndCmds);
+            }
+
+            // Anti-aliasing
+            UMoviePipelineAntiAliasingSetting* AA = Config->FindSetting<UMoviePipelineAntiAliasingSetting>();
+            if (AA)
+            {
+                TSharedPtr<FJsonObject> AAObj = MakeShared<FJsonObject>();
+                AAObj->SetNumberField(TEXT("spatialSampleCount"), AA->SpatialSampleCount);
+                AAObj->SetNumberField(TEXT("temporalSampleCount"), AA->TemporalSampleCount);
+                AAObj->SetBoolField(TEXT("overrideAntiAliasing"), AA->bOverrideAntiAliasing);
+                Result->SetObjectField(TEXT("antiAliasing"), AAObj);
+            }
+
+            // All settings summary
+            TArray<TSharedPtr<FJsonValue>> AllSettings;
+            for (UMoviePipelineSetting* Setting : Config->GetUserSettings())
+            {
+                if (Setting)
+                {
+                    TSharedPtr<FJsonObject> S = MakeShared<FJsonObject>();
+                    S->SetStringField(TEXT("class"), Setting->GetClass()->GetName());
+                    S->SetBoolField(TEXT("enabled"), Setting->IsEnabled());
+                    AllSettings.Add(MakeShared<FJsonValueObject>(S));
+                }
+            }
+            Result->SetArrayField(TEXT("allSettings"), AllSettings);
+        }
+
+        SendAutomationResponse(RequestingSocket, RequestId, true,
+            TEXT("Job config retrieved"), Result);
+        return true;
+    }
+
+    // ─── get_cvars ────────────────────────────────────────────────────────────
+    if (Lower == TEXT("get_cvars"))
+    {
+        int32 JobIndex = 0;
+        if (Payload.IsValid()) Payload->TryGetNumberField(TEXT("jobIndex"), JobIndex);
+
+        UMoviePipelineExecutorJob* Job = GetJobByIndex(Queue, JobIndex);
+        if (!Job)
+        {
+            TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
+            Err->SetStringField(TEXT("error"), TEXT("INVALID_JOB_INDEX"));
+            SendAutomationResponse(RequestingSocket, RequestId, false,
+                FString::Printf(TEXT("No job at index %d"), JobIndex), Err);
+            return true;
+        }
+
+        TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+        UMoviePipelinePrimaryConfig* Config = Cast<UMoviePipelinePrimaryConfig>(Job->GetConfiguration());
+        if (Config)
+        {
+            UMoviePipelineConsoleVariableSetting* CVars = Config->FindSetting<UMoviePipelineConsoleVariableSetting>();
+            if (CVars)
+            {
+                TSharedPtr<FJsonObject> CVarObj = MakeShared<FJsonObject>();
+                TArray<FMoviePipelineConsoleVariableEntry> CVarEntries = CVars->GetConsoleVariables();
+                for (const FMoviePipelineConsoleVariableEntry& Entry : CVarEntries)
+                {
+                    CVarObj->SetNumberField(Entry.Name, Entry.Value);
+                }
+                Result->SetObjectField(TEXT("consoleVariables"), CVarObj);
+
+                TArray<TSharedPtr<FJsonValue>> StartCmds;
+                for (const FString& Cmd : CVars->StartConsoleCommands)
+                {
+                    StartCmds.Add(MakeShared<FJsonValueString>(Cmd));
+                }
+                Result->SetArrayField(TEXT("startConsoleCommands"), StartCmds);
+
+                TArray<TSharedPtr<FJsonValue>> EndCmds;
+                for (const FString& Cmd : CVars->EndConsoleCommands)
+                {
+                    EndCmds.Add(MakeShared<FJsonValueString>(Cmd));
+                }
+                Result->SetArrayField(TEXT("endConsoleCommands"), EndCmds);
+            }
+            else
+            {
+                Result->SetObjectField(TEXT("consoleVariables"), MakeShared<FJsonObject>());
+                Result->SetStringField(TEXT("note"), TEXT("No CVar setting found on this job config"));
+            }
+        }
+
+        SendAutomationResponse(RequestingSocket, RequestId, true,
+            TEXT("CVar overrides retrieved"), Result);
+        return true;
+    }
+
+    // ─── set_cvars ────────────────────────────────────────────────────────────
+    if (Lower == TEXT("set_cvars"))
+    {
+        int32 JobIndex = 0;
+        if (Payload.IsValid()) Payload->TryGetNumberField(TEXT("jobIndex"), JobIndex);
+
+        UMoviePipelineExecutorJob* Job = GetJobByIndex(Queue, JobIndex);
+        if (!Job)
+        {
+            TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
+            Err->SetStringField(TEXT("error"), TEXT("INVALID_JOB_INDEX"));
+            SendAutomationResponse(RequestingSocket, RequestId, false,
+                FString::Printf(TEXT("No job at index %d"), JobIndex), Err);
+            return true;
+        }
+
+        UMoviePipelinePrimaryConfig* Config = Cast<UMoviePipelinePrimaryConfig>(Job->GetConfiguration());
+        if (!Config)
+        {
+            TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
+            Err->SetStringField(TEXT("error"), TEXT("NO_CONFIG"));
+            SendAutomationResponse(RequestingSocket, RequestId, false,
+                TEXT("Job has no pipeline config"), Err);
+            return true;
+        }
+
+        UMoviePipelineConsoleVariableSetting* CVars = Cast<UMoviePipelineConsoleVariableSetting>(Config->FindOrAddSettingByClass(UMoviePipelineConsoleVariableSetting::StaticClass()));
+
+        // Set CVars from payload
+        const TSharedPtr<FJsonObject>* SetObj = nullptr;
+        if (Payload->TryGetObjectField(TEXT("set"), SetObj) && SetObj && (*SetObj).IsValid())
+        {
+            for (const auto& Pair : (*SetObj)->Values)
+            {
+                double Value = 0.0;
+                if (Pair.Value->TryGetNumber(Value))
+                {
+                    CVars->AddOrUpdateConsoleVariable(Pair.Key, (float)Value);
+                }
+            }
+        }
+
+        // Remove CVars from payload
+        const TArray<TSharedPtr<FJsonValue>>* RemoveArr = nullptr;
+        if (Payload->TryGetArrayField(TEXT("remove"), RemoveArr) && RemoveArr)
+        {
+            for (const auto& Val : *RemoveArr)
+            {
+                FString Key;
+                if (Val->TryGetString(Key))
+                {
+                    CVars->RemoveConsoleVariable(Key);
+                }
+            }
+        }
+
+        // Start console commands
+        const TArray<TSharedPtr<FJsonValue>>* StartArr = nullptr;
+        if (Payload->TryGetArrayField(TEXT("startCommands"), StartArr) && StartArr)
+        {
+            CVars->StartConsoleCommands.Empty();
+            for (const auto& Val : *StartArr)
+            {
+                FString Cmd;
+                if (Val->TryGetString(Cmd))
+                {
+                    CVars->StartConsoleCommands.Add(Cmd);
+                }
+            }
+        }
+
+        // End console commands
+        const TArray<TSharedPtr<FJsonValue>>* EndArr = nullptr;
+        if (Payload->TryGetArrayField(TEXT("endCommands"), EndArr) && EndArr)
+        {
+            CVars->EndConsoleCommands.Empty();
+            for (const auto& Val : *EndArr)
+            {
+                FString Cmd;
+                if (Val->TryGetString(Cmd))
+                {
+                    CVars->EndConsoleCommands.Add(Cmd);
+                }
+            }
+        }
+
+        TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+        Result->SetNumberField(TEXT("totalCVars"), CVars->GetConsoleVariables().Num());
+        SendAutomationResponse(RequestingSocket, RequestId, true,
+            TEXT("CVar overrides updated"), Result);
+        return true;
+    }
+
+    // ─── get_output_settings ──────────────────────────────────────────────────
+    if (Lower == TEXT("get_output_settings"))
+    {
+        int32 JobIndex = 0;
+        if (Payload.IsValid()) Payload->TryGetNumberField(TEXT("jobIndex"), JobIndex);
+
+        UMoviePipelineExecutorJob* Job = GetJobByIndex(Queue, JobIndex);
+        if (!Job)
+        {
+            TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
+            Err->SetStringField(TEXT("error"), TEXT("INVALID_JOB_INDEX"));
+            SendAutomationResponse(RequestingSocket, RequestId, false,
+                FString::Printf(TEXT("No job at index %d"), JobIndex), Err);
+            return true;
+        }
+
+        TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+        UMoviePipelinePrimaryConfig* Config = Cast<UMoviePipelinePrimaryConfig>(Job->GetConfiguration());
+        if (Config)
+        {
+            UMoviePipelineOutputSetting* Output = Config->FindSetting<UMoviePipelineOutputSetting>();
+            if (Output)
+            {
+                Result->SetStringField(TEXT("outputDirectory"), Output->OutputDirectory.Path);
+                Result->SetNumberField(TEXT("resolutionX"), Output->OutputResolution.X);
+                Result->SetNumberField(TEXT("resolutionY"), Output->OutputResolution.Y);
+                Result->SetStringField(TEXT("fileNameFormat"), Output->FileNameFormat);
+                Result->SetBoolField(TEXT("overrideExisting"), Output->bOverrideExistingOutput);
+                Result->SetNumberField(TEXT("zeroPadFrameNumbers"), Output->ZeroPadFrameNumbers);
+                Result->SetNumberField(TEXT("frameNumberOffset"), Output->FrameNumberOffset);
+                Result->SetNumberField(TEXT("handleFrameCount"), Output->HandleFrameCount);
+                Result->SetBoolField(TEXT("useCustomFrameRate"), Output->bUseCustomFrameRate);
+                Result->SetBoolField(TEXT("useCustomPlaybackRange"), Output->bUseCustomPlaybackRange);
+                Result->SetNumberField(TEXT("customStartFrame"), Output->CustomStartFrame);
+                Result->SetNumberField(TEXT("customEndFrame"), Output->CustomEndFrame);
+            }
+            else
+            {
+                Result->SetStringField(TEXT("note"), TEXT("No output setting found on this job config"));
+            }
+        }
+
+        SendAutomationResponse(RequestingSocket, RequestId, true,
+            TEXT("Output settings retrieved"), Result);
+        return true;
+    }
+
+    // ─── set_output_settings ──────────────────────────────────────────────────
+    if (Lower == TEXT("set_output_settings"))
+    {
+        int32 JobIndex = 0;
+        if (Payload.IsValid()) Payload->TryGetNumberField(TEXT("jobIndex"), JobIndex);
+
+        UMoviePipelineExecutorJob* Job = GetJobByIndex(Queue, JobIndex);
+        if (!Job)
+        {
+            TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
+            Err->SetStringField(TEXT("error"), TEXT("INVALID_JOB_INDEX"));
+            SendAutomationResponse(RequestingSocket, RequestId, false,
+                FString::Printf(TEXT("No job at index %d"), JobIndex), Err);
+            return true;
+        }
+
+        UMoviePipelinePrimaryConfig* Config = Cast<UMoviePipelinePrimaryConfig>(Job->GetConfiguration());
+        if (!Config)
+        {
+            TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
+            Err->SetStringField(TEXT("error"), TEXT("NO_CONFIG"));
+            SendAutomationResponse(RequestingSocket, RequestId, false,
+                TEXT("Job has no pipeline config"), Err);
+            return true;
+        }
+
+        UMoviePipelineOutputSetting* Output = Cast<UMoviePipelineOutputSetting>(Config->FindOrAddSettingByClass(UMoviePipelineOutputSetting::StaticClass()));
+
+        FString StrVal;
+        double NumVal;
+        bool BoolVal;
+
+        if (Payload->TryGetStringField(TEXT("outputDirectory"), StrVal))
+            Output->OutputDirectory.Path = StrVal;
+        if (Payload->TryGetNumberField(TEXT("resolutionX"), NumVal))
+            Output->OutputResolution.X = (int32)NumVal;
+        if (Payload->TryGetNumberField(TEXT("resolutionY"), NumVal))
+            Output->OutputResolution.Y = (int32)NumVal;
+        if (Payload->TryGetStringField(TEXT("fileNameFormat"), StrVal))
+            Output->FileNameFormat = StrVal;
+        if (Payload->TryGetBoolField(TEXT("overrideExisting"), BoolVal))
+            Output->bOverrideExistingOutput = BoolVal;
+        if (Payload->TryGetNumberField(TEXT("zeroPadFrameNumbers"), NumVal))
+            Output->ZeroPadFrameNumbers = (int32)NumVal;
+        if (Payload->TryGetNumberField(TEXT("frameNumberOffset"), NumVal))
+            Output->FrameNumberOffset = (int32)NumVal;
+        if (Payload->TryGetNumberField(TEXT("handleFrameCount"), NumVal))
+            Output->HandleFrameCount = (int32)NumVal;
+        if (Payload->TryGetBoolField(TEXT("useCustomFrameRate"), BoolVal))
+            Output->bUseCustomFrameRate = BoolVal;
+        if (Payload->TryGetBoolField(TEXT("useCustomPlaybackRange"), BoolVal))
+            Output->bUseCustomPlaybackRange = BoolVal;
+        if (Payload->TryGetNumberField(TEXT("customStartFrame"), NumVal))
+            Output->CustomStartFrame = (int32)NumVal;
+        if (Payload->TryGetNumberField(TEXT("customEndFrame"), NumVal))
+            Output->CustomEndFrame = (int32)NumVal;
+
+        TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+        Result->SetStringField(TEXT("outputDirectory"), Output->OutputDirectory.Path);
+        Result->SetNumberField(TEXT("resolutionX"), Output->OutputResolution.X);
+        Result->SetNumberField(TEXT("resolutionY"), Output->OutputResolution.Y);
+        SendAutomationResponse(RequestingSocket, RequestId, true,
+            TEXT("Output settings updated"), Result);
+        return true;
+    }
+
+    // ─── create_job ───────────────────────────────────────────────────────────
+    if (Lower == TEXT("create_job"))
+    {
+        if (!Queue)
+        {
+            TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
+            Err->SetStringField(TEXT("error"), TEXT("NO_QUEUE"));
+            SendAutomationResponse(RequestingSocket, RequestId, false,
+                TEXT("No MRQ queue available"), Err);
+            return true;
+        }
+
+        UMoviePipelineExecutorJob* NewJob = Queue->AllocateNewJob(UMoviePipelineExecutorJob::StaticClass());
+
+        FString MapPath, SequencePath, JobName;
+        if (Payload.IsValid())
+        {
+            Payload->TryGetStringField(TEXT("map"), MapPath);
+            Payload->TryGetStringField(TEXT("sequence"), SequencePath);
+            Payload->TryGetStringField(TEXT("jobName"), JobName);
+        }
+
+        if (!MapPath.IsEmpty())
+            NewJob->Map = FSoftObjectPath(MapPath);
+        if (!SequencePath.IsEmpty())
+            NewJob->Sequence = FSoftObjectPath(SequencePath);
+        if (!JobName.IsEmpty())
+            NewJob->JobName = JobName;
+        else
+            NewJob->JobName = FString::Printf(TEXT("Job_%d"), Queue->GetJobs().Num() - 1);
+
+        TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+        Result->SetNumberField(TEXT("jobIndex"), Queue->GetJobs().Num() - 1);
+        Result->SetStringField(TEXT("jobName"), NewJob->JobName);
+        SendAutomationResponse(RequestingSocket, RequestId, true,
+            TEXT("Job created"), Result);
+        return true;
+    }
+
+    // ─── delete_job ───────────────────────────────────────────────────────────
+    if (Lower == TEXT("delete_job"))
+    {
+        int32 JobIndex = 0;
+        if (Payload.IsValid()) Payload->TryGetNumberField(TEXT("jobIndex"), JobIndex);
+
+        UMoviePipelineExecutorJob* Job = GetJobByIndex(Queue, JobIndex);
+        if (!Job)
+        {
+            TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
+            Err->SetStringField(TEXT("error"), TEXT("INVALID_JOB_INDEX"));
+            SendAutomationResponse(RequestingSocket, RequestId, false,
+                FString::Printf(TEXT("No job at index %d"), JobIndex), Err);
+            return true;
+        }
+
+        Queue->DeleteJob(Job);
+
+        TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+        Result->SetNumberField(TEXT("remainingJobs"), Queue->GetJobs().Num());
+        SendAutomationResponse(RequestingSocket, RequestId, true,
+            TEXT("Job deleted"), Result);
+        return true;
+    }
+
+    // ─── render ───────────────────────────────────────────────────────────────
+    if (Lower == TEXT("render"))
+    {
+        if (Subsystem->IsRendering())
+        {
+            TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
+            Err->SetStringField(TEXT("error"), TEXT("ALREADY_RENDERING"));
+            SendAutomationResponse(RequestingSocket, RequestId, false,
+                TEXT("A render is already in progress"), Err);
+            return true;
+        }
+
+        if (!Queue || Queue->GetJobs().Num() == 0)
+        {
+            TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
+            Err->SetStringField(TEXT("error"), TEXT("EMPTY_QUEUE"));
+            SendAutomationResponse(RequestingSocket, RequestId, false,
+                TEXT("Queue is empty — add jobs before rendering"), Err);
+            return true;
+        }
+
+        Subsystem->RenderQueueWithExecutor(UMoviePipelinePIEExecutor::StaticClass());
+
+        TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+        Result->SetNumberField(TEXT("jobCount"), Queue->GetJobs().Num());
+        Result->SetBoolField(TEXT("renderStarted"), true);
+        SendAutomationResponse(RequestingSocket, RequestId, true,
+            TEXT("Render queue started"), Result);
+        return true;
+    }
+
+    // ─── get_render_status ────────────────────────────────────────────────────
+    if (Lower == TEXT("get_render_status"))
+    {
+        TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+        Result->SetBoolField(TEXT("isRendering"), Subsystem->IsRendering());
+
+        UMoviePipelineExecutorBase* Executor = Subsystem->GetActiveExecutor();
+        if (Executor)
+        {
+            Result->SetStringField(TEXT("executorClass"), Executor->GetClass()->GetName());
+            Result->SetStringField(TEXT("statusMessage"), Executor->GetStatusMessage());
+        }
+
+        SendAutomationResponse(RequestingSocket, RequestId, true,
+            TEXT("Render status retrieved"), Result);
+        return true;
+    }
+
+    // ─── load_preset ──────────────────────────────────────────────────────────
+    if (Lower == TEXT("load_preset"))
+    {
+        int32 JobIndex = 0;
+        FString PresetPath;
+        if (Payload.IsValid())
+        {
+            Payload->TryGetNumberField(TEXT("jobIndex"), JobIndex);
+            Payload->TryGetStringField(TEXT("presetPath"), PresetPath);
+        }
+
+        if (PresetPath.IsEmpty())
+        {
+            TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
+            Err->SetStringField(TEXT("error"), TEXT("MISSING_PRESET_PATH"));
+            SendAutomationResponse(RequestingSocket, RequestId, false,
+                TEXT("presetPath is required"), Err);
+            return true;
+        }
+
+        UMoviePipelineExecutorJob* Job = GetJobByIndex(Queue, JobIndex);
+        if (!Job)
+        {
+            TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
+            Err->SetStringField(TEXT("error"), TEXT("INVALID_JOB_INDEX"));
+            SendAutomationResponse(RequestingSocket, RequestId, false,
+                FString::Printf(TEXT("No job at index %d"), JobIndex), Err);
+            return true;
+        }
+
+        UMoviePipelinePrimaryConfig* Preset = LoadObject<UMoviePipelinePrimaryConfig>(
+            nullptr, *PresetPath);
+        if (!Preset)
+        {
+            TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
+            Err->SetStringField(TEXT("error"), TEXT("PRESET_NOT_FOUND"));
+            SendAutomationResponse(RequestingSocket, RequestId, false,
+                FString::Printf(TEXT("Preset not found: %s"), *PresetPath), Err);
+            return true;
+        }
+
+        Job->SetConfiguration(Preset);
+
+        TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
+        Result->SetStringField(TEXT("presetPath"), PresetPath);
+        Result->SetNumberField(TEXT("settingCount"), Preset->GetUserSettings().Num());
+        SendAutomationResponse(RequestingSocket, RequestId, true,
+            TEXT("Preset loaded"), Result);
+        return true;
+    }
+
+    // ─── Unknown action fallback ──────────────────────────────────────────────
+    TSharedPtr<FJsonObject> Err = MakeShared<FJsonObject>();
+    Err->SetStringField(TEXT("error"), TEXT("UNKNOWN_ACTION"));
+    Err->SetStringField(TEXT("action"), SubAction);
+    SendAutomationResponse(RequestingSocket, RequestId, false,
+        FString::Printf(TEXT("Unknown MRQ action: %s"), *SubAction), Err);
+    return true;
+#endif // MCP_HAS_MRQ
+}

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_MrqHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_MrqHandlers.cpp
@@ -46,12 +46,18 @@
 #endif
 
 // MRQ headers - guarded for optional availability
+// UE 5.2+ renamed MasterConfig → PrimaryConfig; handle both.
 #if __has_include("MoviePipelineQueueSubsystem.h")
 #define MCP_HAS_MRQ 1
 #include "MoviePipelineQueue.h"
 #include "MoviePipelineQueueSubsystem.h"
 #include "MoviePipelineExecutor.h"
+#if __has_include("MoviePipelinePrimaryConfig.h")
 #include "MoviePipelinePrimaryConfig.h"
+#elif __has_include("MoviePipelineMasterConfig.h")
+#include "MoviePipelineMasterConfig.h"
+using UMoviePipelinePrimaryConfig = UMoviePipelineMasterConfig;
+#endif
 #include "MoviePipelineSetting.h"
 #include "MoviePipelineOutputSetting.h"
 #include "MoviePipelineConsoleVariableSetting.h"

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Public/McpAutomationBridgeSubsystem.h
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Public/McpAutomationBridgeSubsystem.h
@@ -917,6 +917,11 @@ private:
                            const TSharedPtr<FJsonObject> &Payload,
                            TSharedPtr<FMcpBridgeWebSocket> RequestingSocket);
 
+  // Movie Render Queue (MRQ)
+  bool HandleMrqAction(const FString &RequestId, const FString &Action,
+                       const TSharedPtr<FJsonObject> &Payload,
+                       TSharedPtr<FMcpBridgeWebSocket> RequestingSocket);
+
 private:
   // Ticker handle for managing the subsystems tick function
   FTSTicker::FDelegateHandle TickHandle;

--- a/src/tools/consolidated-tool-definitions.ts
+++ b/src/tools/consolidated-tool-definitions.ts
@@ -4717,5 +4717,41 @@ export const consolidatedToolDefinitions: ToolDefinition[] = [
         error: commonSchemas.stringProp
       }
     }
+  },
+  {
+    name: 'manage_mrq',
+    category: 'authoring',
+    description: 'Movie Render Queue (MRQ) management. Read/write render queue jobs, CVar overrides, output settings, presets, and trigger renders. Actions: get_queue, get_job_config, get_cvars, set_cvars, get_output_settings, set_output_settings, create_job, delete_job, render, get_render_status, load_preset.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        action: {
+          type: 'string',
+          enum: [
+            'get_queue', 'get_job_config', 'get_cvars', 'set_cvars',
+            'get_output_settings', 'set_output_settings',
+            'create_job', 'delete_job', 'render', 'get_render_status',
+            'load_preset'
+          ],
+          description: 'MRQ action to perform'
+        },
+        jobIndex: { type: 'number', description: 'Job index in the queue (default 0)' },
+        map: { type: 'string', description: 'Map path for create_job (e.g., /Game/Maps/MyLevel.MyLevel)' },
+        sequence: { type: 'string', description: 'Level sequence path for create_job' },
+        jobName: { type: 'string', description: 'Job name for create_job' },
+        set: { type: 'object', description: 'CVar overrides to set (key: cvar name, value: float). Used with set_cvars.' },
+        cvars: { type: 'object', description: 'Alias for set — CVar overrides as { name: value } pairs' },
+        remove: { type: 'array', items: { type: 'string' }, description: 'CVar names to remove. Used with set_cvars.' },
+        startCommands: { type: 'array', items: { type: 'string' }, description: 'Console commands to run before render' },
+        endCommands: { type: 'array', items: { type: 'string' }, description: 'Console commands to run after render' },
+        outputDirectory: { type: 'string', description: 'Output directory path for set_output_settings' },
+        resolutionX: { type: 'number', description: 'Output width for set_output_settings' },
+        resolutionY: { type: 'number', description: 'Output height for set_output_settings' },
+        fileNameFormat: { type: 'string', description: 'Filename format with tokens like {sequence_name}, {frame_number}' },
+        overrideExisting: { type: 'boolean', description: 'Overwrite existing output files' },
+        presetPath: { type: 'string', description: 'Asset path to MRQ preset config for load_preset' }
+      },
+      required: ['action']
+    }
   }
 ];

--- a/src/tools/consolidated-tool-definitions.ts
+++ b/src/tools/consolidated-tool-definitions.ts
@@ -4749,9 +4749,55 @@ export const consolidatedToolDefinitions: ToolDefinition[] = [
         resolutionY: { type: 'number', description: 'Output height for set_output_settings' },
         fileNameFormat: { type: 'string', description: 'Filename format with tokens like {sequence_name}, {frame_number}' },
         overrideExisting: { type: 'boolean', description: 'Overwrite existing output files' },
+        zeroPadFrameNumbers: { type: 'number', description: 'Number of digits for zero-padded frame numbers (default 4)' },
+        frameNumberOffset: { type: 'number', description: 'Offset added to frame numbers in output filenames' },
+        handleFrameCount: { type: 'number', description: 'Number of extra frames to render before/after sequence range' },
+        useCustomFrameRate: { type: 'boolean', description: 'Use a custom frame rate for output' },
+        useCustomPlaybackRange: { type: 'boolean', description: 'Use custom start/end frames instead of sequence range' },
+        customStartFrame: { type: 'number', description: 'Custom start frame (requires useCustomPlaybackRange)' },
+        customEndFrame: { type: 'number', description: 'Custom end frame (requires useCustomPlaybackRange)' },
         presetPath: { type: 'string', description: 'Asset path to MRQ preset config for load_preset' }
       },
       required: ['action']
+    },
+    outputSchema: {
+      type: 'object',
+      properties: {
+        success: { type: 'boolean' },
+        message: commonSchemas.stringProp,
+        error: commonSchemas.stringProp,
+        result: {
+          type: 'object',
+          description: 'Action-specific result object',
+          properties: {
+            jobs: { type: 'array', description: 'Array of job objects (get_queue)' },
+            jobCount: { type: 'number' },
+            isRendering: { type: 'boolean' },
+            jobIndex: { type: 'number' },
+            jobName: commonSchemas.stringProp,
+            consoleVariables: { type: 'object', description: 'CVar name→value pairs' },
+            startConsoleCommands: { type: 'array', items: { type: 'string' } },
+            endConsoleCommands: { type: 'array', items: { type: 'string' } },
+            totalCVars: { type: 'number' },
+            outputDirectory: commonSchemas.stringProp,
+            resolutionX: { type: 'number' },
+            resolutionY: { type: 'number' },
+            fileNameFormat: commonSchemas.stringProp,
+            overrideExisting: { type: 'boolean' },
+            zeroPadFrameNumbers: { type: 'number' },
+            frameNumberOffset: { type: 'number' },
+            handleFrameCount: { type: 'number' },
+            useCustomFrameRate: { type: 'boolean' },
+            useCustomPlaybackRange: { type: 'boolean' },
+            customStartFrame: { type: 'number' },
+            customEndFrame: { type: 'number' },
+            remainingJobs: { type: 'number' },
+            renderStarted: { type: 'boolean' },
+            presetPath: commonSchemas.stringProp,
+            settingCount: { type: 'number' }
+          }
+        }
+      }
     }
   }
 ];

--- a/src/tools/consolidated-tool-handlers.ts
+++ b/src/tools/consolidated-tool-handlers.ts
@@ -43,6 +43,7 @@ import { handleVolumeTools } from './handlers/volume-handlers.js';
 import { handleNavigationTools } from './handlers/navigation-handlers.js';
 import { handleSplineTools } from './handlers/spline-handlers.js';
 import { handleManageToolsTools } from './handlers/manage-tools-handlers.js';
+import { handleMrqTools } from './handlers/mrq-handlers.js';
 // import { getDynamicHandlerForTool } from './dynamic-handler-registry.js';
 // import { consolidatedToolDefinitions } from './consolidated-tool-definitions.js';
 
@@ -463,6 +464,11 @@ function registerDefaultHandlers() {
 
   // 40. SPLINE SYSTEM (Phase 26)
   toolRegistry.register('manage_splines', async (args, tools) => await handleSplineTools(getAction(args), args, tools));
+
+  // MRQ - Movie Render Queue
+  toolRegistry.register('manage_mrq', async (args, tools) => {
+    return await handleMrqTools(getAction(args), args, tools);
+  });
 }
 
 // Initialize default handlers immediately

--- a/src/tools/handlers/mrq-handlers.ts
+++ b/src/tools/handlers/mrq-handlers.ts
@@ -1,13 +1,50 @@
 import { cleanObject } from '../../utils/safe-json.js';
 import { ITools } from '../../types/tool-interfaces.js';
-import { executeAutomationRequest } from './common-handlers.js';
+import { executeAutomationRequest, requireAction } from './common-handlers.js';
+import { CommandValidator } from '../../utils/command-validator.js';
+
+/**
+ * Normalize asset path fields to canonical /Game/... form.
+ */
+function normalizePathFields(args: Record<string, unknown>, fields: string[]): Record<string, unknown> {
+  const result = { ...args };
+  for (const field of fields) {
+    const value = result[field];
+    if (typeof value === 'string' && value.length > 0) {
+      let normalized = value.replace(/\\/g, '/');
+      if (normalized.startsWith('/Content/')) {
+        normalized = '/Game/' + normalized.slice('/Content/'.length);
+      }
+      if (!normalized.startsWith('/')) {
+        normalized = '/Game/' + normalized;
+      }
+      result[field] = normalized;
+    }
+  }
+  return result;
+}
+
+/**
+ * Validate an array of console commands using the existing safety filter.
+ */
+function validateCommands(commands: unknown): string[] | undefined {
+  if (!Array.isArray(commands)) return undefined;
+  const validated: string[] = [];
+  for (const cmd of commands) {
+    if (typeof cmd === 'string') {
+      CommandValidator.validate(cmd); // throws on dangerous commands
+      validated.push(cmd);
+    }
+  }
+  return validated;
+}
 
 export async function handleMrqTools(
-  action: string,
+  _action: string,
   args: Record<string, unknown>,
   tools: ITools
 ): Promise<Record<string, unknown>> {
-  const mrqAction = String(action || '').trim().toLowerCase();
+  const mrqAction = requireAction(args);
 
   switch (mrqAction) {
     case 'get_queue':
@@ -15,10 +52,8 @@ export async function handleMrqTools(
     case 'get_cvars':
     case 'get_output_settings':
     case 'get_render_status':
-    case 'create_job':
     case 'delete_job':
-    case 'render':
-    case 'load_preset': {
+    case 'render': {
       const res = await executeAutomationRequest(
         tools,
         'manage_mrq',
@@ -28,10 +63,30 @@ export async function handleMrqTools(
       return cleanObject(res) as Record<string, unknown>;
     }
 
+    case 'create_job':
+    case 'load_preset': {
+      // Normalize asset paths to canonical /Game/... form
+      const normalized = normalizePathFields(args, ['map', 'sequence', 'presetPath']);
+      const res = await executeAutomationRequest(
+        tools,
+        'manage_mrq',
+        { ...normalized, action: mrqAction },
+        'MRQ automation bridge not available — ensure Movie Render Queue plugin is enabled'
+      );
+      return cleanObject(res) as Record<string, unknown>;
+    }
+
     case 'set_cvars': {
       const payload: Record<string, unknown> = { ...args, action: mrqAction };
       if (args.cvars && typeof args.cvars === 'object' && !payload.set) {
         payload.set = args.cvars;
+      }
+      // Validate start/end console commands through safety filter
+      if (payload.startCommands) {
+        payload.startCommands = validateCommands(payload.startCommands);
+      }
+      if (payload.endCommands) {
+        payload.endCommands = validateCommands(payload.endCommands);
       }
       const res = await executeAutomationRequest(
         tools,

--- a/src/tools/handlers/mrq-handlers.ts
+++ b/src/tools/handlers/mrq-handlers.ts
@@ -1,0 +1,62 @@
+import { cleanObject } from '../../utils/safe-json.js';
+import { ITools } from '../../types/tool-interfaces.js';
+import { executeAutomationRequest } from './common-handlers.js';
+
+export async function handleMrqTools(
+  action: string,
+  args: Record<string, unknown>,
+  tools: ITools
+): Promise<Record<string, unknown>> {
+  const mrqAction = String(action || '').trim().toLowerCase();
+
+  switch (mrqAction) {
+    case 'get_queue':
+    case 'get_job_config':
+    case 'get_cvars':
+    case 'get_output_settings':
+    case 'get_render_status':
+    case 'create_job':
+    case 'delete_job':
+    case 'render':
+    case 'load_preset': {
+      const res = await executeAutomationRequest(
+        tools,
+        'manage_mrq',
+        { ...args, action: mrqAction },
+        'MRQ automation bridge not available — ensure Movie Render Queue plugin is enabled'
+      );
+      return cleanObject(res) as Record<string, unknown>;
+    }
+
+    case 'set_cvars': {
+      const payload: Record<string, unknown> = { ...args, action: mrqAction };
+      if (args.cvars && typeof args.cvars === 'object' && !payload.set) {
+        payload.set = args.cvars;
+      }
+      const res = await executeAutomationRequest(
+        tools,
+        'manage_mrq',
+        payload,
+        'MRQ automation bridge not available'
+      );
+      return cleanObject(res) as Record<string, unknown>;
+    }
+
+    case 'set_output_settings': {
+      const res = await executeAutomationRequest(
+        tools,
+        'manage_mrq',
+        { ...args, action: mrqAction },
+        'MRQ automation bridge not available'
+      );
+      return cleanObject(res) as Record<string, unknown>;
+    }
+
+    default:
+      return {
+        success: false,
+        error: 'UNKNOWN_ACTION',
+        message: `Unknown MRQ action: ${mrqAction}. Available: get_queue, get_job_config, get_cvars, set_cvars, get_output_settings, set_output_settings, create_job, delete_job, render, get_render_status, load_preset`
+      };
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new `manage_mrq` tool for full Movie Render Queue automation:

- **11 actions**: `get_queue`, `get_job_config`, `get_cvars`, `set_cvars`, `get_output_settings`, `set_output_settings`, `create_job`, `delete_job`, `render`, `get_render_status`, `load_preset`
- **CVar overrides**: read, add/update, and remove console variable overrides per job
- **Output settings**: read and modify resolution, output directory, filename format, frame overrides
- **Render control**: create/delete jobs, trigger renders, check render status
- **Preset loading**: load saved MRQ preset configs by asset path
- **Start/End console commands**: set console commands to run before/after render

### Design decisions

- Uses **legacy MovieRenderPipeline API** (`UMoviePipelinePrimaryConfig`) for compatibility across UE 5.0–5.7. Movie Render Graph (`UMovieGraphConfig`) is newer but many node subclasses lack API export macros for external modules.
- MRQ modules are **optional dynamic dependencies** via `AddOptionalDynamicModule()` with delay-load DLLs — plugin compiles and loads even if the MRQ plugin is disabled. C++ handler returns a clean error if MRQ classes aren't available.
- Follows existing handler pattern: C++ handler in `_MrqHandlers.cpp`, TypeScript handler in `handlers/mrq-handlers.ts`, registration in consolidated files.

### Files changed

| File | Change |
|---|---|
| `McpAutomationBridge.Build.cs` | Added 4 optional MRQ module dependencies |
| `McpAutomationBridgeSubsystem.h` | Added `HandleMrqAction` declaration |
| `McpAutomationBridgeSubsystem.cpp` | Registered `manage_mrq` handler |
| `McpAutomationBridge_MrqHandlers.cpp` | **New** — 706 lines, 11 action handlers |
| `consolidated-tool-definitions.ts` | Added `manage_mrq` tool definition |
| `consolidated-tool-handlers.ts` | Added import + registration |
| `handlers/mrq-handlers.ts` | **New** — TypeScript MRQ handler |

## Test plan

Tested end-to-end on **UE 5.7** (compiled clean on both 5.6 and 5.7):

- [x] `get_queue` — returns empty queue, correct job count
- [x] `create_job` — creates named job at correct index
- [x] `get_job_config` — full config dump with output settings and settings list
- [x] `get_cvars` — reads empty CVars, then confirms set CVars
- [x] `set_cvars` (set) — added `r.ScreenPercentage=200`, `r.Shadow.MaxResolution=4096`
- [x] `set_cvars` (remove) — removed single CVar, confirmed count decreased
- [x] `get_output_settings` — returns default 1920x1080
- [x] `set_output_settings` — changed to 3840x2160, custom output directory
- [x] `load_preset` — correct `PRESET_NOT_FOUND` error on missing asset
- [x] `delete_job` — removed job, confirmed 0 remaining
- [x] `get_render_status` — returns `isRendering: false` when idle

Plugin loads cleanly with MRQ plugin both enabled and disabled (optional dependency).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chir24/unreal_mcp/pull/324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
