### PR TITLE
fix(manage_input): support per-key mapping edits

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_InputHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_InputHandlers.cpp
@@ -61,6 +61,85 @@
 
 #endif
 
+namespace
+{
+#if WITH_EDITOR
+/** Converts an optional input key name into an FKey for mapping-specific operations. */
+FKey McpInputKeyFromName(const FString& KeyName)
+{
+    return KeyName.IsEmpty() ? FKey() : FKey(FName(*KeyName));
+}
+
+/** Adds verified mapping readback for an action after key-specific edits. */
+void AddInputMappingSummary(
+    TSharedPtr<FJsonObject> Result,
+    UInputMappingContext* Context,
+    const UInputAction* InAction)
+{
+    TArray<TSharedPtr<FJsonValue>> Mappings;
+    for (const FEnhancedActionKeyMapping& Mapping : Context->GetMappings())
+    {
+        if (Mapping.Action != InAction)
+        {
+            continue;
+        }
+
+        TSharedPtr<FJsonObject> MappingObject = MakeShared<FJsonObject>();
+        MappingObject->SetStringField(TEXT("key"), Mapping.Key.ToString());
+        MappingObject->SetNumberField(TEXT("modifierCount"), Mapping.Modifiers.Num());
+        MappingObject->SetNumberField(TEXT("triggerCount"), Mapping.Triggers.Num());
+        Mappings.Add(MakeShared<FJsonValueObject>(MappingObject));
+    }
+
+    Result->SetNumberField(TEXT("remainingMappingCount"), Mappings.Num());
+    Result->SetArrayField(TEXT("mappings"), Mappings);
+}
+
+/** Creates the requested Enhanced Input modifier using compatibility fallbacks across UE 5.x. */
+UInputModifier* CreateInputModifierForType(const FString& ModifierType, UObject* Outer)
+{
+    if (ModifierType == TEXT("DeadZone") || ModifierType == TEXT("InputModifierDeadZone"))
+    {
+        return NewObject<UInputModifierDeadZone>(Outer);
+    }
+    if (ModifierType == TEXT("SmoothDelta") || ModifierType == TEXT("InputModifierSmoothDelta"))
+    {
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 4
+        return NewObject<UInputModifierSmoothDelta>(Outer);
+#else
+        return NewObject<UInputModifierSmooth>(Outer);
+#endif
+    }
+    if (ModifierType == TEXT("SwizzleInputAxis") || ModifierType == TEXT("InputModifierSwizzleAxis"))
+    {
+        return NewObject<UInputModifierSwizzleAxis>(Outer);
+    }
+    if (ModifierType == TEXT("Negate") || ModifierType == TEXT("InputModifierNegate"))
+    {
+        return NewObject<UInputModifierNegate>(Outer);
+    }
+    if (ModifierType == TEXT("Scalar") || ModifierType == TEXT("InputModifierScalar"))
+    {
+        return NewObject<UInputModifierScalar>(Outer);
+    }
+    if (ModifierType == TEXT("ScaleByDeltaTime") || ModifierType == TEXT("InputModifierScaleByDeltaTime"))
+    {
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
+        return NewObject<UInputModifierScaleByDeltaTime>(Outer);
+#else
+        return NewObject<UInputModifierScalar>(Outer);
+#endif
+    }
+    if (ModifierType == TEXT("ToWorldSpace") || ModifierType == TEXT("InputModifierToWorldSpace"))
+    {
+        return NewObject<UInputModifierToWorldSpace>(Outer);
+    }
+
+    return nullptr;
+}
+#endif
+}
+
 // =============================================================================
 // Handler Implementation
 // =============================================================================
@@ -332,6 +411,9 @@ bool UMcpAutomationBridgeSubsystem::HandleInputAction(
         FString ActionPath;
         Payload->TryGetStringField(TEXT("actionPath"), ActionPath);
 
+        FString KeyName;
+        Payload->TryGetStringField(TEXT("key"), KeyName);
+
         // Validate and sanitize paths
         FString SanitizedContextPath = SanitizeProjectRelativePath(ContextPath);
         FString SanitizedActionPath = SanitizeProjectRelativePath(ActionPath);
@@ -358,14 +440,32 @@ bool UMcpAutomationBridgeSubsystem::HandleInputAction(
             return true;
         }
 
-        // Collect keys to remove
+        FKey RequestedKey = McpInputKeyFromName(KeyName);
+        const bool bHasSpecificKey = !KeyName.IsEmpty();
+        if (bHasSpecificKey && !RequestedKey.IsValid())
+        {
+            SendAutomationError(RequestingSocket, RequestId,
+                FString::Printf(TEXT("Invalid key name: %s"), *KeyName), TEXT("INVALID_ARGUMENT"));
+            return true;
+        }
+
+        // Collect matching keys before mutating the mapping array.
         TArray<FKey> KeysToRemove;
         for (const FEnhancedActionKeyMapping& Mapping : Context->GetMappings())
         {
-            if (Mapping.Action == InAction)
+            if (Mapping.Action == InAction && (!bHasSpecificKey || Mapping.Key == RequestedKey))
             {
                 KeysToRemove.Add(Mapping.Key);
             }
+        }
+
+        if (bHasSpecificKey && KeysToRemove.IsEmpty())
+        {
+            SendAutomationError(RequestingSocket, RequestId,
+                FString::Printf(TEXT("Mapping not found for action '%s' and key '%s'."),
+                    *SanitizedActionPath, *KeyName),
+                TEXT("NOT_FOUND"));
+            return true;
         }
 
         for (const FKey& KeyToRemove : KeysToRemove)
@@ -378,6 +478,10 @@ bool UMcpAutomationBridgeSubsystem::HandleInputAction(
         TSharedPtr<FJsonObject> Result = McpHandlerUtils::CreateResultObject();
         Result->SetStringField(TEXT("contextPath"), SanitizedContextPath);
         Result->SetStringField(TEXT("actionPath"), SanitizedActionPath);
+        if (bHasSpecificKey)
+        {
+            Result->SetStringField(TEXT("key"), KeyName);
+        }
         Result->SetNumberField(TEXT("keysRemoved"), KeysToRemove.Num());
 
         TArray<TSharedPtr<FJsonValue>> RemovedKeys;
@@ -386,6 +490,7 @@ bool UMcpAutomationBridgeSubsystem::HandleInputAction(
             RemovedKeys.Add(MakeShared<FJsonValueString>(Key.ToString()));
         }
         Result->SetArrayField(TEXT("removedKeys"), RemovedKeys);
+        AddInputMappingSummary(Result, Context, InAction);
 
         AddAssetVerificationNested(Result, TEXT("contextVerification"), Context);
         AddAssetVerificationNested(Result, TEXT("actionVerification"), InAction);
@@ -500,11 +605,26 @@ bool UMcpAutomationBridgeSubsystem::HandleInputAction(
     // -------------------------------------------------------------------------
     if (SubAction == TEXT("set_input_modifier"))
     {
+        FString ContextPath;
+        Payload->TryGetStringField(TEXT("contextPath"), ContextPath);
+
         FString ActionPath;
         Payload->TryGetStringField(TEXT("actionPath"), ActionPath);
 
+        FString KeyName;
+        Payload->TryGetStringField(TEXT("key"), KeyName);
+
         FString ModifierType;
         Payload->TryGetStringField(TEXT("modifierType"), ModifierType);
+
+        const bool bTargetMapping = !ContextPath.IsEmpty() || !KeyName.IsEmpty();
+        if (bTargetMapping && (ContextPath.IsEmpty() || KeyName.IsEmpty()))
+        {
+            SendAutomationError(RequestingSocket, RequestId,
+                TEXT("contextPath and key are both required when setting a modifier on a specific mapping."),
+                TEXT("INVALID_ARGUMENT"));
+            return true;
+        }
 
         FString SanitizedActionPath = SanitizeProjectRelativePath(ActionPath);
         if (SanitizedActionPath.IsEmpty())
@@ -526,52 +646,61 @@ bool UMcpAutomationBridgeSubsystem::HandleInputAction(
             return true;
         }
 
-        // Create the appropriate modifier based on type
-        UInputModifier* NewModifier = nullptr;
-        
-        // Map common modifier type names to their classes
-        if (ModifierType == TEXT("DeadZone") || ModifierType == TEXT("InputModifierDeadZone"))
+        UObject* ModifierOuter = InAction;
+        UInputMappingContext* Context = nullptr;
+        FEnhancedActionKeyMapping* TargetMapping = nullptr;
+        FKey RequestedKey = McpInputKeyFromName(KeyName);
+
+        if (bTargetMapping)
         {
-            NewModifier = NewObject<UInputModifierDeadZone>(InAction);
+            if (!RequestedKey.IsValid())
+            {
+                SendAutomationError(RequestingSocket, RequestId,
+                    FString::Printf(TEXT("Invalid key name: %s"), *KeyName), TEXT("INVALID_ARGUMENT"));
+                return true;
+            }
+
+            FString SanitizedContextPath = SanitizeProjectRelativePath(ContextPath);
+            if (SanitizedContextPath.IsEmpty())
+            {
+                SendAutomationError(RequestingSocket, RequestId,
+                    FString::Printf(TEXT("Invalid context path: '%s' contains traversal or invalid characters."), *ContextPath),
+                    TEXT("INVALID_PATH"));
+                return true;
+            }
+
+            Context = Cast<UInputMappingContext>(UEditorAssetLibrary::LoadAsset(SanitizedContextPath));
+            if (!Context)
+            {
+                SendAutomationError(RequestingSocket, RequestId,
+                    FString::Printf(TEXT("Context not found: %s"), *SanitizedContextPath),
+                    TEXT("NOT_FOUND"));
+                return true;
+            }
+
+            for (int32 MappingIndex = 0; MappingIndex < Context->GetMappings().Num(); ++MappingIndex)
+            {
+                FEnhancedActionKeyMapping& Mapping = Context->GetMapping(MappingIndex);
+                if (Mapping.Action == InAction && Mapping.Key == RequestedKey)
+                {
+                    TargetMapping = &Mapping;
+                    break;
+                }
+            }
+
+            if (!TargetMapping)
+            {
+                SendAutomationError(RequestingSocket, RequestId,
+                    FString::Printf(TEXT("Mapping not found for action '%s' and key '%s'."),
+                        *SanitizedActionPath, *KeyName),
+                    TEXT("NOT_FOUND"));
+                return true;
+            }
+
+            ModifierOuter = Context;
         }
-        else if (ModifierType == TEXT("SmoothDelta") || ModifierType == TEXT("InputModifierSmoothDelta"))
-        {
-            // UInputModifierSmoothDelta was added in UE 5.4
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 4
-            NewModifier = NewObject<UInputModifierSmoothDelta>(InAction);
-#else
-            // Fallback for UE 5.0-5.3: Use UInputModifierSmooth as closest equivalent
-            NewModifier = NewObject<UInputModifierSmooth>(InAction);
-#endif
-        }
-        else if (ModifierType == TEXT("SwizzleInputAxis") || ModifierType == TEXT("InputModifierSwizzleAxis"))
-        {
-            NewModifier = NewObject<UInputModifierSwizzleAxis>(InAction);
-        }
-        else if (ModifierType == TEXT("Negate") || ModifierType == TEXT("InputModifierNegate"))
-        {
-            NewModifier = NewObject<UInputModifierNegate>(InAction);
-        }
-        else if (ModifierType == TEXT("Scalar") || ModifierType == TEXT("InputModifierScalar"))
-        {
-            NewModifier = NewObject<UInputModifierScalar>(InAction);
-        }
-        else if (ModifierType == TEXT("ScaleByDeltaTime") || ModifierType == TEXT("InputModifierScaleByDeltaTime"))
-        {
-            // UInputModifierScaleByDeltaTime was added in UE 5.1
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
-            NewModifier = NewObject<UInputModifierScaleByDeltaTime>(InAction);
-#else
-            // UE 5.0 fallback: Use UInputModifierScalar as closest equivalent
-            // Note: This doesn't actually scale by delta time, but prevents compile error
-            NewModifier = NewObject<UInputModifierScalar>(InAction);
-#endif
-        }
-        else if (ModifierType == TEXT("ToWorldSpace") || ModifierType == TEXT("InputModifierToWorldSpace"))
-        {
-            NewModifier = NewObject<UInputModifierToWorldSpace>(InAction);
-        }
-        
+
+        UInputModifier* NewModifier = CreateInputModifierForType(ModifierType, ModifierOuter);
         if (!NewModifier)
         {
             SendAutomationError(RequestingSocket, RequestId,
@@ -580,16 +709,35 @@ bool UMcpAutomationBridgeSubsystem::HandleInputAction(
             return true;
         }
 
-        // Add the modifier to the action
-        InAction->Modifiers.Add(NewModifier);
-        
-        SaveLoadedAssetThrottled(InAction, -1.0, true);
+        if (TargetMapping)
+        {
+            TargetMapping->Modifiers.Add(NewModifier);
+            SaveLoadedAssetThrottled(Context, -1.0, true);
+        }
+        else
+        {
+            InAction->Modifiers.Add(NewModifier);
+            SaveLoadedAssetThrottled(InAction, -1.0, true);
+        }
 
         TSharedPtr<FJsonObject> Result = McpHandlerUtils::CreateResultObject();
         Result->SetStringField(TEXT("actionPath"), SanitizedActionPath);
         Result->SetStringField(TEXT("modifierType"), ModifierType);
         Result->SetBoolField(TEXT("modifierSet"), true);
-        McpHandlerUtils::AddVerification(Result, InAction);
+        Result->SetStringField(TEXT("target"), TargetMapping ? TEXT("mapping") : TEXT("action"));
+        if (TargetMapping)
+        {
+            Result->SetStringField(TEXT("contextPath"), SanitizeProjectRelativePath(ContextPath));
+            Result->SetStringField(TEXT("key"), KeyName);
+            Result->SetNumberField(TEXT("mappingModifierCount"), TargetMapping->Modifiers.Num());
+            AddInputMappingSummary(Result, Context, InAction);
+            AddAssetVerificationNested(Result, TEXT("contextVerification"), Context);
+            AddAssetVerificationNested(Result, TEXT("actionVerification"), InAction);
+        }
+        else
+        {
+            McpHandlerUtils::AddVerification(Result, InAction);
+        }
 
         SendAutomationResponse(RequestingSocket, RequestId, true,
             FString::Printf(TEXT("Modifier '%s' configured on action."), *ModifierType), Result);

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_InputHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_InputHandlers.cpp
@@ -124,10 +124,10 @@ UInputModifier* CreateInputModifierForType(const FString& ModifierType, UObject*
     }
     if (ModifierType == TEXT("ScaleByDeltaTime") || ModifierType == TEXT("InputModifierScaleByDeltaTime"))
     {
-#if ENGINE_MAJOR_VERSION == 5
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
         return NewObject<UInputModifierScaleByDeltaTime>(Outer);
 #else
-        return nullptr;
+        return NewObject<UInputModifierScalar>(Outer);
 #endif
     }
     if (ModifierType == TEXT("ToWorldSpace") || ModifierType == TEXT("InputModifierToWorldSpace"))

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_InputHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_InputHandlers.cpp
@@ -648,6 +648,7 @@ bool UMcpAutomationBridgeSubsystem::HandleInputAction(
 
         UObject* ModifierOuter = InAction;
         UInputMappingContext* Context = nullptr;
+        FString SanitizedContextPath;
         FEnhancedActionKeyMapping* TargetMapping = nullptr;
         FKey RequestedKey = McpInputKeyFromName(KeyName);
 
@@ -660,7 +661,7 @@ bool UMcpAutomationBridgeSubsystem::HandleInputAction(
                 return true;
             }
 
-            FString SanitizedContextPath = SanitizeProjectRelativePath(ContextPath);
+            SanitizedContextPath = SanitizeProjectRelativePath(ContextPath);
             if (SanitizedContextPath.IsEmpty())
             {
                 SendAutomationError(RequestingSocket, RequestId,
@@ -711,11 +712,13 @@ bool UMcpAutomationBridgeSubsystem::HandleInputAction(
 
         if (TargetMapping)
         {
+            Context->Modify();
             TargetMapping->Modifiers.Add(NewModifier);
             SaveLoadedAssetThrottled(Context, -1.0, true);
         }
         else
         {
+            InAction->Modify();
             InAction->Modifiers.Add(NewModifier);
             SaveLoadedAssetThrottled(InAction, -1.0, true);
         }
@@ -727,7 +730,7 @@ bool UMcpAutomationBridgeSubsystem::HandleInputAction(
         Result->SetStringField(TEXT("target"), TargetMapping ? TEXT("mapping") : TEXT("action"));
         if (TargetMapping)
         {
-            Result->SetStringField(TEXT("contextPath"), SanitizeProjectRelativePath(ContextPath));
+            Result->SetStringField(TEXT("contextPath"), SanitizedContextPath);
             Result->SetStringField(TEXT("key"), KeyName);
             Result->SetNumberField(TEXT("mappingModifierCount"), TargetMapping->Modifiers.Num());
             AddInputMappingSummary(Result, Context, InAction);

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_InputHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_InputHandlers.cpp
@@ -73,7 +73,7 @@ FKey McpInputKeyFromName(const FString& KeyName)
 /** Adds verified mapping readback for an action after key-specific edits. */
 void AddInputMappingSummary(
     TSharedPtr<FJsonObject> Result,
-    UInputMappingContext* Context,
+    const UInputMappingContext* Context,
     const UInputAction* InAction)
 {
     TArray<TSharedPtr<FJsonValue>> Mappings;
@@ -91,7 +91,7 @@ void AddInputMappingSummary(
         Mappings.Add(MakeShared<FJsonValueObject>(MappingObject));
     }
 
-    Result->SetNumberField(TEXT("remainingMappingCount"), Mappings.Num());
+    Result->SetNumberField(TEXT("mappingCount"), Mappings.Num());
     Result->SetArrayField(TEXT("mappings"), Mappings);
 }
 
@@ -124,10 +124,10 @@ UInputModifier* CreateInputModifierForType(const FString& ModifierType, UObject*
     }
     if (ModifierType == TEXT("ScaleByDeltaTime") || ModifierType == TEXT("InputModifierScaleByDeltaTime"))
     {
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
+#if ENGINE_MAJOR_VERSION == 5
         return NewObject<UInputModifierScaleByDeltaTime>(Outer);
 #else
-        return NewObject<UInputModifierScalar>(Outer);
+        return nullptr;
 #endif
     }
     if (ModifierType == TEXT("ToWorldSpace") || ModifierType == TEXT("InputModifierToWorldSpace"))
@@ -495,8 +495,10 @@ bool UMcpAutomationBridgeSubsystem::HandleInputAction(
         AddAssetVerificationNested(Result, TEXT("contextVerification"), Context);
         AddAssetVerificationNested(Result, TEXT("actionVerification"), InAction);
 
-        SendAutomationResponse(RequestingSocket, RequestId, true,
-            TEXT("Mappings removed for action."), Result);
+        const FString SuccessMessage = bHasSpecificKey
+            ? FString::Printf(TEXT("Mapping removed for action key: %s"), *KeyName)
+            : TEXT("Mappings removed for action.");
+        SendAutomationResponse(RequestingSocket, RequestId, true, SuccessMessage, Result);
         return true;
     }
 
@@ -679,7 +681,8 @@ bool UMcpAutomationBridgeSubsystem::HandleInputAction(
                 return true;
             }
 
-            for (int32 MappingIndex = 0; MappingIndex < Context->GetMappings().Num(); ++MappingIndex)
+            const int32 MappingCount = Context->GetMappings().Num();
+            for (int32 MappingIndex = 0; MappingIndex < MappingCount; ++MappingIndex)
             {
                 FEnhancedActionKeyMapping& Mapping = Context->GetMapping(MappingIndex);
                 if (Mapping.Action == InAction && Mapping.Key == RequestedKey)

--- a/src/tools/consolidated-tool-definitions.ts
+++ b/src/tools/consolidated-tool-definitions.ts
@@ -858,7 +858,8 @@ export const consolidatedToolDefinitions: ToolDefinition[] = [
         triggerType: commonSchemas.stringProp,
         modifierType: commonSchemas.stringProp,
         assetPath: commonSchemas.assetPath,
-        priority: { type: 'number', description: 'Priority for input mapping context (default: 0).' }
+        priority: { type: 'number', description: 'Priority for input mapping context (default: 0).' },
+        timeoutMs: commonSchemas.numberProp
       },
       required: ['action']
     },

--- a/src/tools/handlers/input-handlers.ts
+++ b/src/tools/handlers/input-handlers.ts
@@ -15,10 +15,10 @@ const VALID_PARAMS_BY_ACTION: Record<string, Set<string>> = {
     create_input_action: new Set(['action', 'name', 'path', 'timeoutMs']),
     create_input_mapping_context: new Set(['action', 'name', 'path', 'timeoutMs']),
     add_mapping: new Set(['action', 'contextPath', 'actionPath', 'key', 'timeoutMs']),
-    remove_mapping: new Set(['action', 'contextPath', 'actionPath', 'timeoutMs']),
+    remove_mapping: new Set(['action', 'contextPath', 'actionPath', 'key', 'timeoutMs']),
     map_input_action: new Set(['action', 'contextPath', 'actionPath', 'key', 'timeoutMs']),
     set_input_trigger: new Set(['action', 'actionPath', 'triggerType', 'timeoutMs']),
-    set_input_modifier: new Set(['action', 'actionPath', 'modifierType', 'timeoutMs']),
+    set_input_modifier: new Set(['action', 'contextPath', 'actionPath', 'key', 'modifierType', 'timeoutMs']),
     enable_input_mapping: new Set(['action', 'contextPath', 'priority', 'timeoutMs']),
     disable_input_action: new Set(['action', 'actionPath', 'timeoutMs']),
     get_input_info: new Set(['action', 'assetPath', 'timeoutMs']),
@@ -126,9 +126,11 @@ export async function handleInputTools(
           }
       }
       
-      // Also check for optional path params (path, assetPath for non-required)
+      // Also check for optional path params (path, assetPath, contextPath, actionPath for non-required)
       if (argsRecord.path !== undefined) pathParams.path = argsRecord.path;
       if (argsRecord.assetPath !== undefined) pathParams.assetPath = argsRecord.assetPath;
+      if (argsRecord.contextPath !== undefined) pathParams.contextPath = argsRecord.contextPath;
+      if (argsRecord.actionPath !== undefined) pathParams.actionPath = argsRecord.actionPath;
       
       const pathValidation = validateAndSanitizePaths(pathParams, requiredPaths);
       if (!pathValidation.valid) {
@@ -215,7 +217,8 @@ export async function handleInputTools(
             const result = await executeAutomationRequest(tools, TOOL_ACTIONS.MANAGE_INPUT, {
                 action: 'remove_mapping',
                 contextPath: sanitizedContextPath,
-                actionPath: sanitizedActionPath
+                actionPath: sanitizedActionPath,
+                key: argsTyped.key ?? ''
             }, undefined, { timeoutMs });
             return cleanObject(result) as Record<string, unknown>;
         }


### PR DESCRIPTION
## Summary

Fixes `manage_input` key-specific binding edits so `remove_mapping` and `set_input_modifier` can safely target one Enhanced Input mapping by `contextPath + actionPath + key` without damaging sibling mappings.

## Changes

- Allows the TypeScript `manage_input` handler to accept and forward `key` for `remove_mapping`.
- Allows `set_input_modifier` to accept optional `contextPath` and `key` for mapping-specific modifier edits.
- Preserves legacy `remove_mapping` behavior when `key` is omitted, while removing only the matching key when one is provided.
- Adds native mapping readback summaries with remaining keys plus modifier and trigger counts after key-specific edits.
- Adds shared native modifier construction so mapping-specific and action-level modifier paths use the same UE 5.x compatibility fallbacks.

## Related Issues

Fixes a local bug-fix TODO item for precise per-key Enhanced Input mapping edits. No GitHub issue number was provided.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration/build change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test addition/update

## Testing

- [x] Tested with Unreal Engine (version: 5.7)
- [x] Tested MCP client integration (client: Native MCP HTTP / `manage_input`)
- [ ] Added/updated tests

Validation performed:

- Ran `npm run build:core`; TypeScript compilation succeeded.
- Rebuilt `test_thirdEditor` with UBT after closing UnrealEditor; build succeeded and linked the updated plugin DLL.
- Restarted UnrealEditor and verified Native MCP started on `http://0.0.0.0:4000/mcp`.
- Through Native MCP HTTP, created a fresh input action and mapping context, then mapped both `W` and `S` to the same action.
- Called `manage_input.set_input_modifier` with `contextPath + actionPath + key=W + modifierType=Negate`; runtime verification passed with `target=mapping` and `mappingModifierCount=1`.
- Called `manage_input.remove_mapping` with `contextPath + actionPath + key=W`; runtime verification passed with `keysRemoved=1`, `removedKeys=["W"]`, remaining keys containing only `S`, and `get_input_info` returning `mappingCount=1`.
- No automated tests were added because this behavior requires Unreal runtime asset mutation for full verification.

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Updated relevant documentation (if needed)
- [ ] Added/updated tests (if applicable)
- [ ] CI passes

Notes:

- `plugins/McpAutomationBridge/bug-fix.md` was intentionally excluded from the PR per repository skill guidance; the relevant verification details are included in this PR body.
- CI has not run yet at PR creation time.