### PR TITLE
fix: route add_widget_child to system_control instead of manage_widget_authoring

### DIFF
--- a/src/tools/handlers/system-handlers.ts
+++ b/src/tools/handlers/system-handlers.ts
@@ -253,7 +253,7 @@ export async function handleSystemTools(action: string, args: HandlerArgs, tools
       }
 
       try {
-        const res = await executeAutomationRequest(tools, 'manage_widget_authoring', {
+        const res = await executeAutomationRequest(tools, 'system_control', {
           action: 'add_widget_child',
           widgetPath,
           childClass: childClass,


### PR DESCRIPTION
## Summary
- Route `add_widget_child` through `system_control` instead of `manage_widget_authoring` on the C++ bridge, fixing a silent timeout when calling this action

## Problem
`add_widget_child` in `system-handlers.ts` was routed to `manage_widget_authoring` via `executeAutomationRequest`, but the C++ `HandleManageWidgetAuthoringAction` (WidgetAuthoringHandlers.cpp) has **no handler** for this subAction — causing the request to silently hang with no response.

The actual C++ implementation lives in `HandleUiAction` (UiHandlers.cpp:228), which handles `system_control` and `manage_ui` action types only.

## Fix
One-line change in `src/tools/handlers/system-handlers.ts` line 256:
```
- executeAutomationRequest(tools, 'manage_widget_authoring', { action: 'add_widget_child', ... })
+ executeAutomationRequest(tools, 'system_control', { action: 'add_widget_child', ... })
```

## Verification
Tested against live UE 5.7 Editor with MCPtest project:

| Action Type | `add_widget_child` Result |
|---|---|
| `system_control` (fixed) | ✅ Response received — handler reached correctly |
| `manage_ui` | ✅ Response received — same C++ handler |
| `manage_widget_authoring` (old/broken) | ❌ Timeout — subAction unhandled |

Fixes #351
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chir24/unreal_mcp/pull/364" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
