### PR TITLE
fix(inspect): add PIE runtime report

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Tools/McpTool_Inspect.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Tools/McpTool_Inspect.cpp
@@ -16,7 +16,7 @@ public:
 			"and query class info. Actions: inspect_cdo (Blueprint CDO properties + all components "
 			"without spawning an actor; use blueprintPath, optional detailed/componentName/propertyNames), "
 			"inspect_class (class metadata), inspect_object (world actor), get_property/set_property, "
-			"get_components, list_objects, find_by_class, find_by_tag.");
+			"get_components, list_objects, find_by_class, find_by_tag, runtime_report.");
 	}
 
 	FString GetCategory() const override { return TEXT("core"); }
@@ -43,6 +43,8 @@ public:
 				TEXT("set_component_property"),
 				TEXT("inspect_class"),
 				TEXT("inspect_cdo"),
+				TEXT("runtime_report"),
+				TEXT("pie_report"),
 				TEXT("list_objects"),
 				TEXT("get_metadata"),
 				TEXT("add_tag"),
@@ -80,6 +82,7 @@ public:
 			.String(TEXT("blueprintPath"), TEXT("Blueprint asset path."))
 			.Bool(TEXT("detailed"), TEXT(""))
 			.Array(TEXT("propertyNames"), TEXT(""))
+			.Array(TEXT("componentNames"), TEXT("Component names to include detailed property readback for."))
 			.Required({TEXT("action")})
 			.Build();
 	}

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_EnvironmentHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_EnvironmentHandlers.cpp
@@ -98,8 +98,13 @@
 // =============================================================================
 // Engine Component Includes
 // =============================================================================
+#include "Camera/CameraComponent.h"
 #include "Components/DirectionalLightComponent.h"
 #include "Components/SkyLightComponent.h"
+#include "GameFramework/Pawn.h"
+#include "GameFramework/PlayerController.h"
+#include "Camera/PlayerCameraManager.h"
+#include "GameFramework/SpringArmComponent.h"
 
 // =============================================================================
 // Editor & Asset Includes
@@ -137,6 +142,205 @@
 // Logging Category
 // =============================================================================
 DEFINE_LOG_CATEGORY_STATIC(LogMcpEnvironmentHandlers, Log, All);
+
+#if WITH_EDITOR
+static TSharedPtr<FJsonObject> McpMakeVectorObject(const FVector &Vector)
+{
+    TSharedPtr<FJsonObject> Obj = McpHandlerUtils::CreateResultObject();
+    Obj->SetNumberField(TEXT("x"), Vector.X);
+    Obj->SetNumberField(TEXT("y"), Vector.Y);
+    Obj->SetNumberField(TEXT("z"), Vector.Z);
+    return Obj;
+}
+
+static TSharedPtr<FJsonObject> McpMakeRotatorObject(const FRotator &Rotator)
+{
+    TSharedPtr<FJsonObject> Obj = McpHandlerUtils::CreateResultObject();
+    Obj->SetNumberField(TEXT("pitch"), Rotator.Pitch);
+    Obj->SetNumberField(TEXT("yaw"), Rotator.Yaw);
+    Obj->SetNumberField(TEXT("roll"), Rotator.Roll);
+    return Obj;
+}
+
+static TSharedPtr<FJsonObject> McpMakeTransformObject(const FTransform &Transform)
+{
+    TSharedPtr<FJsonObject> Obj = McpHandlerUtils::CreateResultObject();
+    Obj->SetObjectField(TEXT("location"), McpMakeVectorObject(Transform.GetLocation()));
+    Obj->SetObjectField(TEXT("rotation"), McpMakeRotatorObject(Transform.GetRotation().Rotator()));
+    Obj->SetObjectField(TEXT("scale"), McpMakeVectorObject(Transform.GetScale3D()));
+    return Obj;
+}
+
+static UWorld *McpGetRuntimeInspectionWorld()
+{
+    if (!GEditor)
+    {
+        return nullptr;
+    }
+
+    if (GEditor->PlayWorld)
+    {
+        return GEditor->PlayWorld.Get();
+    }
+
+    if (GEngine)
+    {
+        for (const FWorldContext &Context : GEngine->GetWorldContexts())
+        {
+            if (Context.WorldType == EWorldType::PIE || Context.WorldType == EWorldType::Game)
+            {
+                if (UWorld *World = Context.World())
+                {
+                    return World;
+                }
+            }
+        }
+    }
+
+    return GEditor->GetEditorWorldContext().World();
+}
+
+static FString McpGetWorldTypeName(UWorld *World)
+{
+    if (!World)
+    {
+        return TEXT("None");
+    }
+
+    switch (World->WorldType)
+    {
+    case EWorldType::PIE:
+        return TEXT("PIE");
+    case EWorldType::Game:
+        return TEXT("Game");
+    case EWorldType::Editor:
+        return TEXT("Editor");
+    case EWorldType::EditorPreview:
+        return TEXT("EditorPreview");
+    case EWorldType::GamePreview:
+        return TEXT("GamePreview");
+    case EWorldType::GameRPC:
+        return TEXT("GameRPC");
+    case EWorldType::Inactive:
+        return TEXT("Inactive");
+    default:
+        return TEXT("Unknown");
+    }
+}
+
+static void McpAddActorTags(TSharedPtr<FJsonObject> Obj, const AActor *Actor)
+{
+    TArray<TSharedPtr<FJsonValue>> TagsArray;
+    if (Actor)
+    {
+        for (const FName &Tag : Actor->Tags)
+        {
+            TagsArray.Add(MakeShared<FJsonValueString>(Tag.ToString()));
+        }
+    }
+    Obj->SetArrayField(TEXT("tags"), TagsArray);
+}
+
+static TSharedPtr<FJsonObject> McpDescribeRuntimeComponent(UActorComponent *Component, const TArray<FString> &PropertyNames)
+{
+    TSharedPtr<FJsonObject> Obj = McpHandlerUtils::CreateResultObject();
+    if (!Component)
+    {
+        return Obj;
+    }
+
+    Obj->SetStringField(TEXT("name"), Component->GetName());
+    Obj->SetStringField(TEXT("path"), Component->GetPathName());
+    Obj->SetStringField(TEXT("class"), Component->GetClass() ? Component->GetClass()->GetName() : TEXT(""));
+    Obj->SetStringField(TEXT("classPath"), Component->GetClass() ? Component->GetClass()->GetPathName() : TEXT(""));
+    Obj->SetBoolField(TEXT("isActive"), Component->IsActive());
+
+    if (USceneComponent *SceneComp = Cast<USceneComponent>(Component))
+    {
+        Obj->SetBoolField(TEXT("isSceneComponent"), true);
+        Obj->SetBoolField(TEXT("isVisible"), SceneComp->IsVisible());
+        Obj->SetObjectField(TEXT("transform"), McpMakeTransformObject(SceneComp->GetComponentTransform()));
+        Obj->SetStringField(TEXT("attachParent"), SceneComp->GetAttachParent() ? SceneComp->GetAttachParent()->GetName() : TEXT(""));
+    }
+
+    if (UCameraComponent *CameraComp = Cast<UCameraComponent>(Component))
+    {
+        Obj->SetBoolField(TEXT("isCamera"), true);
+        Obj->SetNumberField(TEXT("fieldOfView"), CameraComp->FieldOfView);
+        Obj->SetBoolField(TEXT("isActive"), CameraComp->IsActive());
+    }
+
+    if (USpringArmComponent *SpringArm = Cast<USpringArmComponent>(Component))
+    {
+        Obj->SetBoolField(TEXT("isSpringArm"), true);
+        Obj->SetNumberField(TEXT("targetArmLength"), SpringArm->TargetArmLength);
+        Obj->SetBoolField(TEXT("usePawnControlRotation"), SpringArm->bUsePawnControlRotation);
+    }
+
+    if (PropertyNames.Num() > 0)
+    {
+        TSharedPtr<FJsonObject> PropertiesObj = McpHandlerUtils::CreateResultObject();
+        for (const FString &PropertyName : PropertyNames)
+        {
+            if (PropertyName.IsEmpty())
+            {
+                continue;
+            }
+            McpHandlerUtils::FPropertyResolveResult PropResult = McpHandlerUtils::ResolveProperty(Component, PropertyName);
+            if (PropResult.IsValid())
+            {
+                if (TSharedPtr<FJsonValue> Value = ExportPropertyToJsonValue(PropResult.Container, PropResult.Property))
+                {
+                    PropertiesObj->SetField(PropertyName, Value);
+                }
+            }
+        }
+        Obj->SetObjectField(TEXT("properties"), PropertiesObj);
+    }
+
+    return Obj;
+}
+
+static TSharedPtr<FJsonObject> McpDescribeRuntimeActor(AActor *Actor, const TArray<FString> &ComponentNames, const TArray<FString> &PropertyNames)
+{
+    TSharedPtr<FJsonObject> Obj = McpHandlerUtils::CreateResultObject();
+    if (!Actor)
+    {
+        return Obj;
+    }
+
+    Obj->SetStringField(TEXT("name"), Actor->GetName());
+    Obj->SetStringField(TEXT("label"), Actor->GetActorLabel());
+    Obj->SetStringField(TEXT("path"), Actor->GetPathName());
+    Obj->SetStringField(TEXT("class"), Actor->GetClass() ? Actor->GetClass()->GetName() : TEXT(""));
+    Obj->SetStringField(TEXT("classPath"), Actor->GetClass() ? Actor->GetClass()->GetPathName() : TEXT(""));
+    Obj->SetObjectField(TEXT("transform"), McpMakeTransformObject(Actor->GetActorTransform()));
+    McpAddActorTags(Obj, Actor);
+
+    TArray<TSharedPtr<FJsonValue>> ComponentsArray;
+    TInlineComponentArray<UActorComponent *> Components;
+    Actor->GetComponents(Components);
+    for (UActorComponent *Component : Components)
+    {
+        if (!Component)
+        {
+            continue;
+        }
+
+        const bool bRequestedByName = ComponentNames.Num() == 0 || ComponentNames.ContainsByPredicate([Component](const FString &RequestedName) {
+            return Component->GetName().Equals(RequestedName, ESearchCase::IgnoreCase);
+        });
+        const bool bAlwaysReportCameraState = Component->IsA<UCameraComponent>() || Component->IsA<USpringArmComponent>();
+        if (bRequestedByName || bAlwaysReportCameraState)
+        {
+            ComponentsArray.Add(MakeShared<FJsonValueObject>(McpDescribeRuntimeComponent(Component, PropertyNames)));
+        }
+    }
+    Obj->SetArrayField(TEXT("components"), ComponentsArray);
+    Obj->SetNumberField(TEXT("componentCount"), ComponentsArray.Num());
+    return Obj;
+}
+#endif
 
 // =============================================================================
 // Section 1: Build Environment Actions
@@ -1437,7 +1641,9 @@ bool UMcpAutomationBridgeSubsystem::HandleInspectAction(
         LowerSubAction.Equals(TEXT("find_by_class")) ||
         LowerSubAction.Equals(TEXT("find_by_tag")) ||
         LowerSubAction.Equals(TEXT("inspect_class")) ||
-        LowerSubAction.Equals(TEXT("inspect_cdo"));
+        LowerSubAction.Equals(TEXT("inspect_cdo")) ||
+        LowerSubAction.Equals(TEXT("runtime_report")) ||
+        LowerSubAction.Equals(TEXT("pie_report"));
 
     // Actor actions (delegated to HandleControlActorAction)
     const bool bIsActorAction =
@@ -1622,6 +1828,132 @@ bool UMcpAutomationBridgeSubsystem::HandleInspectAction(
             Resp->SetStringField(TEXT("message"), TEXT("Memory stats placeholder - implement with actual metrics"));
             SendAutomationResponse(RequestingSocket, RequestId, true,
                                    TEXT("Memory stats retrieved"), Resp, FString());
+            return true;
+        }
+        // ---------------------------------------------------------------------
+        // runtime_report / pie_report
+        // ---------------------------------------------------------------------
+        else if (LowerSubAction.Equals(TEXT("runtime_report")) || LowerSubAction.Equals(TEXT("pie_report")))
+        {
+            UWorld *World = McpGetRuntimeInspectionWorld();
+            if (!World)
+            {
+                SendAutomationError(RequestingSocket, RequestId,
+                                    TEXT("No editor, PIE, or game world available for runtime inspection"),
+                                    TEXT("WORLD_NOT_FOUND"));
+                return true;
+            }
+
+            FString Filter;
+            Payload->TryGetStringField(TEXT("filter"), Filter);
+            FString ActorName;
+            Payload->TryGetStringField(TEXT("actorName"), ActorName);
+            if (ActorName.IsEmpty())
+            {
+                Payload->TryGetStringField(TEXT("name"), ActorName);
+            }
+
+            TArray<FString> ComponentNames;
+            FString ComponentName;
+            if (Payload->TryGetStringField(TEXT("componentName"), ComponentName) && !ComponentName.IsEmpty())
+            {
+                ComponentNames.Add(ComponentName);
+            }
+            const TArray<TSharedPtr<FJsonValue>> *ComponentNamesArray = nullptr;
+            if (Payload->TryGetArrayField(TEXT("componentNames"), ComponentNamesArray) && ComponentNamesArray)
+            {
+                for (const TSharedPtr<FJsonValue> &Value : *ComponentNamesArray)
+                {
+                    if (Value.IsValid() && Value->Type == EJson::String)
+                    {
+                        ComponentNames.Add(Value->AsString());
+                    }
+                }
+            }
+
+            TArray<FString> PropertyNames;
+            FString PropertyName;
+            if (Payload->TryGetStringField(TEXT("propertyName"), PropertyName) && !PropertyName.IsEmpty())
+            {
+                PropertyNames.Add(PropertyName);
+            }
+            const TArray<TSharedPtr<FJsonValue>> *PropertyNamesArray = nullptr;
+            if (Payload->TryGetArrayField(TEXT("propertyNames"), PropertyNamesArray) && PropertyNamesArray)
+            {
+                for (const TSharedPtr<FJsonValue> &Value : *PropertyNamesArray)
+                {
+                    if (Value.IsValid() && Value->Type == EJson::String)
+                    {
+                        PropertyNames.Add(Value->AsString());
+                    }
+                }
+            }
+
+            TSharedPtr<FJsonObject> Report = McpHandlerUtils::CreateResultObject();
+            Report->SetBoolField(TEXT("success"), true);
+            Report->SetStringField(TEXT("worldName"), World->GetName());
+            Report->SetStringField(TEXT("worldType"), McpGetWorldTypeName(World));
+            Report->SetStringField(TEXT("worldPath"), World->GetPathName());
+            Report->SetBoolField(TEXT("isPIE"), World->WorldType == EWorldType::PIE);
+
+            TArray<TSharedPtr<FJsonValue>> ActorsArray;
+            int32 TotalActorCount = 0;
+            for (TActorIterator<AActor> It(World); It; ++It)
+            {
+                AActor *Actor = *It;
+                if (!Actor)
+                {
+                    continue;
+                }
+                ++TotalActorCount;
+
+                const FString Label = Actor->GetActorLabel();
+                const FString Name = Actor->GetName();
+                const bool bMatchesActor = ActorName.IsEmpty() ||
+                    Label.Equals(ActorName, ESearchCase::IgnoreCase) ||
+                    Name.Equals(ActorName, ESearchCase::IgnoreCase) ||
+                    Actor->GetPathName().Equals(ActorName, ESearchCase::IgnoreCase);
+                const bool bMatchesFilter = Filter.IsEmpty() ||
+                    Label.Contains(Filter) ||
+                    Name.Contains(Filter) ||
+                    Actor->GetClass()->GetName().Contains(Filter) ||
+                    Actor->GetPathName().Contains(Filter);
+                if (bMatchesActor && bMatchesFilter)
+                {
+                    ActorsArray.Add(MakeShared<FJsonValueObject>(McpDescribeRuntimeActor(Actor, ComponentNames, PropertyNames)));
+                }
+            }
+            Report->SetArrayField(TEXT("actors"), ActorsArray);
+            Report->SetNumberField(TEXT("count"), ActorsArray.Num());
+            Report->SetNumberField(TEXT("totalActorCount"), TotalActorCount);
+
+            APlayerController *PlayerController = World->GetFirstPlayerController();
+            if (PlayerController)
+            {
+                TSharedPtr<FJsonObject> ControllerObj = McpDescribeRuntimeActor(PlayerController, ComponentNames, PropertyNames);
+                Report->SetObjectField(TEXT("playerController"), ControllerObj);
+
+                if (APawn *Pawn = PlayerController->GetPawn())
+                {
+                    Report->SetObjectField(TEXT("pawn"), McpDescribeRuntimeActor(Pawn, ComponentNames, PropertyNames));
+                }
+
+                if (AActor *ViewTarget = PlayerController->GetViewTarget())
+                {
+                    Report->SetObjectField(TEXT("viewTarget"), McpDescribeRuntimeActor(ViewTarget, ComponentNames, PropertyNames));
+                }
+
+                if (APlayerCameraManager *CameraManager = PlayerController->PlayerCameraManager)
+                {
+                    TSharedPtr<FJsonObject> CameraManagerObj = McpDescribeRuntimeActor(CameraManager, ComponentNames, PropertyNames);
+                    CameraManagerObj->SetObjectField(TEXT("cameraLocation"), McpMakeVectorObject(CameraManager->GetCameraLocation()));
+                    CameraManagerObj->SetObjectField(TEXT("cameraRotation"), McpMakeRotatorObject(CameraManager->GetCameraRotation()));
+                    Report->SetObjectField(TEXT("playerCameraManager"), CameraManagerObj);
+                }
+            }
+
+            SendAutomationResponse(RequestingSocket, RequestId, true,
+                                   TEXT("Runtime inspection report generated"), Report, FString());
             return true;
         }
         // ---------------------------------------------------------------------

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpHandlerUtils.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpHandlerUtils.cpp
@@ -159,7 +159,11 @@ FString ValidateAssetPath(const FString& Path)
 #if WITH_EDITOR
 AActor* FindActorByName(const FString& ActorName, bool bExactMatch)
 {
-    UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+    UWorld* World = nullptr;
+    if (GEditor)
+    {
+        World = GEditor->PlayWorld ? GEditor->PlayWorld.Get() : GEditor->GetEditorWorldContext().World();
+    }
     if (!World)
     {
         return nullptr;
@@ -415,7 +419,7 @@ UObject* ResolveObjectFromPath(const FString& ObjectPath, FString* OutResolvedPa
     // Try to find by actor label (display name) as fallback
     if (GEditor)
     {
-        UWorld* World = GEditor->GetEditorWorldContext().World();
+        UWorld* World = GEditor->PlayWorld ? GEditor->PlayWorld.Get() : GEditor->GetEditorWorldContext().World();
         if (World)
         {
             for (TActorIterator<AActor> It(World); It; ++It)

--- a/src/tools/consolidated-tool-definitions.ts
+++ b/src/tools/consolidated-tool-definitions.ts
@@ -873,7 +873,7 @@ export const consolidatedToolDefinitions: ToolDefinition[] = [
   {
     name: 'inspect',
     category: 'core',
-    description: 'Inspect any UObject: read/write properties, list components, export snapshots, and query class info. Actions: inspect_cdo (Blueprint CDO properties + all components without spawning an actor; use blueprintPath, optional detailed/componentName/propertyNames), inspect_class (class metadata), inspect_object (world actor), get_property/set_property, get_components, list_objects, find_by_class, find_by_tag.',
+    description: 'Inspect any UObject: read/write properties, list components, export snapshots, and query class info. Actions: inspect_cdo (Blueprint CDO properties + all components without spawning an actor; use blueprintPath, optional detailed/componentName/propertyNames), inspect_class (class metadata), inspect_object (world actor), get_property/set_property, get_components, list_objects, find_by_class, find_by_tag, runtime_report.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -884,7 +884,7 @@ export const consolidatedToolDefinitions: ToolDefinition[] = [
             'get_texture_details', 'get_material_details', 'get_level_details', 'get_component_details',
             'set_property', 'get_property',
             'get_components', 'get_component_property', 'set_component_property',
-            'inspect_class', 'inspect_cdo', 'list_objects',
+            'inspect_class', 'inspect_cdo', 'runtime_report', 'pie_report', 'list_objects',
             'get_metadata', 'add_tag', 'find_by_tag',
             'create_snapshot', 'restore_snapshot', 'export', 'delete_object', 'find_by_class', 'get_bounding_box',
             'get_project_settings', 'get_world_settings', 'get_viewport_info', 'get_selected_actors',
@@ -909,7 +909,8 @@ export const consolidatedToolDefinitions: ToolDefinition[] = [
         format: commonSchemas.stringProp,
         blueprintPath: commonSchemas.blueprintPath,
         detailed: commonSchemas.booleanProp,
-        propertyNames: commonSchemas.arrayOfStrings
+        propertyNames: commonSchemas.arrayOfStrings,
+        componentNames: commonSchemas.arrayOfStrings
       },
       required: ['action']
     },
@@ -928,7 +929,13 @@ export const consolidatedToolDefinitions: ToolDefinition[] = [
         componentName: commonSchemas.componentName,
         templateObjectName: commonSchemas.stringProp,
         componentClass: commonSchemas.stringProp,
-        properties: commonSchemas.objectProp
+        properties: commonSchemas.objectProp,
+        actors: commonSchemas.arrayOfObjects,
+        playerController: commonSchemas.objectProp,
+        pawn: commonSchemas.objectProp,
+        viewTarget: commonSchemas.objectProp,
+        playerCameraManager: commonSchemas.objectProp,
+        worldType: commonSchemas.stringProp
       }
     }
   },

--- a/src/tools/handlers/inspect-handlers.ts
+++ b/src/tools/handlers/inspect-handlers.ts
@@ -34,6 +34,7 @@ const INSPECT_ACTION_ALIASES: Record<string, string> = {
   'get_scene_stats': 'get_scene_stats',
   'get_viewport_info': 'get_viewport_info',
   'get_selected_actors': 'get_selected_actors',
+  'pie_report': 'runtime_report',
 };
 
 /**
@@ -588,6 +589,18 @@ export async function handleInspectTools(action: string, args: HandlerArgs, tool
         }
         throw err;
       }
+    }
+    case 'runtime_report': {
+      const inspectArgs = args as InspectArgs;
+      return cleanObject(await executeAutomationRequest(tools, 'inspect', {
+        action: 'runtime_report',
+        filter: inspectArgs.filter,
+        actorName: inspectArgs.actorName || inspectArgs.name,
+        componentName: inspectArgs.componentName,
+        componentNames: inspectArgs.componentNames,
+        propertyName: inspectArgs.propertyName || inspectArgs.propertyPath,
+        propertyNames: inspectArgs.propertyNames
+      }) as Record<string, unknown>);
     }
     case 'list_objects':
       return cleanObject(await executeAutomationRequest(tools, 'control_actor', {

--- a/src/tools/handlers/inspect-handlers.ts
+++ b/src/tools/handlers/inspect-handlers.ts
@@ -158,7 +158,9 @@ export async function handleInspectTools(action: string, args: HandlerArgs, tool
     actorName: args.actor_name ?? args.actorName ?? args.name,
     objectPath: args.object_path ?? args.objectPath ?? args.path,
     componentName: args.component_name ?? args.componentName,
+    componentNames: args.component_names ?? args.componentNames,
     propertyName: args.property_name ?? args.propertyName,
+    propertyNames: args.property_names ?? args.propertyNames,
   };
   
   switch (normalizedAction) {
@@ -591,7 +593,7 @@ export async function handleInspectTools(action: string, args: HandlerArgs, tool
       }
     }
     case 'runtime_report': {
-      const inspectArgs = args as InspectArgs;
+      const inspectArgs = normalizedArgs as InspectArgs;
       return cleanObject(await executeAutomationRequest(tools, 'inspect', {
         action: 'runtime_report',
         filter: inspectArgs.filter,

--- a/src/types/handler-types.ts
+++ b/src/types/handler-types.ts
@@ -558,6 +558,7 @@ export interface InspectArgs extends HandlerArgs {
     blueprintPath?: string;
     detailed?: boolean;
     propertyNames?: string[];
+    componentNames?: string[];
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Adds a first-class runtime inspection report for PIE validation so MCP clients can inspect the active runtime world instead of relying on editor-world actor queries, Unreal Python fallbacks, screenshots, or external report files.

## Changes

- Add `inspect.runtime_report` plus `inspect.pie_report` alias to the TypeScript and native inspect tool schemas.
- Report active runtime world metadata, actors, player controller, pawn, view target, player camera manager, camera/spring-arm components, actor tags, and selected component property readback.
- Prefer the active PIE/game world when resolving actor/object paths during runtime inspection.
- Keep `bug-fix.md` local-only and translate the relevant validation details into this PR instead of including local verification notes in the diff.

## Related Issues

Related to `plugins/McpAutomationBridge/bug-fix-todo.md` item 2: PIE runtime inspection needs a first-class report action.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration/build change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test addition/update

## Testing

Pre-fix confirmation: existing `inspect`, `control_actor.list`, and `find_by_class` paths were editor-world based during PIE, matching the todo evidence that runtime validation needed ad-hoc Python/report fallbacks.

- [x] Tested with Unreal Engine (version: 5.7)
- [x] Tested MCP client integration (client: Native MCP HTTP / `inspect.runtime_report` and `inspect.pie_report`)
- [ ] Added/updated tests

Validation performed:

- `npm run build:core` passed.
- `UnrealBuildTool test_thirdEditor Win64 Development -Project=D:\me\code\ue\test_third\test_third.uproject -WaitMutex -NoHotReloadFromIDE` passed after closing the editor to release `UnrealEditor-McpAutomationBridge.dll`.
- Runtime verification passed through Native MCP HTTP fallback on `http://127.0.0.1:4000/mcp` after editor restart invalidated the in-process MCP session:
  - `tools/list` showed `inspect.runtime_report` and `inspect.pie_report`.
  - `inspect.runtime_report` returned editor-world data outside PIE.
  - `control_editor.play` followed by `inspect.pie_report` returned `worldType=PIE`, `isPIE=true`, 85 actors, `playerController`, `pawn=BP_ThirdPersonCharacter_C_0`, `viewTarget`, and `playerCameraManager`.
  - `control_editor.stop` succeeded.

No automated test was added because this change depends on live PIE runtime state in Unreal Editor; validation was performed through the runtime MCP endpoint.

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Updated relevant documentation (if needed)
- [ ] Added/updated tests (if applicable)
- [ ] CI passes

Notes:

- `plugins/McpAutomationBridge/bug-fix.md` remains local-only and is intentionally excluded from the PR.
- Generated Unreal outputs under `plugins/McpAutomationBridge/Binaries/` and `plugins/McpAutomationBridge/Intermediate/` are intentionally excluded from the PR.