### PR TITLE
fix(blueprint): include inherited variables and SCS components in introspection

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_SCSHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_SCSHandlers.cpp
@@ -215,64 +215,84 @@ FSCSHandlers::GetBlueprintSCS(const FString &BlueprintPath) {
     return Result;
   }
 
-  // Get SCS
-  USimpleConstructionScript *SCS = Blueprint->SimpleConstructionScript;
-  if (!SCS) {
-    Result->SetBoolField(TEXT("success"), false);
-    Result->SetStringField(TEXT("error"),
-                           TEXT("Blueprint has no SimpleConstructionScript"));
-    return Result;
+  TArray<UBlueprint *> Chain;
+  {
+    UBlueprint *Current = Blueprint;
+    while (Current) {
+      Chain.Add(Current);
+      UClass *ParentClass = Current->ParentClass;
+      UBlueprint *ParentBP =
+          ParentClass ? Cast<UBlueprint>(ParentClass->ClassGeneratedBy)
+                      : nullptr;
+      if (!ParentBP || ParentBP == Current || Chain.Contains(ParentBP)) {
+        break;
+      }
+      Current = ParentBP;
+    }
   }
 
-  // Build component tree
   TArray<TSharedPtr<FJsonValue>> Components;
-  const TArray<USCS_Node *> &AllNodes = SCS->GetAllNodes();
+  for (int32 ChainIdx = Chain.Num() - 1; ChainIdx >= 0; --ChainIdx) {
+    UBlueprint *CurrentBP = Chain[ChainIdx];
+    USimpleConstructionScript *SCS = CurrentBP->SimpleConstructionScript;
+    if (!SCS) {
+      continue;
+    }
+    const bool bInherited = (CurrentBP != Blueprint);
+    const TArray<USCS_Node *> &AllNodes = SCS->GetAllNodes();
 
-  for (USCS_Node *Node : AllNodes) {
-    if (Node && Node->GetVariableName().IsValid()) {
-      TSharedPtr<FJsonObject> ComponentObj = McpHandlerUtils::CreateResultObject();
-      ComponentObj->SetStringField(TEXT("name"),
-                                   Node->GetVariableName().ToString());
-      ComponentObj->SetStringField(
-          TEXT("class"), Node->ComponentClass ? Node->ComponentClass->GetName()
-                                              : TEXT("Unknown"));
-      if (!Node->ParentComponentOrVariableName.IsNone()) {
+    for (USCS_Node *Node : AllNodes) {
+      if (Node && Node->GetVariableName().IsValid()) {
+        TSharedPtr<FJsonObject> ComponentObj = McpHandlerUtils::CreateResultObject();
+        ComponentObj->SetStringField(TEXT("name"),
+                                     Node->GetVariableName().ToString());
         ComponentObj->SetStringField(
-            TEXT("parent"), Node->ParentComponentOrVariableName.ToString());
-      }
-
-      // Add transform if component template exists (cast to SceneComponent for
-      // UE 5.6)
-      if (Node->ComponentTemplate) {
-        FTransform Transform = FTransform::Identity;
-        if (USceneComponent *SceneComp =
-                Cast<USceneComponent>(Node->ComponentTemplate)) {
-          Transform = SceneComp->GetRelativeTransform();
+            TEXT("class"), Node->ComponentClass ? Node->ComponentClass->GetName()
+                                                : TEXT("Unknown"));
+        if (!Node->ParentComponentOrVariableName.IsNone()) {
+          ComponentObj->SetStringField(
+              TEXT("parent"), Node->ParentComponentOrVariableName.ToString());
         }
-        TSharedPtr<FJsonObject> TransformObj = McpHandlerUtils::CreateResultObject();
 
-        FVector Loc = Transform.GetLocation();
-        FRotator Rot = Transform.GetRotation().Rotator();
-        FVector Scale = Transform.GetScale3D();
+        // Add transform if component template exists (cast to SceneComponent for
+        // UE 5.6)
+        if (Node->ComponentTemplate) {
+          FTransform Transform = FTransform::Identity;
+          if (USceneComponent *SceneComp =
+                  Cast<USceneComponent>(Node->ComponentTemplate)) {
+            Transform = SceneComp->GetRelativeTransform();
+          }
+          TSharedPtr<FJsonObject> TransformObj = McpHandlerUtils::CreateResultObject();
 
-        TransformObj->SetStringField(
-            TEXT("location"),
-            FString::Printf(TEXT("X=%.2f Y=%.2f Z=%.2f"), Loc.X, Loc.Y, Loc.Z));
-        TransformObj->SetStringField(
-            TEXT("rotation"), FString::Printf(TEXT("P=%.2f Y=%.2f R=%.2f"),
-                                              Rot.Pitch, Rot.Yaw, Rot.Roll));
-        TransformObj->SetStringField(
-            TEXT("scale"), FString::Printf(TEXT("X=%.2f Y=%.2f Z=%.2f"),
-                                           Scale.X, Scale.Y, Scale.Z));
+          FVector Loc = Transform.GetLocation();
+          FRotator Rot = Transform.GetRotation().Rotator();
+          FVector Scale = Transform.GetScale3D();
 
-        ComponentObj->SetObjectField(TEXT("transform"), TransformObj);
+          TransformObj->SetStringField(
+              TEXT("location"),
+              FString::Printf(TEXT("X=%.2f Y=%.2f Z=%.2f"), Loc.X, Loc.Y, Loc.Z));
+          TransformObj->SetStringField(
+              TEXT("rotation"), FString::Printf(TEXT("P=%.2f Y=%.2f R=%.2f"),
+                                                Rot.Pitch, Rot.Yaw, Rot.Roll));
+          TransformObj->SetStringField(
+              TEXT("scale"), FString::Printf(TEXT("X=%.2f Y=%.2f Z=%.2f"),
+                                             Scale.X, Scale.Y, Scale.Z));
+
+          ComponentObj->SetObjectField(TEXT("transform"), TransformObj);
+        }
+
+        // Add child count
+        ComponentObj->SetNumberField(TEXT("child_count"),
+                                     Node->GetChildNodes().Num());
+
+        if (bInherited) {
+          ComponentObj->SetBoolField(TEXT("inherited"), true);
+          ComponentObj->SetStringField(TEXT("declaringBlueprint"),
+                                       CurrentBP->GetName());
+        }
+
+        Components.Add(MakeShared<FJsonValueObject>(ComponentObj));
       }
-
-      // Add child count
-      ComponentObj->SetNumberField(TEXT("child_count"),
-                                   Node->GetChildNodes().Num());
-
-      Components.Add(MakeShared<FJsonValueObject>(ComponentObj));
     }
   }
 

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpHandlerUtils.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpHandlerUtils.cpp
@@ -898,23 +898,53 @@ TArray<TSharedPtr<FJsonValue>> CollectBlueprintVariables(UBlueprint* Blueprint)
         return Out;
     }
 
-    for (const FBPVariableDescription& Var : Blueprint->NewVariables)
+    TArray<UBlueprint*> Chain;
     {
-        TSharedPtr<FJsonObject> Obj = MakeShared<FJsonObject>();
-        Obj->SetStringField(TEXT("name"), Var.VarName.ToString());
-        Obj->SetStringField(TEXT("type"), DescribePinType(Var.VarType));
-        Obj->SetBoolField(TEXT("replicated"), (Var.PropertyFlags & CPF_Net) != 0);
-        Obj->SetBoolField(TEXT("public"), (Var.PropertyFlags & CPF_BlueprintReadOnly) == 0);
-        
-        const FString CategoryStr = Var.Category.IsEmpty() ? FString() : Var.Category.ToString();
-        if (!CategoryStr.IsEmpty())
+        UBlueprint* Current = Blueprint;
+        while (Current)
         {
-            Obj->SetStringField(TEXT("category"), CategoryStr);
+            Chain.Add(Current);
+            UClass* ParentClass = Current->ParentClass;
+            UBlueprint* ParentBP = ParentClass
+                ? Cast<UBlueprint>(ParentClass->ClassGeneratedBy)
+                : nullptr;
+            if (!ParentBP || ParentBP == Current || Chain.Contains(ParentBP))
+            {
+                break;
+            }
+            Current = ParentBP;
         }
-        
-        Out.Add(MakeShared<FJsonValueObject>(Obj));
     }
-    
+
+    for (int32 ChainIdx = Chain.Num() - 1; ChainIdx >= 0; --ChainIdx)
+    {
+        UBlueprint* CurrentBP = Chain[ChainIdx];
+        const bool bInherited = (CurrentBP != Blueprint);
+
+        for (const FBPVariableDescription& Var : CurrentBP->NewVariables)
+        {
+            TSharedPtr<FJsonObject> Obj = MakeShared<FJsonObject>();
+            Obj->SetStringField(TEXT("name"), Var.VarName.ToString());
+            Obj->SetStringField(TEXT("type"), DescribePinType(Var.VarType));
+            Obj->SetBoolField(TEXT("replicated"), (Var.PropertyFlags & CPF_Net) != 0);
+            Obj->SetBoolField(TEXT("public"), (Var.PropertyFlags & CPF_BlueprintReadOnly) == 0);
+
+            const FString CategoryStr = Var.Category.IsEmpty() ? FString() : Var.Category.ToString();
+            if (!CategoryStr.IsEmpty())
+            {
+                Obj->SetStringField(TEXT("category"), CategoryStr);
+            }
+
+            if (bInherited)
+            {
+                Obj->SetBoolField(TEXT("inherited"), true);
+                Obj->SetStringField(TEXT("declaringBlueprint"), CurrentBP->GetName());
+            }
+
+            Out.Add(MakeShared<FJsonValueObject>(Obj));
+        }
+    }
+
     return Out;
 }
 


### PR DESCRIPTION
## Summary

`manage_blueprint.blueprint_get` (alias `inspect.get_blueprint_details`) and `manage_blueprint.get_scs` previously returned only the variables/components declared on the target blueprint, omitting anything inherited from a parent BP. For a child BP, the response would miss every inherited variable and SCS component, even though those are accessible at runtime and visible in the BP editor.

This PR walks the parent BP chain so introspection responses match what's actually available on the blueprint, and tags inherited entries so callers can distinguish ownership.

## Changes

- `McpHandlerUtils.cpp` `CollectBlueprintVariables`: walk `Blueprint->ParentClass->ClassGeneratedBy` chain, accumulate `NewVariables` from each ancestor BP. Inherited entries get `inherited: true` and `declaringBlueprint`. Chain stops at the first non-BP parent (native classes), matching the existing convention that BP variable lists do not surface native parent properties.
- `McpAutomationBridge_SCSHandlers.cpp` `FSCSHandlers::GetBlueprintSCS`: same chain walk for `SimpleConstructionScript` nodes, with the same `inherited` / `declaringBlueprint` tagging.
- Cycle guard in both walks (defensive — should not occur in valid assets).
- Backwards compatible: existing fields unchanged; `inherited` and `declaringBlueprint` are additive optional fields surfaced only on inherited entries.

## Related Issues

<!-- None tracked; surfaced through usage. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Tested with Unreal Engine (version: 5.7)
- [x] Tested MCP client integration (client: Claude Code)
- [ ] Added/updated tests

Manual verification with a parent/child BP pair where the child does not override parent declarations:

- \`inspect.get_blueprint_details\` on child BP: variable count 2 → 4 (2 inherited + 2 own); inherited entries tagged with \`inherited:true\` and \`declaringBlueprint\`. \`defaults\` payload now includes parent-declared values.
- \`manage_blueprint.get_scs\` on child BP: component count 2 → 5 (3 inherited + 2 own); inherited components tagged.
- \`inspect.get_blueprint_details\` on parent BP (parent is native \`AActor\`): no \`inherited\` markers — chain terminates correctly at the native boundary.

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [ ] Updated relevant documentation (if needed)
- [ ] Added/updated tests (if applicable)
- [ ] CI passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chir24/unreal_mcp/pull/382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
