### PR TITLE
fix(blueprint): fix action routing by using exact match in ActionMatchesPattern

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_BlueprintHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_BlueprintHandlers.cpp
@@ -1465,8 +1465,7 @@ bool UMcpAutomationBridgeSubsystem::HandleBlueprintAction(
       if (FChar::IsAlnum(C))
         PatternAlpha.AppendChar(C);
     }
-    const bool bExactOrContains =
-        (Lower.Equals(PatternStr) || Lower.Contains(PatternStr));
+    const bool bExactOrContains = Lower.Equals(PatternStr);
     const bool bAlphaMatch =
         (!AlphaNumLower.IsEmpty() && !PatternAlpha.IsEmpty() &&
          AlphaNumLower.Contains(PatternAlpha));

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_BlueprintHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_BlueprintHandlers.cpp
@@ -1468,7 +1468,7 @@ bool UMcpAutomationBridgeSubsystem::HandleBlueprintAction(
     const bool bExactOrContains = Lower.Equals(PatternStr);
     const bool bAlphaMatch =
         (!AlphaNumLower.IsEmpty() && !PatternAlpha.IsEmpty() &&
-         AlphaNumLower.Contains(PatternAlpha));
+         AlphaNumLower.Equals(PatternAlpha));
     const bool bMatched = (bExactOrContains || bAlphaMatch);
     // Keep this at VeryVerbose because it executes for every pattern match
     // attempt and rapidly fills the log during normal operation.


### PR DESCRIPTION
…on hijacking

Refactor pattern matching logicChanged the logic in ActionMatchesPattern from substring matching (Contains) to exact matching (Equals). This fixes a bug where 'manage_blueprint_graph' actions were being incorrectly intercepted by general blueprint handlers, as identified in issue #380. to only check for exact matches.

## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact. -->

## Changes

<!-- List the key changes made in this PR. -->

- 

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). 
     If only related, use: Related to #123 -->

## Type of Change

<!-- Check all that apply -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration/build change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test addition/update

## Testing

<!-- Describe how to test these changes -->

- [ ] Tested with Unreal Engine (version: ___)
- [ ] Tested MCP client integration (client: ___)
- [ ] Added/updated tests

## Pre-Merge Checklist

- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Updated relevant documentation (if needed)
- [ ] Added/updated tests (if applicable)
- [ ] CI passes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chir24/unreal_mcp/pull/381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
