### PR TITLE
fix(animation): make path params optional and harden notify validation

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_AnimationAuthoringHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_AnimationAuthoringHandlers.cpp
@@ -556,25 +556,29 @@ static TSharedPtr<FJsonObject> HandleAnimationAuthoringRequest(const TSharedPtr<
     
     if (SubAction == TEXT("create_animation_sequence"))
     {
-        FString Name = GetStringFieldAnimAuth(Params, TEXT("name"), TEXT(""));
-        FString Path = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("path"), TEXT("/Game/Animations")));
-        FString SkeletonPath = GetStringFieldAnimAuth(Params, TEXT("skeletonPath"), TEXT(""));
-        int32 NumFrames = static_cast<int32>(GetNumberFieldAnimAuth(Params, TEXT("numFrames"), 30));
-        int32 FrameRate = static_cast<int32>(GetNumberFieldAnimAuth(Params, TEXT("frameRate"), 30));
-        bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
-        
-        if (Name.IsEmpty())
-        {
-            ANIM_ERROR_RESPONSE(TEXT("Name is required"), TEXT("MISSING_NAME"));
-        }
-        
-        USkeleton* Skeleton = LoadSkeletonFromPathAnim(SkeletonPath);
+    FString Name = GetStringFieldAnimAuth(Params, TEXT("name"), TEXT(""));
+    FString Path = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("path"), TEXT("/Game/Animations")));
+    FString SkeletonPath = GetStringFieldAnimAuth(Params, TEXT("skeletonPath"), TEXT(""));
+    int32 NumFrames = static_cast<int32>(GetNumberFieldAnimAuth(Params, TEXT("numFrames"), 30));
+    int32 FrameRate = static_cast<int32>(GetNumberFieldAnimAuth(Params, TEXT("frameRate"), 30));
+    bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
+
+    if (Name.IsEmpty())
+    {
+        ANIM_ERROR_RESPONSE(TEXT("Name is required"), TEXT("MISSING_NAME"));
+    }
+
+    USkeleton* Skeleton = nullptr;
+    if (!SkeletonPath.IsEmpty())
+    {
+        Skeleton = LoadSkeletonFromPathAnim(SkeletonPath);
         if (!Skeleton)
         {
             ANIM_ERROR_RESPONSE(FString::Printf(TEXT("Could not load skeleton: %s"), *SkeletonPath), TEXT("SKELETON_NOT_FOUND"));
         }
-        
-        // Check if an asset already exists at the target path to prevent assertion failure
+    }
+
+    // Check if an asset already exists at the target path to prevent assertion failure
         FString ObjectPath = FString::Printf(TEXT("%s/%s"), *Path, *Name);
         if (UEditorAssetLibrary::DoesAssetExist(ObjectPath))
         {
@@ -734,46 +738,39 @@ static TSharedPtr<FJsonObject> HandleAnimationAuthoringRequest(const TSharedPtr<
         }
         
 #if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 1
-        // UE 5.1+ uses IAnimationDataController with IsValidBoneTrackName and AddBoneCurve
-        IAnimationDataController& Controller = Sequence->GetController();
-        
-        // Validate the controller model is available
-        if (!Controller.GetModel())
-        {
-            ANIM_ERROR_RESPONSE(
-                TEXT("Animation data model is not available - cannot add bone track"),
-                TEXT("MODEL_NOT_AVAILABLE")
-            );
-        }
-        
-        PRAGMA_DISABLE_DEPRECATION_WARNINGS
-        const int32 ExistingTrackIndex = Controller.GetModel()->GetBoneTrackIndexByName(BoneFName);
-        PRAGMA_ENABLE_DEPRECATION_WARNINGS
-        if (ExistingTrackIndex == INDEX_NONE)
-        {
-            // AddBoneCurve returns bool - check the result
-            const bool bAdded = Controller.AddBoneCurve(BoneFName);
-            if (!bAdded)
-            {
-                ANIM_ERROR_RESPONSE(
-                    FString::Printf(TEXT("AddBoneCurve failed for bone '%s' - the bone may not be valid for this animation"), *BoneName),
-                    TEXT("BONE_TRACK_ADD_FAILED")
-                );
-            }
+	// UE 5.1+ uses IAnimationDataController with IsValidBoneTrackName and AddBoneCurve
+	IAnimationDataController& Controller = Sequence->GetController();
 
-            // Verify the bone curve was actually added
-            // Note: GetBoneTrackIndexByName is deprecated in UE 5.2+ but still functional
-            PRAGMA_DISABLE_DEPRECATION_WARNINGS
-            const int32 AddedTrackIndex = Controller.GetModel()->GetBoneTrackIndexByName(BoneFName);
-            PRAGMA_ENABLE_DEPRECATION_WARNINGS
-            if (AddedTrackIndex == INDEX_NONE)
-            {
-                ANIM_ERROR_RESPONSE(
-                    FString::Printf(TEXT("Bone track '%s' was not found after AddBoneCurve succeeded - internal inconsistency"), *BoneName),
-                    TEXT("BONE_TRACK_ADD_FAILED")
-                );
-            }
-        }
+	// Validate the controller model is available
+	if (!Controller.GetModel())
+	{
+		ANIM_ERROR_RESPONSE(
+			TEXT("Animation data model is not available - cannot add bone track"),
+			TEXT("MODEL_NOT_AVAILABLE")
+		);
+	}
+
+	// Use IsValidBoneTrackName (non-deprecated) instead of GetBoneTrackIndexByName (deprecated since 5.2)
+	if (!Controller.GetModel()->IsValidBoneTrackName(BoneFName))
+	{
+		// AddBoneCurve returns bool - check the result
+		const bool bAdded = Controller.AddBoneCurve(BoneFName);
+		if (!bAdded)
+		{
+			ANIM_ERROR_RESPONSE(
+				FString::Printf(TEXT("AddBoneCurve failed for bone '%s' - the bone may not be valid for this animation"), *BoneName),
+				TEXT("BONE_TRACK_ADD_FAILED")
+			);
+		}
+
+		if (!Controller.GetModel()->IsValidBoneTrackName(BoneFName))
+		{
+			ANIM_ERROR_RESPONSE(
+				FString::Printf(TEXT("Bone track '%s' was not found after AddBoneCurve succeeded - internal inconsistency"), *BoneName),
+				TEXT("BONE_TRACK_ADD_FAILED")
+			);
+		}
+	}
 #elif ENGINE_MAJOR_VERSION >= 5
         // UE 5.0 approach - uses FindBoneTrackByName which returns a pointer
         IAnimationDataController& Controller = Sequence->GetController();
@@ -843,44 +840,38 @@ static TSharedPtr<FJsonObject> HandleAnimationAuthoringRequest(const TSharedPtr<
         
 #if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 1
         // UE 5.1+ API
-        IAnimationDataController& Controller = Sequence->GetController();
-        FName BoneFName(*BoneName);
+	IAnimationDataController& Controller = Sequence->GetController();
+	FName BoneFName(*BoneName);
 
-        if (!Controller.GetModel())
-        {
-            ANIM_ERROR_RESPONSE(
-                TEXT("Animation data model is not available - cannot set bone key"),
-                TEXT("MODEL_NOT_AVAILABLE")
-            );
-        }
+	if (!Controller.GetModel())
+	{
+		ANIM_ERROR_RESPONSE(
+			TEXT("Animation data model is not available - cannot set bone key"),
+			TEXT("MODEL_NOT_AVAILABLE")
+		);
+	}
 
-        PRAGMA_DISABLE_DEPRECATION_WARNINGS
-        int32 TrackIndex = Controller.GetModel()->GetBoneTrackIndexByName(BoneFName);
-        PRAGMA_ENABLE_DEPRECATION_WARNINGS
-        if (TrackIndex == INDEX_NONE)
-        {
-            const bool bAdded = Controller.AddBoneCurve(BoneFName);
-            if (!bAdded)
+	// Use IsValidBoneTrackName (non-deprecated) instead of GetBoneTrackIndexByName (deprecated since 5.2)
+            if (!Controller.GetModel()->IsValidBoneTrackName(BoneFName))
             {
-                ANIM_ERROR_RESPONSE(
-                    FString::Printf(TEXT("Failed to create missing bone track '%s' before keying"), *BoneName),
-                    TEXT("BONE_TRACK_ADD_FAILED")
-                );
+                const bool bAdded = Controller.AddBoneCurve(BoneFName);
+                if (!bAdded)
+                {
+                    ANIM_ERROR_RESPONSE(
+                        FString::Printf(TEXT("Failed to create missing bone track '%s' before keying"), *BoneName),
+                        TEXT("BONE_TRACK_ADD_FAILED")
+                    );
+                }
+
+                // Verify the track was actually created after AddBoneCurve succeeded
+                if (!Controller.GetModel()->IsValidBoneTrackName(BoneFName))
+                {
+                    ANIM_ERROR_RESPONSE(
+                        FString::Printf(TEXT("Bone track '%s' not found in animation sequence after AddBoneCurve. Add the track first using add_bone_track."), *BoneName),
+                        TEXT("BONE_TRACK_NOT_FOUND")
+                    );
+                }
             }
-
-            PRAGMA_DISABLE_DEPRECATION_WARNINGS
-            TrackIndex = Controller.GetModel()->GetBoneTrackIndexByName(BoneFName);
-            PRAGMA_ENABLE_DEPRECATION_WARNINGS
-        }
-
-        // Verify bone track exists before setting keys
-        if (TrackIndex == INDEX_NONE)
-        {
-            ANIM_ERROR_RESPONSE(
-                FString::Printf(TEXT("Bone track '%s' not found in animation sequence. Add the track first using add_bone_track."), *BoneName),
-                TEXT("BONE_TRACK_NOT_FOUND")
-            );
-        }
         
         // Build transform key
         FVector Location = LocationObj.IsValid() ? GetVectorFromJsonAnim(LocationObj) : FVector::ZeroVector;
@@ -985,154 +976,206 @@ static TSharedPtr<FJsonObject> HandleAnimationAuthoringRequest(const TSharedPtr<
         return Response;
     }
 
-    if (SubAction == TEXT("add_notify"))
+if (SubAction == TEXT("add_notify"))
+{
+	FString AssetPath = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("assetPath"), TEXT("")));
+    FString NotifyClass = GetStringFieldAnimAuth(Params, TEXT("notifyClass"), TEXT(""));
+    int32 Frame = static_cast<int32>(GetNumberFieldAnimAuth(Params, TEXT("frame"), 0));
+    int32 TrackIndex = static_cast<int32>(GetNumberFieldAnimAuth(Params, TEXT("trackIndex"), 0));
+    FString NotifyName = GetStringFieldAnimAuth(Params, TEXT("notifyName"), TEXT(""));
+    bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
+
+    if (NotifyClass.IsEmpty() && NotifyName.IsEmpty())
     {
-        FString AssetPath = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("assetPath"), TEXT("")));
-        FString NotifyClass = GetStringFieldAnimAuth(Params, TEXT("notifyClass"), TEXT("AnimNotify"));
-        int32 Frame = static_cast<int32>(GetNumberFieldAnimAuth(Params, TEXT("frame"), 0));
-        int32 TrackIndex = static_cast<int32>(GetNumberFieldAnimAuth(Params, TEXT("trackIndex"), 0));
-        FString NotifyName = GetStringFieldAnimAuth(Params, TEXT("notifyName"), TEXT(""));
-        bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
-        
-        UAnimSequenceBase* AnimAsset = Cast<UAnimSequenceBase>(StaticLoadObject(UAnimSequenceBase::StaticClass(), nullptr, *AssetPath));
-        if (!AnimAsset)
-        {
-            ANIM_ERROR_RESPONSE(FString::Printf(TEXT("Could not load animation asset: %s"), *AssetPath), TEXT("ASSET_NOT_FOUND"));
-        }
-        
-        // Find notify class
+        ANIM_ERROR_RESPONSE(TEXT("At least one of notifyClass or notifyName is required"), TEXT("MISSING_NOTIFY_PARAMS"));
+    }
+
+    // Resolve notify class BEFORE modifying the asset
+    UClass* ResolvedNotifyClass = nullptr;
+    if (!NotifyClass.IsEmpty())
+    {
         FString FullClassName = NotifyClass;
         if (!FullClassName.StartsWith(TEXT("AnimNotify_")))
         {
             FullClassName = TEXT("AnimNotify_") + NotifyClass;
         }
-        
+
 #if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 1
-        UClass* NotifyUClass = FindFirstObject<UClass>(*FullClassName, EFindFirstObjectOptions::ExactClass);
+        ResolvedNotifyClass = FindFirstObject<UClass>(*FullClassName, EFindFirstObjectOptions::ExactClass);
 #else
-        // UE 5.0: Use ResolveClassByName instead of deprecated ANY_PACKAGE
-        UClass* NotifyUClass = ResolveClassByName(FullClassName);
+        ResolvedNotifyClass = ResolveClassByName(FullClassName);
 #endif
-        if (!NotifyUClass)
+        if (!ResolvedNotifyClass)
         {
-            NotifyUClass = UAnimNotify::StaticClass();
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 1
+            ResolvedNotifyClass = FindFirstObject<UClass>(*NotifyClass, EFindFirstObjectOptions::ExactClass);
+#else
+            ResolvedNotifyClass = ResolveClassByName(NotifyClass);
+#endif
         }
-        
-        // Validate that the class is not abstract - abstract classes cannot be instantiated
-        if (NotifyUClass && NotifyUClass->HasAnyClassFlags(CLASS_Abstract))
+
+        if (ResolvedNotifyClass && ResolvedNotifyClass->HasAnyClassFlags(CLASS_Abstract))
         {
             ANIM_ERROR_RESPONSE(
                 FString::Printf(TEXT("Cannot create AnimNotify: '%s' is an abstract class. Use a concrete subclass like AnimNotify_PlaySound or create a custom AnimNotify blueprint."), *FullClassName),
                 TEXT("ABSTRACT_CLASS_ERROR")
             );
         }
-        
-        // Calculate time from frame
-        float FrameRate = 30.0f;
-#if ENGINE_MAJOR_VERSION >= 5
-        if (UAnimSequence* Seq = Cast<UAnimSequence>(AnimAsset))
-        {
-            FrameRate = Seq->GetSamplingFrameRate().AsDecimal();
-        }
-#endif
-        float TriggerTime = static_cast<float>(Frame) / FrameRate;
-        
-        // Create notify
-        UAnimNotify* NewNotify = NewObject<UAnimNotify>(AnimAsset, NotifyUClass);
-        if (NewNotify)
-        {
-            FAnimNotifyEvent& NotifyEvent = AnimAsset->Notifies.AddDefaulted_GetRef();
-            NotifyEvent.Notify = NewNotify;
-            NotifyEvent.TriggerTimeOffset = TriggerTime;
-            NotifyEvent.TrackIndex = TrackIndex;
-            
-            if (!NotifyName.IsEmpty())
-            {
-                NotifyEvent.NotifyName = FName(*NotifyName);
-            }
-            
-            AnimAsset->RefreshCacheData();
-        }
-        
-        SaveAnimAsset(AnimAsset, bSave);
 
-        ANIM_SUCCESS_RESPONSE(TEXT("Notify added"));
-        McpHandlerUtils::AddVerification(Response, AnimAsset);
-        return Response;
+        if (!ResolvedNotifyClass)
+        {
+            ANIM_ERROR_RESPONSE(
+                FString::Printf(TEXT("AnimNotify class '%s' not found. Use a concrete subclass like AnimNotify_PlaySound or a custom AnimNotify blueprint."), *NotifyClass),
+                TEXT("CLASS_NOT_FOUND")
+            );
+        }
     }
 
-    if (SubAction == TEXT("add_notify_state"))
+    UAnimSequenceBase* AnimAsset = Cast<UAnimSequenceBase>(StaticLoadObject(UAnimSequenceBase::StaticClass(), nullptr, *AssetPath));
+    if (!AnimAsset)
     {
-        FString AssetPath = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("assetPath"), TEXT("")));
-        FString NotifyClass = GetStringFieldAnimAuth(Params, TEXT("notifyClass"), TEXT("AnimNotifyState"));
-        int32 StartFrame = static_cast<int32>(GetNumberFieldAnimAuth(Params, TEXT("startFrame"), 0));
-        int32 EndFrame = static_cast<int32>(GetNumberFieldAnimAuth(Params, TEXT("endFrame"), 10));
-        int32 TrackIndex = static_cast<int32>(GetNumberFieldAnimAuth(Params, TEXT("trackIndex"), 0));
-        FString NotifyName = GetStringFieldAnimAuth(Params, TEXT("notifyName"), TEXT(""));
-        bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
-        
-        UAnimSequenceBase* AnimAsset = Cast<UAnimSequenceBase>(StaticLoadObject(UAnimSequenceBase::StaticClass(), nullptr, *AssetPath));
-        if (!AnimAsset)
+        ANIM_ERROR_RESPONSE(FString::Printf(TEXT("Could not load animation asset: %s"), *AssetPath), TEXT("ASSET_NOT_FOUND"));
+    }
+
+    // Calculate time from frame
+    float FrameRate = 30.0f;
+#if ENGINE_MAJOR_VERSION >= 5
+    if (UAnimSequence* Seq = Cast<UAnimSequence>(AnimAsset))
+    {
+        FrameRate = Seq->GetSamplingFrameRate().AsDecimal();
+    }
+#endif
+    float TriggerTime = static_cast<float>(Frame) / FrameRate;
+
+    FAnimNotifyEvent& NotifyEvent = AnimAsset->Notifies.AddDefaulted_GetRef();
+    NotifyEvent.TriggerTimeOffset = TriggerTime;
+    NotifyEvent.TrackIndex = TrackIndex;
+
+    if (!NotifyName.IsEmpty())
+    {
+        NotifyEvent.NotifyName = FName(*NotifyName);
+    }
+
+    if (ResolvedNotifyClass)
+    {
+        UAnimNotify* NewNotify = NewObject<UAnimNotify>(AnimAsset, ResolvedNotifyClass);
+        if (!NewNotify)
         {
-            ANIM_ERROR_RESPONSE(FString::Printf(TEXT("Could not load animation asset: %s"), *AssetPath), TEXT("ASSET_NOT_FOUND"));
+            AnimAsset->Notifies.Pop();
+            ANIM_ERROR_RESPONSE(
+                FString::Printf(TEXT("Failed to create AnimNotify instance of class '%s'"), *NotifyClass),
+                TEXT("INSTANTIATION_FAILED")
+            );
         }
-        
-        // Find notify state class
+        NotifyEvent.Notify = NewNotify;
+    }
+
+	AnimAsset->RefreshCacheData();
+	SaveAnimAsset(AnimAsset, bSave);
+
+	ANIM_SUCCESS_RESPONSE(TEXT("Notify added"));
+	McpHandlerUtils::AddVerification(Response, AnimAsset);
+	return Response;
+}
+
+if (SubAction == TEXT("add_notify_state"))
+{
+	FString AssetPath = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("assetPath"), TEXT("")));
+    FString NotifyClass = GetStringFieldAnimAuth(Params, TEXT("notifyClass"), TEXT(""));
+    int32 StartFrame = static_cast<int32>(GetNumberFieldAnimAuth(Params, TEXT("startFrame"), 0));
+    int32 EndFrame = static_cast<int32>(GetNumberFieldAnimAuth(Params, TEXT("endFrame"), 10));
+    int32 TrackIndex = static_cast<int32>(GetNumberFieldAnimAuth(Params, TEXT("trackIndex"), 0));
+    FString NotifyName = GetStringFieldAnimAuth(Params, TEXT("notifyName"), TEXT(""));
+    bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
+
+    if (NotifyClass.IsEmpty() && NotifyName.IsEmpty())
+    {
+        ANIM_ERROR_RESPONSE(TEXT("At least one of notifyClass or notifyName is required"), TEXT("MISSING_NOTIFY_PARAMS"));
+    }
+
+    // Resolve notify state class BEFORE modifying the asset
+    UClass* ResolvedNotifyStateClass = nullptr;
+    if (!NotifyClass.IsEmpty())
+    {
         FString FullClassName = NotifyClass;
         if (!FullClassName.StartsWith(TEXT("AnimNotifyState_")))
         {
             FullClassName = TEXT("AnimNotifyState_") + NotifyClass;
         }
-        
+
 #if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 1
-        UClass* NotifyStateClass = FindFirstObject<UClass>(*FullClassName, EFindFirstObjectOptions::ExactClass);
+        ResolvedNotifyStateClass = FindFirstObject<UClass>(*FullClassName, EFindFirstObjectOptions::ExactClass);
 #else
-        // UE 5.0: Use ResolveClassByName instead of deprecated ANY_PACKAGE
-        UClass* NotifyStateClass = ResolveClassByName(FullClassName);
+        ResolvedNotifyStateClass = ResolveClassByName(FullClassName);
 #endif
-        if (!NotifyStateClass)
+        if (!ResolvedNotifyStateClass)
         {
-            NotifyStateClass = UAnimNotifyState::StaticClass();
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 1
+            ResolvedNotifyStateClass = FindFirstObject<UClass>(*NotifyClass, EFindFirstObjectOptions::ExactClass);
+#else
+            ResolvedNotifyStateClass = ResolveClassByName(NotifyClass);
+#endif
         }
-        
-        // Validate that the class is not abstract - abstract classes cannot be instantiated
-        if (NotifyStateClass && NotifyStateClass->HasAnyClassFlags(CLASS_Abstract))
+
+        if (ResolvedNotifyStateClass && ResolvedNotifyStateClass->HasAnyClassFlags(CLASS_Abstract))
         {
             ANIM_ERROR_RESPONSE(
                 FString::Printf(TEXT("Cannot create AnimNotifyState: '%s' is an abstract class. Use a concrete subclass like AnimNotifyState_PlayMontageNotify or create a custom AnimNotifyState blueprint."), *FullClassName),
                 TEXT("ABSTRACT_CLASS_ERROR")
             );
         }
-        
-        // Calculate times from frames
-        float FrameRate = 30.0f;
+
+        if (!ResolvedNotifyStateClass)
+        {
+            ANIM_ERROR_RESPONSE(
+                FString::Printf(TEXT("AnimNotifyState class '%s' not found. Use a concrete subclass like AnimNotifyState_PlayMontageNotify or a custom AnimNotifyState blueprint."), *NotifyClass),
+                TEXT("CLASS_NOT_FOUND")
+            );
+        }
+    }
+
+    UAnimSequenceBase* AnimAsset = Cast<UAnimSequenceBase>(StaticLoadObject(UAnimSequenceBase::StaticClass(), nullptr, *AssetPath));
+    if (!AnimAsset)
+    {
+        ANIM_ERROR_RESPONSE(FString::Printf(TEXT("Could not load animation asset: %s"), *AssetPath), TEXT("ASSET_NOT_FOUND"));
+    }
+
+    float FrameRate = 30.0f;
 #if ENGINE_MAJOR_VERSION >= 5
-        if (UAnimSequence* Seq = Cast<UAnimSequence>(AnimAsset))
-        {
-            FrameRate = Seq->GetSamplingFrameRate().AsDecimal();
-        }
+    if (UAnimSequence* Seq = Cast<UAnimSequence>(AnimAsset))
+    {
+        FrameRate = Seq->GetSamplingFrameRate().AsDecimal();
+    }
 #endif
-        float StartTime = static_cast<float>(StartFrame) / FrameRate;
-        float EndTime = static_cast<float>(EndFrame) / FrameRate;
-        float Duration = EndTime - StartTime;
-        
-        // Create notify state
-        UAnimNotifyState* NewNotifyState = NewObject<UAnimNotifyState>(AnimAsset, NotifyStateClass);
-        if (NewNotifyState)
+    float StartTime = static_cast<float>(StartFrame) / FrameRate;
+    float EndTime = static_cast<float>(EndFrame) / FrameRate;
+    float Duration = EndTime - StartTime;
+
+    FAnimNotifyEvent& NotifyEvent = AnimAsset->Notifies.AddDefaulted_GetRef();
+    NotifyEvent.TriggerTimeOffset = StartTime;
+    NotifyEvent.SetDuration(Duration);
+    NotifyEvent.TrackIndex = TrackIndex;
+
+    if (!NotifyName.IsEmpty())
+    {
+        NotifyEvent.NotifyName = FName(*NotifyName);
+    }
+
+    if (ResolvedNotifyStateClass)
+    {
+        UAnimNotifyState* NewNotifyState = NewObject<UAnimNotifyState>(AnimAsset, ResolvedNotifyStateClass);
+        if (!NewNotifyState)
         {
-            FAnimNotifyEvent& NotifyEvent = AnimAsset->Notifies.AddDefaulted_GetRef();
-            NotifyEvent.NotifyStateClass = NewNotifyState;
-            NotifyEvent.TriggerTimeOffset = StartTime;
-            NotifyEvent.SetDuration(Duration);
-            NotifyEvent.TrackIndex = TrackIndex;
-            
-            if (!NotifyName.IsEmpty())
-            {
-                NotifyEvent.NotifyName = FName(*NotifyName);
-            }
-            
-            AnimAsset->RefreshCacheData();
+            AnimAsset->Notifies.Pop();
+            ANIM_ERROR_RESPONSE(
+                FString::Printf(TEXT("Failed to create AnimNotifyState instance of class '%s'"), *NotifyClass),
+                TEXT("INSTANTIATION_FAILED")
+            );
         }
+        NotifyEvent.NotifyStateClass = NewNotifyState;
+    }
+
+	AnimAsset->RefreshCacheData();
         
         SaveAnimAsset(AnimAsset, bSave);
 
@@ -1284,24 +1327,28 @@ static TSharedPtr<FJsonObject> HandleAnimationAuthoringRequest(const TSharedPtr<
     
     if (SubAction == TEXT("create_montage"))
     {
-        FString Name = GetStringFieldAnimAuth(Params, TEXT("name"), TEXT(""));
-        FString Path = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("path"), TEXT("/Game/Animations")));
-        FString SkeletonPath = GetStringFieldAnimAuth(Params, TEXT("skeletonPath"), TEXT(""));
-        FString SlotName = GetStringFieldAnimAuth(Params, TEXT("slotName"), TEXT("DefaultSlot"));
-        bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
-        
-        if (Name.IsEmpty())
-        {
-            ANIM_ERROR_RESPONSE(TEXT("Name is required"), TEXT("MISSING_NAME"));
-        }
-        
-        USkeleton* Skeleton = LoadSkeletonFromPathAnim(SkeletonPath);
+    FString Name = GetStringFieldAnimAuth(Params, TEXT("name"), TEXT(""));
+    FString Path = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("path"), TEXT("/Game/Animations")));
+    FString SkeletonPath = GetStringFieldAnimAuth(Params, TEXT("skeletonPath"), TEXT(""));
+    FString SlotName = GetStringFieldAnimAuth(Params, TEXT("slotName"), TEXT("DefaultSlot"));
+    bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
+
+    if (Name.IsEmpty())
+    {
+        ANIM_ERROR_RESPONSE(TEXT("Name is required"), TEXT("MISSING_NAME"));
+    }
+
+    USkeleton* Skeleton = nullptr;
+    if (!SkeletonPath.IsEmpty())
+    {
+        Skeleton = LoadSkeletonFromPathAnim(SkeletonPath);
         if (!Skeleton)
         {
             ANIM_ERROR_RESPONSE(FString::Printf(TEXT("Could not load skeleton: %s"), *SkeletonPath), TEXT("SKELETON_NOT_FOUND"));
         }
-        
-        // Create package and asset directly to avoid UI dialogs
+    }
+
+    // Create package and asset directly to avoid UI dialogs
         FString PackagePath = Path / Name;
         UPackage* Package = CreatePackage(*PackagePath);
         if (!Package)
@@ -1460,80 +1507,109 @@ static TSharedPtr<FJsonObject> HandleAnimationAuthoringRequest(const TSharedPtr<
         return Response;
     }
 
-    if (SubAction == TEXT("add_montage_notify"))
+if (SubAction == TEXT("add_montage_notify"))
+{
+	FString AssetPath = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("assetPath"), TEXT("")));
+    FString NotifyClass = GetStringFieldAnimAuth(Params, TEXT("notifyClass"), TEXT(""));
+    float Time = static_cast<float>(GetNumberFieldAnimAuth(Params, TEXT("time"), 0.0));
+    int32 TrackIndex = static_cast<int32>(GetNumberFieldAnimAuth(Params, TEXT("trackIndex"), 0));
+    FString NotifyName = GetStringFieldAnimAuth(Params, TEXT("notifyName"), TEXT(""));
+    bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
+
+    if (NotifyClass.IsEmpty() && NotifyName.IsEmpty())
     {
-        // Similar to add_notify but for montages
-        FString AssetPath = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("assetPath"), TEXT("")));
-        FString NotifyClass = GetStringFieldAnimAuth(Params, TEXT("notifyClass"), TEXT("AnimNotify"));
-        float Time = static_cast<float>(GetNumberFieldAnimAuth(Params, TEXT("time"), 0.0));
-        int32 TrackIndex = static_cast<int32>(GetNumberFieldAnimAuth(Params, TEXT("trackIndex"), 0));
-        FString NotifyName = GetStringFieldAnimAuth(Params, TEXT("notifyName"), TEXT(""));
-        bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
-        
-        UAnimMontage* Montage = Cast<UAnimMontage>(StaticLoadObject(UAnimMontage::StaticClass(), nullptr, *AssetPath));
-        if (!Montage)
-        {
-            ANIM_ERROR_RESPONSE(FString::Printf(TEXT("Could not load montage: %s"), *AssetPath), TEXT("MONTAGE_NOT_FOUND"));
-        }
-        
-        // Find notify class
+        ANIM_ERROR_RESPONSE(TEXT("At least one of notifyClass or notifyName is required"), TEXT("MISSING_NOTIFY_PARAMS"));
+    }
+
+    // Resolve notify class BEFORE modifying the asset
+    UClass* ResolvedNotifyClass = nullptr;
+    if (!NotifyClass.IsEmpty())
+    {
         FString FullClassName = NotifyClass;
         if (!FullClassName.StartsWith(TEXT("AnimNotify_")))
         {
             FullClassName = TEXT("AnimNotify_") + NotifyClass;
         }
-        
-#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 1
-        UClass* NotifyUClass = FindFirstObject<UClass>(*FullClassName, EFindFirstObjectOptions::ExactClass);
-#else
-        // UE 5.0: Use ResolveClassByName instead of deprecated ANY_PACKAGE
-        UClass* NotifyUClass = ResolveClassByName(FullClassName);
-#endif
-        if (!NotifyUClass)
-        {
-            NotifyUClass = UAnimNotify::StaticClass();
-        }
-        
-        // Ensure notify track exists BEFORE creating the notify
-        // This prevents the ensure/debugbreak in RefreshCacheData() when validating notify track indices
-        // The engine's RefreshCacheData() uses WITH_EDITOR, so we use the same guard here
-#if WITH_EDITOR
-        if (TrackIndex >= 0)
-        {
-            // Ensure we have enough tracks for the requested TrackIndex
-            // Use the engine's exact approach: FAnimNotifyTrack(Name, Color)
-            while (!Montage->AnimNotifyTracks.IsValidIndex(TrackIndex))
-            {
-                const int32 NewTrackIndex = Montage->AnimNotifyTracks.Add(
-                    FAnimNotifyTrack(*FString::FromInt(Montage->AnimNotifyTracks.Num() + 1), FLinearColor::White)
-                );
-            }
-        }
-#endif
-        
-        // Create notify
-        UAnimNotify* NewNotify = NewObject<UAnimNotify>(Montage, NotifyUClass);
-        if (NewNotify)
-        {
-            FAnimNotifyEvent& NotifyEvent = Montage->Notifies.AddDefaulted_GetRef();
-            NotifyEvent.Notify = NewNotify;
-            NotifyEvent.TriggerTimeOffset = Time;
-            NotifyEvent.TrackIndex = TrackIndex;
-            
-            if (!NotifyName.IsEmpty())
-            {
-                NotifyEvent.NotifyName = FName(*NotifyName);
-            }
-            
-            Montage->RefreshCacheData();
-        }
-        
-        SaveAnimAsset(Montage, bSave);
 
-        ANIM_SUCCESS_RESPONSE(TEXT("Montage notify added"));
-        McpHandlerUtils::AddVerification(Response, Montage);
-        return Response;
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 1
+        ResolvedNotifyClass = FindFirstObject<UClass>(*FullClassName, EFindFirstObjectOptions::ExactClass);
+#else
+        ResolvedNotifyClass = ResolveClassByName(FullClassName);
+#endif
+        if (!ResolvedNotifyClass)
+        {
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 1
+            ResolvedNotifyClass = FindFirstObject<UClass>(*NotifyClass, EFindFirstObjectOptions::ExactClass);
+#else
+            ResolvedNotifyClass = ResolveClassByName(NotifyClass);
+#endif
+        }
+
+        if (ResolvedNotifyClass && ResolvedNotifyClass->HasAnyClassFlags(CLASS_Abstract))
+        {
+            ANIM_ERROR_RESPONSE(
+                FString::Printf(TEXT("Cannot create AnimNotify: '%s' is an abstract class. Use a concrete subclass like AnimNotify_PlaySound or create a custom AnimNotify blueprint."), *FullClassName),
+                TEXT("ABSTRACT_CLASS_ERROR")
+            );
+        }
+
+        if (!ResolvedNotifyClass)
+        {
+            ANIM_ERROR_RESPONSE(
+                FString::Printf(TEXT("AnimNotify class '%s' not found. Use a concrete subclass like AnimNotify_PlaySound or a custom AnimNotify blueprint."), *NotifyClass),
+                TEXT("CLASS_NOT_FOUND")
+            );
+        }
     }
+
+    UAnimMontage* Montage = Cast<UAnimMontage>(StaticLoadObject(UAnimMontage::StaticClass(), nullptr, *AssetPath));
+    if (!Montage)
+    {
+        ANIM_ERROR_RESPONSE(FString::Printf(TEXT("Could not load montage: %s"), *AssetPath), TEXT("MONTAGE_NOT_FOUND"));
+    }
+
+#if WITH_EDITOR
+    if (TrackIndex >= 0)
+    {
+        while (!Montage->AnimNotifyTracks.IsValidIndex(TrackIndex))
+        {
+            Montage->AnimNotifyTracks.Add(
+                FAnimNotifyTrack(*FString::FromInt(Montage->AnimNotifyTracks.Num() + 1), FLinearColor::White)
+            );
+        }
+    }
+#endif
+
+    FAnimNotifyEvent& NotifyEvent = Montage->Notifies.AddDefaulted_GetRef();
+    NotifyEvent.TriggerTimeOffset = Time;
+    NotifyEvent.TrackIndex = TrackIndex;
+
+    if (!NotifyName.IsEmpty())
+    {
+        NotifyEvent.NotifyName = FName(*NotifyName);
+    }
+
+    if (ResolvedNotifyClass)
+    {
+        UAnimNotify* NewNotify = NewObject<UAnimNotify>(Montage, ResolvedNotifyClass);
+        if (!NewNotify)
+        {
+            Montage->Notifies.Pop();
+            ANIM_ERROR_RESPONSE(
+                FString::Printf(TEXT("Failed to create AnimNotify instance of class '%s'"), *NotifyClass),
+                TEXT("INSTANTIATION_FAILED")
+            );
+        }
+        NotifyEvent.Notify = NewNotify;
+    }
+
+	Montage->RefreshCacheData();
+	SaveAnimAsset(Montage, bSave);
+
+	ANIM_SUCCESS_RESPONSE(TEXT("Montage notify added"));
+	McpHandlerUtils::AddVerification(Response, Montage);
+	return Response;
+}
 
     if (SubAction == TEXT("set_blend_in"))
     {
@@ -1645,26 +1721,30 @@ static TSharedPtr<FJsonObject> HandleAnimationAuthoringRequest(const TSharedPtr<
     if (SubAction == TEXT("create_blend_space_1d"))
     {
 #if MCP_HAS_BLENDSPACE_FACTORY
-        FString Name = GetStringFieldAnimAuth(Params, TEXT("name"), TEXT(""));
-        FString Path = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("path"), TEXT("/Game/Animations")));
-        FString SkeletonPath = GetStringFieldAnimAuth(Params, TEXT("skeletonPath"), TEXT(""));
-        FString AxisName = GetStringFieldAnimAuth(Params, TEXT("axisName"), TEXT("Speed"));
-        float AxisMin = static_cast<float>(GetNumberFieldAnimAuth(Params, TEXT("axisMin"), 0.0));
-        float AxisMax = static_cast<float>(GetNumberFieldAnimAuth(Params, TEXT("axisMax"), 600.0));
-        bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
-        
-        if (Name.IsEmpty())
-        {
-            ANIM_ERROR_RESPONSE(TEXT("Name is required"), TEXT("MISSING_NAME"));
-        }
-        
-        USkeleton* Skeleton = LoadSkeletonFromPathAnim(SkeletonPath);
+    FString Name = GetStringFieldAnimAuth(Params, TEXT("name"), TEXT(""));
+    FString Path = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("path"), TEXT("/Game/Animations")));
+    FString SkeletonPath = GetStringFieldAnimAuth(Params, TEXT("skeletonPath"), TEXT(""));
+    FString AxisName = GetStringFieldAnimAuth(Params, TEXT("axisName"), TEXT("Speed"));
+    float AxisMin = static_cast<float>(GetNumberFieldAnimAuth(Params, TEXT("axisMin"), 0.0));
+    float AxisMax = static_cast<float>(GetNumberFieldAnimAuth(Params, TEXT("axisMax"), 600.0));
+    bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
+
+    if (Name.IsEmpty())
+    {
+        ANIM_ERROR_RESPONSE(TEXT("Name is required"), TEXT("MISSING_NAME"));
+    }
+
+    USkeleton* Skeleton = nullptr;
+    if (!SkeletonPath.IsEmpty())
+    {
+        Skeleton = LoadSkeletonFromPathAnim(SkeletonPath);
         if (!Skeleton)
         {
             ANIM_ERROR_RESPONSE(FString::Printf(TEXT("Could not load skeleton: %s"), *SkeletonPath), TEXT("SKELETON_NOT_FOUND"));
         }
-        
-        // Check if an asset already exists at the target path to prevent modal dialog
+    }
+
+    // Check if an asset already exists at the target path to prevent modal dialog
         FString ObjectPath = FString::Printf(TEXT("%s/%s"), *Path, *Name);
         if (UEditorAssetLibrary::DoesAssetExist(ObjectPath))
         {
@@ -1748,29 +1828,33 @@ static TSharedPtr<FJsonObject> HandleAnimationAuthoringRequest(const TSharedPtr<
     if (SubAction == TEXT("create_blend_space_2d"))
     {
 #if MCP_HAS_BLENDSPACE_FACTORY
-        FString Name = GetStringFieldAnimAuth(Params, TEXT("name"), TEXT(""));
-        FString Path = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("path"), TEXT("/Game/Animations")));
-        FString SkeletonPath = GetStringFieldAnimAuth(Params, TEXT("skeletonPath"), TEXT(""));
-        FString HorizontalAxisName = GetStringFieldAnimAuth(Params, TEXT("horizontalAxisName"), TEXT("Direction"));
-        float HorizontalMin = static_cast<float>(GetNumberFieldAnimAuth(Params, TEXT("horizontalMin"), -180.0));
-        float HorizontalMax = static_cast<float>(GetNumberFieldAnimAuth(Params, TEXT("horizontalMax"), 180.0));
-        FString VerticalAxisName = GetStringFieldAnimAuth(Params, TEXT("verticalAxisName"), TEXT("Speed"));
-        float VerticalMin = static_cast<float>(GetNumberFieldAnimAuth(Params, TEXT("verticalMin"), 0.0));
-        float VerticalMax = static_cast<float>(GetNumberFieldAnimAuth(Params, TEXT("verticalMax"), 600.0));
-        bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
-        
-        if (Name.IsEmpty())
-        {
-            ANIM_ERROR_RESPONSE(TEXT("Name is required"), TEXT("MISSING_NAME"));
-        }
-        
-        USkeleton* Skeleton = LoadSkeletonFromPathAnim(SkeletonPath);
+    FString Name = GetStringFieldAnimAuth(Params, TEXT("name"), TEXT(""));
+    FString Path = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("path"), TEXT("/Game/Animations")));
+    FString SkeletonPath = GetStringFieldAnimAuth(Params, TEXT("skeletonPath"), TEXT(""));
+    FString HorizontalAxisName = GetStringFieldAnimAuth(Params, TEXT("horizontalAxisName"), TEXT("Direction"));
+    float HorizontalMin = static_cast<float>(GetNumberFieldAnimAuth(Params, TEXT("horizontalMin"), -180.0));
+    float HorizontalMax = static_cast<float>(GetNumberFieldAnimAuth(Params, TEXT("horizontalMax"), 180.0));
+    FString VerticalAxisName = GetStringFieldAnimAuth(Params, TEXT("verticalAxisName"), TEXT("Speed"));
+    float VerticalMin = static_cast<float>(GetNumberFieldAnimAuth(Params, TEXT("verticalMin"), 0.0));
+    float VerticalMax = static_cast<float>(GetNumberFieldAnimAuth(Params, TEXT("verticalMax"), 600.0));
+    bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
+
+    if (Name.IsEmpty())
+    {
+        ANIM_ERROR_RESPONSE(TEXT("Name is required"), TEXT("MISSING_NAME"));
+    }
+
+    USkeleton* Skeleton = nullptr;
+    if (!SkeletonPath.IsEmpty())
+    {
+        Skeleton = LoadSkeletonFromPathAnim(SkeletonPath);
         if (!Skeleton)
         {
             ANIM_ERROR_RESPONSE(FString::Printf(TEXT("Could not load skeleton: %s"), *SkeletonPath), TEXT("SKELETON_NOT_FOUND"));
         }
-        
-        // Check if an asset already exists at the target path to prevent modal dialog
+    }
+
+    // Check if an asset already exists at the target path to prevent modal dialog
         FString ObjectPath = FString::Printf(TEXT("%s/%s"), *Path, *Name);
         if (UEditorAssetLibrary::DoesAssetExist(ObjectPath))
         {
@@ -1982,23 +2066,27 @@ static TSharedPtr<FJsonObject> HandleAnimationAuthoringRequest(const TSharedPtr<
     if (SubAction == TEXT("create_aim_offset"))
     {
 #if MCP_HAS_BLENDSPACE_FACTORY
-        FString Name = GetStringFieldAnimAuth(Params, TEXT("name"), TEXT(""));
-        FString Path = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("path"), TEXT("/Game/Animations")));
-        FString SkeletonPath = GetStringFieldAnimAuth(Params, TEXT("skeletonPath"), TEXT(""));
-        bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
-        
-        if (Name.IsEmpty())
-        {
-            ANIM_ERROR_RESPONSE(TEXT("Name is required"), TEXT("MISSING_NAME"));
-        }
-        
-        USkeleton* Skeleton = LoadSkeletonFromPathAnim(SkeletonPath);
+    FString Name = GetStringFieldAnimAuth(Params, TEXT("name"), TEXT(""));
+    FString Path = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("path"), TEXT("/Game/Animations")));
+    FString SkeletonPath = GetStringFieldAnimAuth(Params, TEXT("skeletonPath"), TEXT(""));
+    bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
+
+    if (Name.IsEmpty())
+    {
+        ANIM_ERROR_RESPONSE(TEXT("Name is required"), TEXT("MISSING_NAME"));
+    }
+
+    USkeleton* Skeleton = nullptr;
+    if (!SkeletonPath.IsEmpty())
+    {
+        Skeleton = LoadSkeletonFromPathAnim(SkeletonPath);
         if (!Skeleton)
         {
             ANIM_ERROR_RESPONSE(FString::Printf(TEXT("Could not load skeleton: %s"), *SkeletonPath), TEXT("SKELETON_NOT_FOUND"));
         }
-        
-        // Create package and asset directly to avoid UI dialogs
+    }
+
+    // Create package and asset directly to avoid UI dialogs
         FString PackagePath = Path / Name;
         UPackage* Package = CreatePackage(*PackagePath);
         if (!Package)
@@ -2087,24 +2175,28 @@ static TSharedPtr<FJsonObject> HandleAnimationAuthoringRequest(const TSharedPtr<
     
     if (SubAction == TEXT("create_anim_blueprint"))
     {
-        FString Name = GetStringFieldAnimAuth(Params, TEXT("name"), TEXT(""));
-        FString Path = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("path"), TEXT("/Game/Blueprints")));
-        FString SkeletonPath = GetStringFieldAnimAuth(Params, TEXT("skeletonPath"), TEXT(""));
-        FString ParentClass = GetStringFieldAnimAuth(Params, TEXT("parentClass"), TEXT("AnimInstance"));
-        bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
-        
-        if (Name.IsEmpty())
-        {
-            ANIM_ERROR_RESPONSE(TEXT("Name is required"), TEXT("MISSING_NAME"));
-        }
-        
-        USkeleton* Skeleton = LoadSkeletonFromPathAnim(SkeletonPath);
+    FString Name = GetStringFieldAnimAuth(Params, TEXT("name"), TEXT(""));
+    FString Path = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("path"), TEXT("/Game/Blueprints")));
+    FString SkeletonPath = GetStringFieldAnimAuth(Params, TEXT("skeletonPath"), TEXT(""));
+    FString ParentClass = GetStringFieldAnimAuth(Params, TEXT("parentClass"), TEXT("AnimInstance"));
+    bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
+
+    if (Name.IsEmpty())
+    {
+        ANIM_ERROR_RESPONSE(TEXT("Name is required"), TEXT("MISSING_NAME"));
+    }
+
+    USkeleton* Skeleton = nullptr;
+    if (!SkeletonPath.IsEmpty())
+    {
+        Skeleton = LoadSkeletonFromPathAnim(SkeletonPath);
         if (!Skeleton)
         {
             ANIM_ERROR_RESPONSE(FString::Printf(TEXT("Could not load skeleton: %s"), *SkeletonPath), TEXT("SKELETON_NOT_FOUND"));
         }
-        
-        // Check if an asset already exists at the target path to prevent assertion failure in Kismet2.cpp
+    }
+
+    // Check if an asset already exists at the target path to prevent assertion failure in Kismet2.cpp
         FString ObjectPath = FString::Printf(TEXT("%s/%s"), *Path, *Name);
         if (UEditorAssetLibrary::DoesAssetExist(ObjectPath))
         {
@@ -3032,37 +3124,47 @@ static TSharedPtr<FJsonObject> HandleAnimationAuthoringRequest(const TSharedPtr<
 // ControlRig factory static methods (CreateNewControlRigAsset, CreateControlRigFromSkeletalMeshOrSkeleton)
 // are only available in UE 5.5+ where ControlRigBlueprintFactory.h is in Public folder
 #if MCP_HAS_CONTROLRIG_FACTORY && MCP_HAS_CONTROLRIG_BLUEPRINT && ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5
-        FString Name = GetStringFieldAnimAuth(Params, TEXT("name"), TEXT(""));
-        FString Path = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("path"), TEXT("/Game/ControlRigs")));
-        FString SkeletalMeshPath = GetStringFieldAnimAuth(Params, TEXT("skeletalMeshPath"), TEXT(""));
-        bool bModularRig = GetBoolFieldAnimAuth(Params, TEXT("modularRig"), false);
-        bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
-        
-        if (Name.IsEmpty())
-        {
-            ANIM_ERROR_RESPONSE(TEXT("Name is required"), TEXT("MISSING_NAME"));
-        }
-        
-        UControlRigBlueprint* ControlRigBP = nullptr;
-        FString FullPath = Path / Name;
-        
-        // If skeletal mesh provided, create from it; otherwise create empty
-        if (!SkeletalMeshPath.IsEmpty())
-        {
-            USkeletalMesh* SkeletalMesh = LoadSkeletalMeshFromPathAnim(SkeletalMeshPath);
-            if (!SkeletalMesh)
-            {
-                ANIM_ERROR_RESPONSE(FString::Printf(TEXT("Could not load skeletal mesh: %s"), *SkeletalMeshPath), TEXT("SKELETAL_MESH_NOT_FOUND"));
-            }
-            
-            // Use static factory method to create from skeletal mesh (UE 5.5+ only)
-            ControlRigBP = UControlRigBlueprintFactory::CreateControlRigFromSkeletalMeshOrSkeleton(SkeletalMesh, bModularRig);
-        }
-        else
-        {
-            // Create empty control rig at specified path (UE 5.5+ only)
-            ControlRigBP = UControlRigBlueprintFactory::CreateNewControlRigAsset(FullPath, bModularRig);
-        }
+	FString Name = GetStringFieldAnimAuth(Params, TEXT("name"), TEXT(""));
+	FString Path = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("path"), TEXT("/Game/ControlRigs")));
+	FString SkeletalMeshPath = GetStringFieldAnimAuth(Params, TEXT("skeletalMeshPath"), TEXT(""));
+	FString SkeletonPath = GetStringFieldAnimAuth(Params, TEXT("skeletonPath"), TEXT(""));
+	bool bModularRig = GetBoolFieldAnimAuth(Params, TEXT("modularRig"), false);
+	bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
+
+	if (Name.IsEmpty())
+	{
+		ANIM_ERROR_RESPONSE(TEXT("Name is required"), TEXT("MISSING_NAME"));
+	}
+
+	UControlRigBlueprint* ControlRigBP = nullptr;
+	FString FullPath = Path / Name;
+
+	UObject* SelectedObject = nullptr;
+	if (!SkeletalMeshPath.IsEmpty())
+	{
+		SelectedObject = LoadSkeletalMeshFromPathAnim(SkeletalMeshPath);
+		if (!SelectedObject)
+		{
+			ANIM_ERROR_RESPONSE(FString::Printf(TEXT("Could not load skeletal mesh: %s"), *SkeletalMeshPath), TEXT("SKELETAL_MESH_NOT_FOUND"));
+		}
+	}
+	else if (!SkeletonPath.IsEmpty())
+	{
+		SelectedObject = LoadObject<USkeleton>(nullptr, *SkeletonPath);
+		if (!SelectedObject)
+		{
+			ANIM_ERROR_RESPONSE(FString::Printf(TEXT("Could not load skeleton: %s"), *SkeletonPath), TEXT("SKELETON_NOT_FOUND"));
+		}
+	}
+
+	if (SelectedObject)
+	{
+		ControlRigBP = UControlRigBlueprintFactory::CreateControlRigFromSkeletalMeshOrSkeleton(SelectedObject, bModularRig);
+	}
+	else
+	{
+		ControlRigBP = UControlRigBlueprintFactory::CreateNewControlRigAsset(FullPath, bModularRig);
+	}
         
         if (!ControlRigBP)
         {
@@ -3083,26 +3185,27 @@ static TSharedPtr<FJsonObject> HandleAnimationAuthoringRequest(const TSharedPtr<
         FString Name = GetStringFieldAnimAuth(Params, TEXT("name"), TEXT(""));
         FString Path = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("path"), TEXT("/Game/ControlRigs")));
         FString SkeletalMeshPath = GetStringFieldAnimAuth(Params, TEXT("skeletalMeshPath"), TEXT(""));
-        
+        FString SkeletonPath = GetStringFieldAnimAuth(Params, TEXT("skeletonPath"), TEXT(""));
+
         if (Name.IsEmpty())
         {
             ANIM_ERROR_RESPONSE(TEXT("Name is required"), TEXT("MISSING_NAME"));
         }
-        
+
         FString FullPath = Path / Name;
-        
+
         // Create Control Rig Blueprint using FKismetEditorUtilities (works in all UE 5.x versions)
         FString FullPackageName = Path / Name;
-        
+
         // Create the package
         UPackage* Package = CreatePackage(*FullPackageName);
         if (!Package)
         {
             ANIM_ERROR_RESPONSE(FString::Printf(TEXT("Failed to create package: %s"), *FullPackageName), TEXT("PACKAGE_CREATE_FAILED"));
         }
-        
+
         Package->FullyLoad();
-        
+
         // Create the Control Rig Blueprint using FKismetEditorUtilities
         UControlRigBlueprint* ControlRigBP = Cast<UControlRigBlueprint>(
             FKismetEditorUtilities::CreateBlueprint(
@@ -3118,19 +3221,31 @@ static TSharedPtr<FJsonObject> HandleAnimationAuthoringRequest(const TSharedPtr<
                 UControlRigBlueprintGeneratedClass::StaticClass(),
 #endif
                 NAME_None));
-        
+
         if (!ControlRigBP)
         {
             ANIM_ERROR_RESPONSE(TEXT("Failed to create Control Rig Blueprint"), TEXT("CREATION_FAILED"));
         }
-        
-        // Set the target skeleton if provided (via skeletal mesh)
+
+        // Set the target skeleton if provided (via skeletal mesh or skeleton path)
         if (!SkeletalMeshPath.IsEmpty())
         {
             USkeletalMesh* SkeletalMesh = LoadSkeletalMeshFromPathAnim(SkeletalMeshPath);
             if (SkeletalMesh && SkeletalMesh->GetSkeleton())
             {
                 USkeletalMesh* PreviewMesh = SkeletalMesh->GetSkeleton()->GetPreviewMesh();
+                if (PreviewMesh)
+                {
+                    ControlRigBP->SetPreviewMesh(PreviewMesh);
+                }
+            }
+        }
+        else if (!SkeletonPath.IsEmpty())
+        {
+            USkeleton* Skeleton = LoadObject<USkeleton>(nullptr, *SkeletonPath);
+            if (Skeleton)
+            {
+                USkeletalMesh* PreviewMesh = Skeleton->GetPreviewMesh();
                 if (PreviewMesh)
                 {
                     ControlRigBP->SetPreviewMesh(PreviewMesh);
@@ -3224,72 +3339,87 @@ static TSharedPtr<FJsonObject> HandleAnimationAuthoringRequest(const TSharedPtr<
     
     // ===== 10.6 Retargeting =====
     
-    if (SubAction == TEXT("create_ik_rig"))
-    {
+if (SubAction == TEXT("create_ik_rig"))
+{
 #if MCP_HAS_IKRIG_FACTORY && MCP_HAS_IKRIG
-        FString Name = GetStringFieldAnimAuth(Params, TEXT("name"), TEXT(""));
-        FString Path = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("path"), TEXT("/Game/Retargeting")));
-        FString SkeletalMeshPath = GetStringFieldAnimAuth(Params, TEXT("skeletalMeshPath"), TEXT(""));
-        bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
-        
-        if (Name.IsEmpty())
-        {
-            ANIM_ERROR_RESPONSE(TEXT("Name is required"), TEXT("MISSING_NAME"));
-        }
-        
-// Use static factory method to create IK Rig (UE 5.1+) or fallback to NewObject (UE 5.0)
-#if MCP_HAS_IKRIG_CREATE_NEW_ASSET
-UIKRigDefinition* IKRig = MCP_IKRIG_CREATE_NEW_ASSET(Path, Name);
-#else
-// UE 5.0: Create using NewObject since CreateNewIKRigAsset doesn't exist
-UPackage* Package = CreatePackage(*FString(Path / Name));
-if (!Package)
-{
-ANIM_ERROR_RESPONSE(TEXT("Failed to create package for IK Rig"), TEXT("PACKAGE_FAILED"));
-}
-UIKRigDefinition* IKRig = NewObject<UIKRigDefinition>(Package, *Name, RF_Public | RF_Standalone);
-if (!IKRig)
-{
-ANIM_ERROR_RESPONSE(TEXT("Failed to create IK Rig asset"), TEXT("CREATION_FAILED"));
-}
-// Mark the package as needing save
-Package->MarkPackageDirty();
-#endif
-        
-        if (!IKRig)
-        {
-            ANIM_ERROR_RESPONSE(TEXT("Failed to create IK Rig asset"), TEXT("CREATION_FAILED"));
-        }
-        
-        // If skeletal mesh path provided, set the preview mesh
-        if (!SkeletalMeshPath.IsEmpty())
-        {
-            USkeletalMesh* SkeletalMesh = LoadSkeletalMeshFromPathAnim(SkeletalMeshPath);
-            if (SkeletalMesh)
-            {
-                IKRig->SetPreviewMesh(SkeletalMesh);
-            }
-        }
-        
-        if (!SaveAnimAsset(IKRig, bSave))
-        {
-            ANIM_ERROR_RESPONSE(TEXT("Failed to save IK Rig asset"), TEXT("SAVE_FAILED"));
-        }
-        
-        Response->SetStringField(TEXT("assetPath"), IKRig->GetPathName());
-        ANIM_SUCCESS_RESPONSE(FString::Printf(TEXT("IK Rig '%s' created successfully"), *Name));
-#elif MCP_HAS_IKRIG
-        // Factory not available, fall back to informative message
-        FString Name = GetStringFieldAnimAuth(Params, TEXT("name"), TEXT(""));
-        FString Path = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("path"), TEXT("/Game/Retargeting")));
-        FString FullPath = Path / Name;
-        Response->SetStringField(TEXT("assetPath"), FullPath);
-        ANIM_SUCCESS_RESPONSE(FString::Printf(TEXT("IK Rig '%s' creation requires IKRigEditor module"), *Name));
-#else
-        ANIM_ERROR_RESPONSE(TEXT("IK Rig module not available"), TEXT("NOT_SUPPORTED"));
-#endif
-        return Response;
+    FString Name = GetStringFieldAnimAuth(Params, TEXT("name"), TEXT(""));
+    FString Path = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("path"), TEXT("/Game/Retargeting")));
+    FString SkeletalMeshPath = GetStringFieldAnimAuth(Params, TEXT("skeletalMeshPath"), TEXT(""));
+    FString SkeletonPath = GetStringFieldAnimAuth(Params, TEXT("skeletonPath"), TEXT(""));
+    bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
+
+    if (Name.IsEmpty())
+    {
+        ANIM_ERROR_RESPONSE(TEXT("Name is required"), TEXT("MISSING_NAME"));
     }
+
+    // Use static factory method to create IK Rig (UE 5.1+) or fallback to NewObject (UE 5.0)
+#if MCP_HAS_IKRIG_CREATE_NEW_ASSET
+    UIKRigDefinition* IKRig = MCP_IKRIG_CREATE_NEW_ASSET(Path, Name);
+#else
+    // UE 5.0: Create using NewObject since CreateNewIKRigAsset doesn't exist
+    UPackage* Package = CreatePackage(*FString(Path / Name));
+    if (!Package)
+    {
+        ANIM_ERROR_RESPONSE(TEXT("Failed to create package for IK Rig"), TEXT("PACKAGE_FAILED"));
+    }
+    UIKRigDefinition* IKRig = NewObject<UIKRigDefinition>(Package, *Name, RF_Public | RF_Standalone);
+    if (!IKRig)
+    {
+        ANIM_ERROR_RESPONSE(TEXT("Failed to create IK Rig asset"), TEXT("CREATION_FAILED"));
+    }
+    // Mark the package as needing save
+    Package->MarkPackageDirty();
+#endif
+
+    if (!IKRig)
+    {
+        ANIM_ERROR_RESPONSE(TEXT("Failed to create IK Rig asset"), TEXT("CREATION_FAILED"));
+    }
+
+    // If skeletal mesh path provided, set the preview mesh
+    if (!SkeletalMeshPath.IsEmpty())
+    {
+        USkeletalMesh* SkeletalMesh = LoadSkeletalMeshFromPathAnim(SkeletalMeshPath);
+        if (SkeletalMesh)
+        {
+            IKRig->SetPreviewMesh(SkeletalMesh);
+        }
+    }
+    // Also support skeletonPath: load skeleton and set its preview mesh on the IK Rig
+    else if (!SkeletonPath.IsEmpty())
+    {
+        USkeleton* Skeleton = LoadObject<USkeleton>(nullptr, *SkeletonPath);
+        if (Skeleton)
+        {
+            USkeletalMesh* PreviewMesh = Skeleton->GetPreviewMesh();
+            if (PreviewMesh)
+            {
+                IKRig->SetPreviewMesh(PreviewMesh);
+            }
+            Response->SetStringField(TEXT("skeletonPath"), Skeleton->GetPathName());
+        }
+    }
+
+    if (!SaveAnimAsset(IKRig, bSave))
+    {
+        ANIM_ERROR_RESPONSE(TEXT("Failed to save IK Rig asset"), TEXT("SAVE_FAILED"));
+    }
+
+    Response->SetStringField(TEXT("assetPath"), IKRig->GetPathName());
+    ANIM_SUCCESS_RESPONSE(FString::Printf(TEXT("IK Rig '%s' created successfully"), *Name));
+#elif MCP_HAS_IKRIG
+    // Factory not available, fall back to informative message
+    FString Name = GetStringFieldAnimAuth(Params, TEXT("name"), TEXT(""));
+    FString Path = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("path"), TEXT("/Game/Retargeting")));
+    FString FullPath = Path / Name;
+    Response->SetStringField(TEXT("assetPath"), FullPath);
+    ANIM_SUCCESS_RESPONSE(FString::Printf(TEXT("IK Rig '%s' creation requires IKRigEditor module"), *Name));
+#else
+    ANIM_ERROR_RESPONSE(TEXT("IK Rig module not available"), TEXT("NOT_SUPPORTED"));
+#endif
+    return Response;
+}
     
     if (SubAction == TEXT("add_ik_chain"))
     {

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_AnimationAuthoringHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_AnimationAuthoringHandlers.cpp
@@ -738,39 +738,39 @@ static TSharedPtr<FJsonObject> HandleAnimationAuthoringRequest(const TSharedPtr<
         }
         
 #if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 1
-	// UE 5.1+ uses IAnimationDataController with IsValidBoneTrackName and AddBoneCurve
-	IAnimationDataController& Controller = Sequence->GetController();
+        // UE 5.1+ uses IAnimationDataController with IsValidBoneTrackName and AddBoneCurve
+        IAnimationDataController& Controller = Sequence->GetController();
 
-	// Validate the controller model is available
-	if (!Controller.GetModel())
-	{
-		ANIM_ERROR_RESPONSE(
-			TEXT("Animation data model is not available - cannot add bone track"),
-			TEXT("MODEL_NOT_AVAILABLE")
-		);
-	}
+        // Validate the controller model is available
+        if (!Controller.GetModel())
+        {
+            ANIM_ERROR_RESPONSE(
+                TEXT("Animation data model is not available - cannot add bone track"),
+                TEXT("MODEL_NOT_AVAILABLE")
+            );
+        }
 
-	// Use IsValidBoneTrackName (non-deprecated) instead of GetBoneTrackIndexByName (deprecated since 5.2)
-	if (!Controller.GetModel()->IsValidBoneTrackName(BoneFName))
-	{
-		// AddBoneCurve returns bool - check the result
-		const bool bAdded = Controller.AddBoneCurve(BoneFName);
-		if (!bAdded)
-		{
-			ANIM_ERROR_RESPONSE(
-				FString::Printf(TEXT("AddBoneCurve failed for bone '%s' - the bone may not be valid for this animation"), *BoneName),
-				TEXT("BONE_TRACK_ADD_FAILED")
-			);
-		}
+        // Use IsValidBoneTrackName (non-deprecated) instead of GetBoneTrackIndexByName (deprecated since 5.2)
+        if (!Controller.GetModel()->IsValidBoneTrackName(BoneFName))
+        {
+            // AddBoneCurve returns bool - check the result
+            const bool bAdded = Controller.AddBoneCurve(BoneFName);
+            if (!bAdded)
+            {
+                ANIM_ERROR_RESPONSE(
+                    FString::Printf(TEXT("AddBoneCurve failed for bone '%s' - the bone may not be valid for this animation"), *BoneName),
+                    TEXT("BONE_TRACK_ADD_FAILED")
+                );
+            }
 
-		if (!Controller.GetModel()->IsValidBoneTrackName(BoneFName))
-		{
-			ANIM_ERROR_RESPONSE(
-				FString::Printf(TEXT("Bone track '%s' was not found after AddBoneCurve succeeded - internal inconsistency"), *BoneName),
-				TEXT("BONE_TRACK_ADD_FAILED")
-			);
-		}
-	}
+            if (!Controller.GetModel()->IsValidBoneTrackName(BoneFName))
+            {
+                ANIM_ERROR_RESPONSE(
+                    FString::Printf(TEXT("Bone track '%s' was not found after AddBoneCurve succeeded - internal inconsistency"), *BoneName),
+                    TEXT("BONE_TRACK_ADD_FAILED")
+                );
+            }
+        }
 #elif ENGINE_MAJOR_VERSION >= 5
         // UE 5.0 approach - uses FindBoneTrackByName which returns a pointer
         IAnimationDataController& Controller = Sequence->GetController();
@@ -840,18 +840,18 @@ static TSharedPtr<FJsonObject> HandleAnimationAuthoringRequest(const TSharedPtr<
         
 #if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 1
         // UE 5.1+ API
-	IAnimationDataController& Controller = Sequence->GetController();
-	FName BoneFName(*BoneName);
+        IAnimationDataController& Controller = Sequence->GetController();
+        FName BoneFName(*BoneName);
 
-	if (!Controller.GetModel())
-	{
-		ANIM_ERROR_RESPONSE(
-			TEXT("Animation data model is not available - cannot set bone key"),
-			TEXT("MODEL_NOT_AVAILABLE")
-		);
-	}
+        if (!Controller.GetModel())
+        {
+            ANIM_ERROR_RESPONSE(
+                TEXT("Animation data model is not available - cannot set bone key"),
+                TEXT("MODEL_NOT_AVAILABLE")
+            );
+        }
 
-	// Use IsValidBoneTrackName (non-deprecated) instead of GetBoneTrackIndexByName (deprecated since 5.2)
+        // Use IsValidBoneTrackName (non-deprecated) instead of GetBoneTrackIndexByName (deprecated since 5.2)
             if (!Controller.GetModel()->IsValidBoneTrackName(BoneFName))
             {
                 const bool bAdded = Controller.AddBoneCurve(BoneFName);
@@ -978,7 +978,7 @@ static TSharedPtr<FJsonObject> HandleAnimationAuthoringRequest(const TSharedPtr<
 
 if (SubAction == TEXT("add_notify"))
 {
-	FString AssetPath = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("assetPath"), TEXT("")));
+        FString AssetPath = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("assetPath"), TEXT("")));
     FString NotifyClass = GetStringFieldAnimAuth(Params, TEXT("notifyClass"), TEXT(""));
     int32 Frame = static_cast<int32>(GetNumberFieldAnimAuth(Params, TEXT("frame"), 0));
     int32 TrackIndex = static_cast<int32>(GetNumberFieldAnimAuth(Params, TEXT("trackIndex"), 0));
@@ -1048,7 +1048,7 @@ if (SubAction == TEXT("add_notify"))
     float TriggerTime = static_cast<float>(Frame) / FrameRate;
 
     FAnimNotifyEvent& NotifyEvent = AnimAsset->Notifies.AddDefaulted_GetRef();
-    NotifyEvent.TriggerTimeOffset = TriggerTime;
+    NotifyEvent.SetTime(TriggerTime);
     NotifyEvent.TrackIndex = TrackIndex;
 
     if (!NotifyName.IsEmpty())
@@ -1070,17 +1070,17 @@ if (SubAction == TEXT("add_notify"))
         NotifyEvent.Notify = NewNotify;
     }
 
-	AnimAsset->RefreshCacheData();
-	SaveAnimAsset(AnimAsset, bSave);
+        AnimAsset->RefreshCacheData();
+        SaveAnimAsset(AnimAsset, bSave);
 
-	ANIM_SUCCESS_RESPONSE(TEXT("Notify added"));
-	McpHandlerUtils::AddVerification(Response, AnimAsset);
-	return Response;
+        ANIM_SUCCESS_RESPONSE(TEXT("Notify added"));
+        McpHandlerUtils::AddVerification(Response, AnimAsset);
+        return Response;
 }
 
 if (SubAction == TEXT("add_notify_state"))
 {
-	FString AssetPath = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("assetPath"), TEXT("")));
+        FString AssetPath = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("assetPath"), TEXT("")));
     FString NotifyClass = GetStringFieldAnimAuth(Params, TEXT("notifyClass"), TEXT(""));
     int32 StartFrame = static_cast<int32>(GetNumberFieldAnimAuth(Params, TEXT("startFrame"), 0));
     int32 EndFrame = static_cast<int32>(GetNumberFieldAnimAuth(Params, TEXT("endFrame"), 10));
@@ -1152,7 +1152,7 @@ if (SubAction == TEXT("add_notify_state"))
     float Duration = EndTime - StartTime;
 
     FAnimNotifyEvent& NotifyEvent = AnimAsset->Notifies.AddDefaulted_GetRef();
-    NotifyEvent.TriggerTimeOffset = StartTime;
+    NotifyEvent.SetTime(StartTime);
     NotifyEvent.SetDuration(Duration);
     NotifyEvent.TrackIndex = TrackIndex;
 
@@ -1175,7 +1175,7 @@ if (SubAction == TEXT("add_notify_state"))
         NotifyEvent.NotifyStateClass = NewNotifyState;
     }
 
-	AnimAsset->RefreshCacheData();
+        AnimAsset->RefreshCacheData();
         
         SaveAnimAsset(AnimAsset, bSave);
 
@@ -1509,7 +1509,7 @@ if (SubAction == TEXT("add_notify_state"))
 
 if (SubAction == TEXT("add_montage_notify"))
 {
-	FString AssetPath = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("assetPath"), TEXT("")));
+        FString AssetPath = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("assetPath"), TEXT("")));
     FString NotifyClass = GetStringFieldAnimAuth(Params, TEXT("notifyClass"), TEXT(""));
     float Time = static_cast<float>(GetNumberFieldAnimAuth(Params, TEXT("time"), 0.0));
     int32 TrackIndex = static_cast<int32>(GetNumberFieldAnimAuth(Params, TEXT("trackIndex"), 0));
@@ -1581,7 +1581,7 @@ if (SubAction == TEXT("add_montage_notify"))
 #endif
 
     FAnimNotifyEvent& NotifyEvent = Montage->Notifies.AddDefaulted_GetRef();
-    NotifyEvent.TriggerTimeOffset = Time;
+    NotifyEvent.SetTime(Time);
     NotifyEvent.TrackIndex = TrackIndex;
 
     if (!NotifyName.IsEmpty())
@@ -1603,12 +1603,12 @@ if (SubAction == TEXT("add_montage_notify"))
         NotifyEvent.Notify = NewNotify;
     }
 
-	Montage->RefreshCacheData();
-	SaveAnimAsset(Montage, bSave);
+        Montage->RefreshCacheData();
+        SaveAnimAsset(Montage, bSave);
 
-	ANIM_SUCCESS_RESPONSE(TEXT("Montage notify added"));
-	McpHandlerUtils::AddVerification(Response, Montage);
-	return Response;
+        ANIM_SUCCESS_RESPONSE(TEXT("Montage notify added"));
+        McpHandlerUtils::AddVerification(Response, Montage);
+        return Response;
 }
 
     if (SubAction == TEXT("set_blend_in"))
@@ -3124,47 +3124,47 @@ if (SubAction == TEXT("add_montage_notify"))
 // ControlRig factory static methods (CreateNewControlRigAsset, CreateControlRigFromSkeletalMeshOrSkeleton)
 // are only available in UE 5.5+ where ControlRigBlueprintFactory.h is in Public folder
 #if MCP_HAS_CONTROLRIG_FACTORY && MCP_HAS_CONTROLRIG_BLUEPRINT && ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5
-	FString Name = GetStringFieldAnimAuth(Params, TEXT("name"), TEXT(""));
-	FString Path = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("path"), TEXT("/Game/ControlRigs")));
-	FString SkeletalMeshPath = GetStringFieldAnimAuth(Params, TEXT("skeletalMeshPath"), TEXT(""));
-	FString SkeletonPath = GetStringFieldAnimAuth(Params, TEXT("skeletonPath"), TEXT(""));
-	bool bModularRig = GetBoolFieldAnimAuth(Params, TEXT("modularRig"), false);
-	bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
+        FString Name = GetStringFieldAnimAuth(Params, TEXT("name"), TEXT(""));
+        FString Path = NormalizeAnimPath(GetStringFieldAnimAuth(Params, TEXT("path"), TEXT("/Game/ControlRigs")));
+        FString SkeletalMeshPath = GetStringFieldAnimAuth(Params, TEXT("skeletalMeshPath"), TEXT(""));
+        FString SkeletonPath = GetStringFieldAnimAuth(Params, TEXT("skeletonPath"), TEXT(""));
+        bool bModularRig = GetBoolFieldAnimAuth(Params, TEXT("modularRig"), false);
+        bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
 
-	if (Name.IsEmpty())
-	{
-		ANIM_ERROR_RESPONSE(TEXT("Name is required"), TEXT("MISSING_NAME"));
-	}
+        if (Name.IsEmpty())
+        {
+            ANIM_ERROR_RESPONSE(TEXT("Name is required"), TEXT("MISSING_NAME"));
+        }
 
-	UControlRigBlueprint* ControlRigBP = nullptr;
-	FString FullPath = Path / Name;
+        UControlRigBlueprint* ControlRigBP = nullptr;
+        FString FullPath = Path / Name;
 
-	UObject* SelectedObject = nullptr;
-	if (!SkeletalMeshPath.IsEmpty())
-	{
-		SelectedObject = LoadSkeletalMeshFromPathAnim(SkeletalMeshPath);
-		if (!SelectedObject)
-		{
-			ANIM_ERROR_RESPONSE(FString::Printf(TEXT("Could not load skeletal mesh: %s"), *SkeletalMeshPath), TEXT("SKELETAL_MESH_NOT_FOUND"));
-		}
-	}
-	else if (!SkeletonPath.IsEmpty())
-	{
-		SelectedObject = LoadObject<USkeleton>(nullptr, *SkeletonPath);
-		if (!SelectedObject)
-		{
-			ANIM_ERROR_RESPONSE(FString::Printf(TEXT("Could not load skeleton: %s"), *SkeletonPath), TEXT("SKELETON_NOT_FOUND"));
-		}
-	}
+        UObject* SelectedObject = nullptr;
+        if (!SkeletalMeshPath.IsEmpty())
+        {
+            SelectedObject = LoadSkeletalMeshFromPathAnim(SkeletalMeshPath);
+            if (!SelectedObject)
+            {
+                ANIM_ERROR_RESPONSE(FString::Printf(TEXT("Could not load skeletal mesh: %s"), *SkeletalMeshPath), TEXT("SKELETAL_MESH_NOT_FOUND"));
+            }
+        }
+        else if (!SkeletonPath.IsEmpty())
+        {
+            SelectedObject = LoadSkeletonFromPathAnim(SkeletonPath);
+            if (!SelectedObject)
+            {
+                ANIM_ERROR_RESPONSE(FString::Printf(TEXT("Could not load skeleton: %s"), *SkeletonPath), TEXT("SKELETON_NOT_FOUND"));
+            }
+        }
 
-	if (SelectedObject)
-	{
-		ControlRigBP = UControlRigBlueprintFactory::CreateControlRigFromSkeletalMeshOrSkeleton(SelectedObject, bModularRig);
-	}
-	else
-	{
-		ControlRigBP = UControlRigBlueprintFactory::CreateNewControlRigAsset(FullPath, bModularRig);
-	}
+        if (SelectedObject)
+        {
+            ControlRigBP = UControlRigBlueprintFactory::CreateControlRigFromSkeletalMeshOrSkeleton(SelectedObject, bModularRig);
+        }
+        else
+        {
+            ControlRigBP = UControlRigBlueprintFactory::CreateNewControlRigAsset(FullPath, bModularRig);
+        }
         
         if (!ControlRigBP)
         {
@@ -3242,14 +3242,15 @@ if (SubAction == TEXT("add_montage_notify"))
         }
         else if (!SkeletonPath.IsEmpty())
         {
-            USkeleton* Skeleton = LoadObject<USkeleton>(nullptr, *SkeletonPath);
-            if (Skeleton)
+            USkeleton* Skeleton = LoadSkeletonFromPathAnim(SkeletonPath);
+            if (!Skeleton)
             {
-                USkeletalMesh* PreviewMesh = Skeleton->GetPreviewMesh();
-                if (PreviewMesh)
-                {
-                    ControlRigBP->SetPreviewMesh(PreviewMesh);
-                }
+                ANIM_ERROR_RESPONSE(FString::Printf(TEXT("Could not load skeleton: %s"), *SkeletonPath), TEXT("SKELETON_NOT_FOUND"));
+            }
+            USkeletalMesh* PreviewMesh = Skeleton->GetPreviewMesh();
+            if (PreviewMesh)
+            {
+                ControlRigBP->SetPreviewMesh(PreviewMesh);
             }
         }
         
@@ -3386,12 +3387,14 @@ if (SubAction == TEXT("create_ik_rig"))
             IKRig->SetPreviewMesh(SkeletalMesh);
         }
     }
-    // Also support skeletonPath: load skeleton and set its preview mesh on the IK Rig
-    else if (!SkeletonPath.IsEmpty())
-    {
-        USkeleton* Skeleton = LoadObject<USkeleton>(nullptr, *SkeletonPath);
-        if (Skeleton)
+        // Also support skeletonPath: load skeleton and set its preview mesh on the IK Rig
+        else if (!SkeletonPath.IsEmpty())
         {
+            USkeleton* Skeleton = LoadSkeletonFromPathAnim(SkeletonPath);
+            if (!Skeleton)
+            {
+                ANIM_ERROR_RESPONSE(FString::Printf(TEXT("Could not load skeleton: %s"), *SkeletonPath), TEXT("SKELETON_NOT_FOUND"));
+            }
             USkeletalMesh* PreviewMesh = Skeleton->GetPreviewMesh();
             if (PreviewMesh)
             {
@@ -3399,7 +3402,6 @@ if (SubAction == TEXT("create_ik_rig"))
             }
             Response->SetStringField(TEXT("skeletonPath"), Skeleton->GetPathName());
         }
-    }
 
     if (!SaveAnimAsset(IKRig, bSave))
     {

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_AnimationAuthoringHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_AnimationAuthoringHandlers.cpp
@@ -849,7 +849,7 @@ static TSharedPtr<FJsonObject> HandleAnimationAuthoringRequest(const TSharedPtr<
         FVector Scale = ScaleObj.IsValid() ? GetVectorFromJsonAnim(ScaleObj) : FVector::OneVector;
 
         int32 TotalFrames = Sequence->GetDataModel()->GetNumberOfFrames();
-        if (Frame >= TotalFrames)
+        if (Frame < 0 || Frame >= TotalFrames)
         {
             ANIM_ERROR_RESPONSE(
                 FString::Printf(TEXT("Frame %d is out of range (animation has %d frames)"), Frame, TotalFrames),
@@ -1015,14 +1015,14 @@ if (SubAction == TEXT("add_notify"))
         }
 
 #if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 1
-        ResolvedNotifyClass = FindFirstObject<UClass>(*FullClassName, EFindFirstObjectOptions::ExactClass);
+        ResolvedNotifyClass = FindFirstObject<UClass>(*FullClassName, EFindFirstObjectOptions::None);
 #else
         ResolvedNotifyClass = ResolveClassByName(FullClassName);
 #endif
         if (!ResolvedNotifyClass)
         {
 #if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 1
-            ResolvedNotifyClass = FindFirstObject<UClass>(*NotifyClass, EFindFirstObjectOptions::ExactClass);
+            ResolvedNotifyClass = FindFirstObject<UClass>(*NotifyClass, EFindFirstObjectOptions::None);
 #else
             ResolvedNotifyClass = ResolveClassByName(NotifyClass);
 #endif
@@ -1123,14 +1123,14 @@ if (SubAction == TEXT("add_notify_state"))
         }
 
 #if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 1
-        ResolvedNotifyStateClass = FindFirstObject<UClass>(*FullClassName, EFindFirstObjectOptions::ExactClass);
+        ResolvedNotifyStateClass = FindFirstObject<UClass>(*FullClassName, EFindFirstObjectOptions::None);
 #else
         ResolvedNotifyStateClass = ResolveClassByName(FullClassName);
 #endif
         if (!ResolvedNotifyStateClass)
         {
 #if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 1
-            ResolvedNotifyStateClass = FindFirstObject<UClass>(*NotifyClass, EFindFirstObjectOptions::ExactClass);
+            ResolvedNotifyStateClass = FindFirstObject<UClass>(*NotifyClass, EFindFirstObjectOptions::None);
 #else
             ResolvedNotifyStateClass = ResolveClassByName(NotifyClass);
 #endif
@@ -1551,14 +1551,14 @@ if (SubAction == TEXT("add_montage_notify"))
         }
 
 #if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 1
-        ResolvedNotifyClass = FindFirstObject<UClass>(*FullClassName, EFindFirstObjectOptions::ExactClass);
+        ResolvedNotifyClass = FindFirstObject<UClass>(*FullClassName, EFindFirstObjectOptions::None);
 #else
         ResolvedNotifyClass = ResolveClassByName(FullClassName);
 #endif
         if (!ResolvedNotifyClass)
         {
 #if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 1
-            ResolvedNotifyClass = FindFirstObject<UClass>(*NotifyClass, EFindFirstObjectOptions::ExactClass);
+            ResolvedNotifyClass = FindFirstObject<UClass>(*NotifyClass, EFindFirstObjectOptions::None);
 #else
             ResolvedNotifyClass = ResolveClassByName(NotifyClass);
 #endif
@@ -3250,7 +3250,11 @@ if (SubAction == TEXT("add_montage_notify"))
         if (!SkeletalMeshPath.IsEmpty())
         {
             USkeletalMesh* SkeletalMesh = LoadSkeletalMeshFromPathAnim(SkeletalMeshPath);
-            if (SkeletalMesh && SkeletalMesh->GetSkeleton())
+            if (!SkeletalMesh)
+            {
+                ANIM_ERROR_RESPONSE(FString::Printf(TEXT("Could not load skeletal mesh: %s"), *SkeletalMeshPath), TEXT("SKELETAL_MESH_NOT_FOUND"));
+            }
+            if (SkeletalMesh->GetSkeleton())
             {
                 USkeletalMesh* PreviewMesh = SkeletalMesh->GetSkeleton()->GetPreviewMesh();
                 if (PreviewMesh)

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_AnimationAuthoringHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_AnimationAuthoringHandlers.cpp
@@ -563,6 +563,11 @@ static TSharedPtr<FJsonObject> HandleAnimationAuthoringRequest(const TSharedPtr<
     int32 FrameRate = static_cast<int32>(GetNumberFieldAnimAuth(Params, TEXT("frameRate"), 30));
     bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
 
+    if (FrameRate <= 0)
+    {
+        ANIM_ERROR_RESPONSE(TEXT("frameRate must be greater than 0"), TEXT("INVALID_FRAME_RATE"));
+    }
+
     if (Name.IsEmpty())
     {
         ANIM_ERROR_RESPONSE(TEXT("Name is required"), TEXT("MISSING_NAME"));
@@ -838,6 +843,20 @@ static TSharedPtr<FJsonObject> HandleAnimationAuthoringRequest(const TSharedPtr<
             ANIM_ERROR_RESPONSE(FString::Printf(TEXT("Could not load animation sequence: %s"), *AssetPath), TEXT("SEQUENCE_NOT_FOUND"));
         }
         
+        // Build transform key
+        FVector Location = LocationObj.IsValid() ? GetVectorFromJsonAnim(LocationObj) : FVector::ZeroVector;
+        FQuat Rotation = RotationObj.IsValid() ? GetRotatorFromJsonAnim(RotationObj).Quaternion() : FQuat::Identity;
+        FVector Scale = ScaleObj.IsValid() ? GetVectorFromJsonAnim(ScaleObj) : FVector::OneVector;
+
+        int32 TotalFrames = Sequence->GetDataModel()->GetNumberOfFrames();
+        if (Frame >= TotalFrames)
+        {
+            ANIM_ERROR_RESPONSE(
+                FString::Printf(TEXT("Frame %d is out of range (animation has %d frames)"), Frame, TotalFrames),
+                TEXT("FRAME_OUT_OF_RANGE")
+            );
+        }
+
 #if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 1
         // UE 5.1+ API
         IAnimationDataController& Controller = Sequence->GetController();
@@ -852,42 +871,41 @@ static TSharedPtr<FJsonObject> HandleAnimationAuthoringRequest(const TSharedPtr<
         }
 
         // Use IsValidBoneTrackName (non-deprecated) instead of GetBoneTrackIndexByName (deprecated since 5.2)
+        if (!Controller.GetModel()->IsValidBoneTrackName(BoneFName))
+        {
+            const bool bAdded = Controller.AddBoneCurve(BoneFName);
+            if (!bAdded)
+            {
+                ANIM_ERROR_RESPONSE(
+                    FString::Printf(TEXT("Failed to create missing bone track '%s' before keying"), *BoneName),
+                    TEXT("BONE_TRACK_ADD_FAILED")
+                );
+            }
+
+            // Verify the track was actually created after AddBoneCurve succeeded
             if (!Controller.GetModel()->IsValidBoneTrackName(BoneFName))
             {
-                const bool bAdded = Controller.AddBoneCurve(BoneFName);
-                if (!bAdded)
-                {
-                    ANIM_ERROR_RESPONSE(
-                        FString::Printf(TEXT("Failed to create missing bone track '%s' before keying"), *BoneName),
-                        TEXT("BONE_TRACK_ADD_FAILED")
-                    );
-                }
-
-                // Verify the track was actually created after AddBoneCurve succeeded
-                if (!Controller.GetModel()->IsValidBoneTrackName(BoneFName))
-                {
-                    ANIM_ERROR_RESPONSE(
-                        FString::Printf(TEXT("Bone track '%s' not found in animation sequence after AddBoneCurve. Add the track first using add_bone_track."), *BoneName),
-                        TEXT("BONE_TRACK_NOT_FOUND")
-                    );
-                }
+                ANIM_ERROR_RESPONSE(
+                    FString::Printf(TEXT("Bone track '%s' not found in animation sequence after AddBoneCurve. Add the track first using add_bone_track."), *BoneName),
+                    TEXT("BONE_TRACK_NOT_FOUND")
+                );
             }
-        
-        // Build transform key
-        FVector Location = LocationObj.IsValid() ? GetVectorFromJsonAnim(LocationObj) : FVector::ZeroVector;
-        FQuat Rotation = RotationObj.IsValid() ? GetRotatorFromJsonAnim(RotationObj).Quaternion() : FQuat::Identity;
-        FVector Scale = ScaleObj.IsValid() ? GetVectorFromJsonAnim(ScaleObj) : FVector::OneVector;
-        
-        FTransform Transform(Rotation, Location, Scale);
-        
-        // Set key at frame
-        FFrameNumber FrameNumber(Frame);
-        Controller.SetBoneTrackKeys(BoneFName, {Location}, {Rotation}, {Scale});
+        }
+
+        // UpdateBoneTrackKeys preserves other frames; SetBoneTrackKeys would replace the entire track
+        FInt32Range KeyRange(Frame, Frame + 1);
+        if (!Controller.UpdateBoneTrackKeys(BoneFName, KeyRange, {Location}, {Rotation}, {Scale}))
+        {
+            ANIM_ERROR_RESPONSE(
+                FString::Printf(TEXT("Failed to set bone key at frame %d"), Frame),
+                TEXT("BONE_KEY_SET_FAILED")
+            );
+        }
 #elif ENGINE_MAJOR_VERSION >= 5
         // UE 5.0 API - uses FindBoneTrackByName which returns a pointer
         IAnimationDataController& Controller = Sequence->GetController();
         FName BoneFName(*BoneName);
-        
+
         const FBoneAnimationTrack* Track = Controller.GetModel()->FindBoneTrackByName(BoneFName);
         if (Track == nullptr)
         {
@@ -908,12 +926,8 @@ static TSharedPtr<FJsonObject> HandleAnimationAuthoringRequest(const TSharedPtr<
                 TEXT("BONE_TRACK_NOT_FOUND")
             );
         }
-        
-        FVector Location = LocationObj.IsValid() ? GetVectorFromJsonAnim(LocationObj) : FVector::ZeroVector;
-        FQuat Rotation = RotationObj.IsValid() ? GetRotatorFromJsonAnim(RotationObj).Quaternion() : FQuat::Identity;
-        FVector Scale = ScaleObj.IsValid() ? GetVectorFromJsonAnim(ScaleObj) : FVector::OneVector;
-        
-        FFrameNumber FrameNumber(Frame);
+
+        // UE 5.0 fallback: SetBoneTrackKeys replaces the entire track (no UpdateBoneTrackKeys available)
         Controller.SetBoneTrackKeys(BoneFName, {Location}, {Rotation}, {Scale});
 #endif
         
@@ -1087,6 +1101,11 @@ if (SubAction == TEXT("add_notify_state"))
     int32 TrackIndex = static_cast<int32>(GetNumberFieldAnimAuth(Params, TEXT("trackIndex"), 0));
     FString NotifyName = GetStringFieldAnimAuth(Params, TEXT("notifyName"), TEXT(""));
     bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
+
+    if (EndFrame < StartFrame)
+    {
+        ANIM_ERROR_RESPONSE(TEXT("endFrame must be greater than or equal to startFrame"), TEXT("INVALID_FRAME_RANGE"));
+    }
 
     if (NotifyClass.IsEmpty() && NotifyName.IsEmpty())
     {
@@ -3129,9 +3148,9 @@ if (SubAction == TEXT("add_montage_notify"))
         FString SkeletalMeshPath = GetStringFieldAnimAuth(Params, TEXT("skeletalMeshPath"), TEXT(""));
         FString SkeletonPath = GetStringFieldAnimAuth(Params, TEXT("skeletonPath"), TEXT(""));
         bool bModularRig = GetBoolFieldAnimAuth(Params, TEXT("modularRig"), false);
-        bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
+    bool bSave = GetBoolFieldAnimAuth(Params, TEXT("save"), true);
 
-        if (Name.IsEmpty())
+    if (Name.IsEmpty())
         {
             ANIM_ERROR_RESPONSE(TEXT("Name is required"), TEXT("MISSING_NAME"));
         }
@@ -3378,15 +3397,16 @@ if (SubAction == TEXT("create_ik_rig"))
         ANIM_ERROR_RESPONSE(TEXT("Failed to create IK Rig asset"), TEXT("CREATION_FAILED"));
     }
 
-    // If skeletal mesh path provided, set the preview mesh
-    if (!SkeletalMeshPath.IsEmpty())
-    {
-        USkeletalMesh* SkeletalMesh = LoadSkeletalMeshFromPathAnim(SkeletalMeshPath);
-        if (SkeletalMesh)
+        // If skeletal mesh path provided, set the preview mesh
+        if (!SkeletalMeshPath.IsEmpty())
         {
+            USkeletalMesh* SkeletalMesh = LoadSkeletalMeshFromPathAnim(SkeletalMeshPath);
+            if (!SkeletalMesh)
+            {
+                ANIM_ERROR_RESPONSE(FString::Printf(TEXT("Could not load skeletal mesh: %s"), *SkeletalMeshPath), TEXT("SKELETAL_MESH_NOT_FOUND"));
+            }
             IKRig->SetPreviewMesh(SkeletalMesh);
         }
-    }
         // Also support skeletonPath: load skeleton and set its preview mesh on the IK Rig
         else if (!SkeletonPath.IsEmpty())
         {

--- a/src/tools/handlers/animation-authoring-handlers.ts
+++ b/src/tools/handlers/animation-authoring-handlers.ts
@@ -71,19 +71,19 @@ export async function handleAnimationAuthoringTools(
 
     switch (action) {
       // ===== 10.1 Animation Sequences =====
-      case 'create_animation_sequence': {
-        const params = normalizeArgs(args, [
-          { key: 'name', required: true },
-          { key: 'path', aliases: ['directory'], default: '/Game/Animations' },
-          { key: 'skeletonPath', required: true },
-          { key: 'numFrames', default: 30 },
-          { key: 'frameRate', default: 30 },
-          { key: 'save', default: true },
-        ]);
+  case 'create_animation_sequence': {
+    const params = normalizeArgs(args, [
+      { key: 'name', required: true },
+      { key: 'path', aliases: ['directory'], default: '/Game/Animations' },
+      { key: 'skeletonPath', required: false },
+      { key: 'numFrames', default: 30 },
+      { key: 'frameRate', default: 30 },
+      { key: 'save', default: true },
+    ]);
 
-        const name = extractString(params, 'name');
-        const path = extractOptionalString(params, 'path') ?? '/Game/Animations';
-        const skeletonPath = extractString(params, 'skeletonPath');
+    const name = extractString(params, 'name');
+    const path = extractOptionalString(params, 'path') ?? '/Game/Animations';
+    const skeletonPath = extractOptionalString(params, 'skeletonPath');
         const numFrames = extractOptionalNumber(params, 'numFrames') ?? 30;
         const frameRate = extractOptionalNumber(params, 'frameRate') ?? 30;
         const save = extractOptionalBoolean(params, 'save') ?? true;
@@ -104,28 +104,27 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? `Animation sequence '${name}' created`);
       }
 
-      case 'set_sequence_length': {
-        const params = normalizeArgs(args, [
-          { key: 'assetPath', required: true },
-          { key: 'numFrames', required: true },
-          { key: 'frameRate' },
-          { key: 'save', default: true },
-        ]);
+  case 'set_sequence_length': {
+    const params = normalizeArgs(args, [
+      { key: 'assetPath', required: false },
+      { key: 'numFrames', required: true },
+      { key: 'frameRate' },
+      { key: 'save', default: true },
+    ]);
 
-        const rawAssetPath = extractString(params, 'assetPath');
-        const pathValidation = validatePath(rawAssetPath, 'assetPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const assetPath = pathValidation.sanitized;
+    const rawAssetPath = extractOptionalString(params, 'assetPath');
+    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
+    if (assetPath && !assetPath.valid) {
+      return assetPath.error;
+    }
         const numFrames = extractOptionalNumber(params, 'numFrames') ?? 30;
         const frameRate = extractOptionalNumber(params, 'frameRate');
         const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'set_sequence_length',
-          assetPath,
-          numFrames,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'set_sequence_length',
+      assetPath: assetPath?.sanitized,
+      numFrames,
           frameRate,
           save,
         })) as AutomationResponse;
@@ -136,25 +135,24 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? 'Sequence length updated');
       }
 
-      case 'add_bone_track': {
-        const params = normalizeArgs(args, [
-          { key: 'assetPath', required: true },
-          { key: 'boneName', required: true },
-          { key: 'save', default: true },
-        ]);
+  case 'add_bone_track': {
+    const params = normalizeArgs(args, [
+      { key: 'assetPath', required: false },
+      { key: 'boneName', required: true },
+      { key: 'save', default: true },
+    ]);
 
-        const rawAssetPath = extractString(params, 'assetPath');
-        const pathValidation = validatePath(rawAssetPath, 'assetPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const assetPath = pathValidation.sanitized;
-        const boneName = extractString(params, 'boneName');
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawAssetPath = extractOptionalString(params, 'assetPath');
+    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
+    if (assetPath && !assetPath.valid) {
+      return assetPath.error;
+    }
+    const boneName = extractString(params, 'boneName');
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'add_bone_track',
-          assetPath,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'add_bone_track',
+      assetPath: assetPath?.sanitized,
           boneName,
           save,
         })) as AutomationResponse;
@@ -165,40 +163,39 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? `Bone track '${boneName}' added`);
       }
 
-      case 'set_bone_key': {
-        const params = normalizeArgs(args, [
-          { key: 'assetPath', required: true },
-          { key: 'boneName', required: true },
-          { key: 'frame', required: true },
-          { key: 'location' }, // {x, y, z}
-          { key: 'rotation' }, // {pitch, yaw, roll} or {x, y, z, w}
-          { key: 'scale' },    // {x, y, z}
-          { key: 'save', default: true },
-        ]);
+  case 'set_bone_key': {
+    const params = normalizeArgs(args, [
+      { key: 'assetPath', required: false },
+      { key: 'boneName', required: true },
+      { key: 'frame', required: true },
+      { key: 'location' }, // {x, y, z}
+      { key: 'rotation' }, // {pitch, yaw, roll} or {x, y, z, w}
+      { key: 'scale' }, // {x, y, z}
+      { key: 'save', default: true },
+    ]);
 
-        const rawAssetPath = extractString(params, 'assetPath');
-        const pathValidation = validatePath(rawAssetPath, 'assetPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const assetPath = pathValidation.sanitized;
-        const boneName = extractString(params, 'boneName');
-        const frame = extractOptionalNumber(params, 'frame') ?? 0;
-        const location = extractOptionalObject(params, 'location');
-        const rotation = extractOptionalObject(params, 'rotation');
-        const scale = extractOptionalObject(params, 'scale');
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawAssetPath = extractOptionalString(params, 'assetPath');
+    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
+    if (assetPath && !assetPath.valid) {
+      return assetPath.error;
+    }
+    const boneName = extractString(params, 'boneName');
+    const frame = extractOptionalNumber(params, 'frame') ?? 0;
+    const location = extractOptionalObject(params, 'location');
+    const rotation = extractOptionalObject(params, 'rotation');
+    const scale = extractOptionalObject(params, 'scale');
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'set_bone_key',
-          assetPath,
-          boneName,
-          frame,
-          location,
-          rotation,
-          scale,
-          save,
-        })) as AutomationResponse;
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'set_bone_key',
+      assetPath: assetPath?.sanitized,
+      boneName,
+      frame,
+      location,
+      rotation,
+      scale,
+      save,
+    })) as AutomationResponse;
 
         if (res.success === false) {
           return ResponseFactory.error(res.error ?? 'Failed to set bone key', res.errorCode);
@@ -206,31 +203,30 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? `Bone key set at frame ${frame}`);
       }
 
-      case 'set_curve_key': {
-        const params = normalizeArgs(args, [
-          { key: 'assetPath', required: true },
-          { key: 'curveName', required: true },
-          { key: 'frame', required: true },
-          { key: 'value', required: true },
-          { key: 'createIfMissing', default: true },
-          { key: 'save', default: true },
-        ]);
+  case 'set_curve_key': {
+    const params = normalizeArgs(args, [
+      { key: 'assetPath', required: false },
+      { key: 'curveName', required: true },
+      { key: 'frame', required: true },
+      { key: 'value', required: true },
+      { key: 'createIfMissing', default: true },
+      { key: 'save', default: true },
+    ]);
 
-        const rawAssetPath = extractString(params, 'assetPath');
-        const pathValidation = validatePath(rawAssetPath, 'assetPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const assetPath = pathValidation.sanitized;
-        const curveName = extractString(params, 'curveName');
-        const frame = extractOptionalNumber(params, 'frame') ?? 0;
-        const value = extractOptionalNumber(params, 'value') ?? 0;
-        const createIfMissing = extractOptionalBoolean(params, 'createIfMissing') ?? true;
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawAssetPath = extractOptionalString(params, 'assetPath');
+    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
+    if (assetPath && !assetPath.valid) {
+      return assetPath.error;
+    }
+    const curveName = extractString(params, 'curveName');
+    const frame = extractOptionalNumber(params, 'frame') ?? 0;
+    const value = extractOptionalNumber(params, 'value') ?? 0;
+    const createIfMissing = extractOptionalBoolean(params, 'createIfMissing') ?? true;
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'set_curve_key',
-          assetPath,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'set_curve_key',
+      assetPath: assetPath?.sanitized,
           curveName,
           frame,
           value,
@@ -244,33 +240,32 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? `Curve key set at frame ${frame}`);
       }
 
-      case 'add_notify': {
-        const params = normalizeArgs(args, [
-          { key: 'assetPath', required: true },
-          { key: 'notifyClass', required: true },
-          { key: 'frame', required: true },
-          { key: 'trackIndex', default: 0 },
-          { key: 'notifyName' },
-          { key: 'save', default: true },
-        ]);
+  case 'add_notify': {
+    const params = normalizeArgs(args, [
+      { key: 'assetPath', required: false },
+      { key: 'notifyClass', required: false },
+      { key: 'frame', required: true },
+      { key: 'trackIndex', default: 0 },
+      { key: 'notifyName' },
+      { key: 'save', default: true },
+    ]);
 
-        const rawAssetPath = extractString(params, 'assetPath');
-        const pathValidation = validatePath(rawAssetPath, 'assetPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const assetPath = pathValidation.sanitized;
-        const notifyClass = extractString(params, 'notifyClass');
-        const frame = extractOptionalNumber(params, 'frame') ?? 0;
-        const trackIndex = extractOptionalNumber(params, 'trackIndex') ?? 0;
-        const notifyName = extractOptionalString(params, 'notifyName');
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawAssetPath = extractOptionalString(params, 'assetPath');
+    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
+    if (assetPath && !assetPath.valid) {
+      return assetPath.error;
+    }
+    const notifyClass = extractOptionalString(params, 'notifyClass');
+    const frame = extractOptionalNumber(params, 'frame') ?? 0;
+    const trackIndex = extractOptionalNumber(params, 'trackIndex') ?? 0;
+    const notifyName = extractOptionalString(params, 'notifyName');
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'add_notify',
-          assetPath,
-          notifyClass,
-          frame,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'add_notify',
+      assetPath: assetPath?.sanitized,
+      notifyClass,
+      frame,
           trackIndex,
           notifyName,
           save,
@@ -282,33 +277,32 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? 'Notify added');
       }
 
-      case 'add_notify_state': {
-        const params = normalizeArgs(args, [
-          { key: 'assetPath', required: true },
-          { key: 'notifyClass', required: true },
-          { key: 'startFrame', required: true },
-          { key: 'endFrame', required: true },
-          { key: 'trackIndex', default: 0 },
-          { key: 'notifyName' },
-          { key: 'save', default: true },
-        ]);
+  case 'add_notify_state': {
+    const params = normalizeArgs(args, [
+      { key: 'assetPath', required: false },
+      { key: 'notifyClass', required: false },
+      { key: 'startFrame', required: true },
+      { key: 'endFrame', required: true },
+      { key: 'trackIndex', default: 0 },
+      { key: 'notifyName' },
+      { key: 'save', default: true },
+    ]);
 
-        const rawAssetPath = extractString(params, 'assetPath');
-        const pathValidation = validatePath(rawAssetPath, 'assetPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const assetPath = pathValidation.sanitized;
-        const notifyClass = extractString(params, 'notifyClass');
-        const startFrame = extractOptionalNumber(params, 'startFrame') ?? 0;
-        const endFrame = extractOptionalNumber(params, 'endFrame') ?? 10;
-        const trackIndex = extractOptionalNumber(params, 'trackIndex') ?? 0;
-        const notifyName = extractOptionalString(params, 'notifyName');
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawAssetPath = extractOptionalString(params, 'assetPath');
+    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
+    if (assetPath && !assetPath.valid) {
+      return assetPath.error;
+    }
+    const notifyClass = extractOptionalString(params, 'notifyClass');
+    const startFrame = extractOptionalNumber(params, 'startFrame') ?? 0;
+    const endFrame = extractOptionalNumber(params, 'endFrame') ?? 10;
+    const trackIndex = extractOptionalNumber(params, 'trackIndex') ?? 0;
+    const notifyName = extractOptionalString(params, 'notifyName');
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'add_notify_state',
-          assetPath,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'add_notify_state',
+      assetPath: assetPath?.sanitized,
           notifyClass,
           startFrame,
           endFrame,
@@ -323,27 +317,26 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? 'Notify state added');
       }
 
-      case 'add_sync_marker': {
-        const params = normalizeArgs(args, [
-          { key: 'assetPath', required: true },
-          { key: 'markerName', required: true },
-          { key: 'frame', required: true },
-          { key: 'save', default: true },
-        ]);
+  case 'add_sync_marker': {
+    const params = normalizeArgs(args, [
+      { key: 'assetPath', required: false },
+      { key: 'markerName', required: true },
+      { key: 'frame', required: true },
+      { key: 'save', default: true },
+    ]);
 
-        const rawAssetPath = extractString(params, 'assetPath');
-        const pathValidation = validatePath(rawAssetPath, 'assetPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const assetPath = pathValidation.sanitized;
-        const markerName = extractString(params, 'markerName');
-        const frame = extractOptionalNumber(params, 'frame') ?? 0;
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawAssetPath = extractOptionalString(params, 'assetPath');
+    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
+    if (assetPath && !assetPath.valid) {
+      return assetPath.error;
+    }
+    const markerName = extractString(params, 'markerName');
+    const frame = extractOptionalNumber(params, 'frame') ?? 0;
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'add_sync_marker',
-          assetPath,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'add_sync_marker',
+      assetPath: assetPath?.sanitized,
           markerName,
           frame,
           save,
@@ -355,29 +348,28 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? `Sync marker '${markerName}' added`);
       }
 
-      case 'set_root_motion_settings': {
-        const params = normalizeArgs(args, [
-          { key: 'assetPath', required: true },
-          { key: 'enableRootMotion', default: true },
-          { key: 'rootMotionRootLock', default: 'RefPose' },
-          { key: 'forceRootLock', default: false },
-          { key: 'save', default: true },
-        ]);
+  case 'set_root_motion_settings': {
+    const params = normalizeArgs(args, [
+      { key: 'assetPath', required: false },
+      { key: 'enableRootMotion', default: true },
+      { key: 'rootMotionRootLock', default: 'RefPose' },
+      { key: 'forceRootLock', default: false },
+      { key: 'save', default: true },
+    ]);
 
-        const rawAssetPath = extractString(params, 'assetPath');
-        const pathValidation = validatePath(rawAssetPath, 'assetPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const assetPath = pathValidation.sanitized;
-        const enableRootMotion = extractOptionalBoolean(params, 'enableRootMotion') ?? true;
-        const rootMotionRootLock = extractOptionalString(params, 'rootMotionRootLock') ?? 'RefPose';
-        const forceRootLock = extractOptionalBoolean(params, 'forceRootLock') ?? false;
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawAssetPath = extractOptionalString(params, 'assetPath');
+    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
+    if (assetPath && !assetPath.valid) {
+      return assetPath.error;
+    }
+    const enableRootMotion = extractOptionalBoolean(params, 'enableRootMotion') ?? true;
+    const rootMotionRootLock = extractOptionalString(params, 'rootMotionRootLock') ?? 'RefPose';
+    const forceRootLock = extractOptionalBoolean(params, 'forceRootLock') ?? false;
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'set_root_motion_settings',
-          assetPath,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'set_root_motion_settings',
+      assetPath: assetPath?.sanitized,
           enableRootMotion,
           rootMotionRootLock,
           forceRootLock,
@@ -390,31 +382,30 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? 'Root motion settings updated');
       }
 
-      case 'set_additive_settings': {
-        const params = normalizeArgs(args, [
-          { key: 'assetPath', required: true },
-          { key: 'additiveAnimType', default: 'NoAdditive' }, // NoAdditive, LocalSpaceAdditive, MeshSpaceAdditive
-          { key: 'basePoseType', default: 'RefPose' }, // RefPose, AnimationFrame, AnimationScaled
-          { key: 'basePoseAnimation' },
-          { key: 'basePoseFrame', default: 0 },
-          { key: 'save', default: true },
-        ]);
+  case 'set_additive_settings': {
+    const params = normalizeArgs(args, [
+      { key: 'assetPath', required: false },
+      { key: 'additiveAnimType', default: 'NoAdditive' }, // NoAdditive, LocalSpaceAdditive, MeshSpaceAdditive
+      { key: 'basePoseType', default: 'RefPose' }, // RefPose, AnimationFrame, AnimationScaled
+      { key: 'basePoseAnimation' },
+      { key: 'basePoseFrame', default: 0 },
+      { key: 'save', default: true },
+    ]);
 
-        const rawAssetPath = extractString(params, 'assetPath');
-        const pathValidation = validatePath(rawAssetPath, 'assetPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const assetPath = pathValidation.sanitized;
-        const additiveAnimType = extractOptionalString(params, 'additiveAnimType') ?? 'NoAdditive';
-        const basePoseType = extractOptionalString(params, 'basePoseType') ?? 'RefPose';
-        const basePoseAnimation = extractOptionalString(params, 'basePoseAnimation');
-        const basePoseFrame = extractOptionalNumber(params, 'basePoseFrame') ?? 0;
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawAssetPath = extractOptionalString(params, 'assetPath');
+    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
+    if (assetPath && !assetPath.valid) {
+      return assetPath.error;
+    }
+    const additiveAnimType = extractOptionalString(params, 'additiveAnimType') ?? 'NoAdditive';
+    const basePoseType = extractOptionalString(params, 'basePoseType') ?? 'RefPose';
+    const basePoseAnimation = extractOptionalString(params, 'basePoseAnimation');
+    const basePoseFrame = extractOptionalNumber(params, 'basePoseFrame') ?? 0;
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'set_additive_settings',
-          assetPath,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'set_additive_settings',
+      assetPath: assetPath?.sanitized,
           additiveAnimType,
           basePoseType,
           basePoseAnimation,
@@ -429,18 +420,18 @@ export async function handleAnimationAuthoringTools(
       }
 
       // ===== 10.2 Animation Montages =====
-      case 'create_montage': {
-        const params = normalizeArgs(args, [
-          { key: 'name', required: true },
-          { key: 'path', aliases: ['directory'], default: '/Game/Animations' },
-          { key: 'skeletonPath', required: true },
-          { key: 'slotName', default: 'DefaultSlot' },
-          { key: 'save', default: true },
-        ]);
+  case 'create_montage': {
+    const params = normalizeArgs(args, [
+      { key: 'name', required: true },
+      { key: 'path', aliases: ['directory'], default: '/Game/Animations' },
+      { key: 'skeletonPath', required: false },
+      { key: 'slotName', default: 'DefaultSlot' },
+      { key: 'save', default: true },
+    ]);
 
-        const name = extractString(params, 'name');
-        const path = extractOptionalString(params, 'path') ?? '/Game/Animations';
-        const skeletonPath = extractString(params, 'skeletonPath');
+    const name = extractString(params, 'name');
+    const path = extractOptionalString(params, 'path') ?? '/Game/Animations';
+    const skeletonPath = extractOptionalString(params, 'skeletonPath');
         const slotName = extractOptionalString(params, 'slotName') ?? 'DefaultSlot';
         const save = extractOptionalBoolean(params, 'save') ?? true;
 
@@ -459,27 +450,26 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? `Montage '${name}' created`);
       }
 
-      case 'add_montage_section': {
-        const params = normalizeArgs(args, [
-          { key: 'assetPath', required: true },
-          { key: 'sectionName', required: true },
-          { key: 'startTime', required: true },
-          { key: 'save', default: true },
-        ]);
+  case 'add_montage_section': {
+    const params = normalizeArgs(args, [
+      { key: 'assetPath', required: false },
+      { key: 'sectionName', required: true },
+      { key: 'startTime', required: true },
+      { key: 'save', default: true },
+    ]);
 
-        const rawAssetPath = extractString(params, 'assetPath');
-        const pathValidation = validatePath(rawAssetPath, 'assetPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const assetPath = pathValidation.sanitized;
-        const sectionName = extractString(params, 'sectionName');
-        const startTime = extractOptionalNumber(params, 'startTime') ?? 0;
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawAssetPath = extractOptionalString(params, 'assetPath');
+    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
+    if (assetPath && !assetPath.valid) {
+      return assetPath.error;
+    }
+    const sectionName = extractString(params, 'sectionName');
+    const startTime = extractOptionalNumber(params, 'startTime') ?? 0;
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'add_montage_section',
-          assetPath,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'add_montage_section',
+      assetPath: assetPath?.sanitized,
           sectionName,
           startTime,
           save,
@@ -491,35 +481,33 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? `Section '${sectionName}' added`);
       }
 
-      case 'add_montage_slot': {
-        const params = normalizeArgs(args, [
-          { key: 'assetPath', required: true },
-          { key: 'animationPath', required: true },
-          { key: 'slotName', default: 'DefaultSlot' },
-          { key: 'startTime', default: 0 },
-          { key: 'save', default: true },
-        ]);
+  case 'add_montage_slot': {
+    const params = normalizeArgs(args, [
+      { key: 'assetPath', required: false },
+      { key: 'animationPath', required: false },
+      { key: 'slotName', default: 'DefaultSlot' },
+      { key: 'startTime', default: 0 },
+      { key: 'save', default: true },
+    ]);
 
-        const rawAssetPath = extractString(params, 'assetPath');
-        const pathValidationAsset = validatePath(rawAssetPath, 'assetPath');
-        if (!pathValidationAsset.valid) {
-          return pathValidationAsset.error;
-        }
-        const assetPath = pathValidationAsset.sanitized;
-        const rawAnimationPath = extractString(params, 'animationPath');
-        const pathValidationAnim = validatePath(rawAnimationPath, 'animationPath');
-        if (!pathValidationAnim.valid) {
-          return pathValidationAnim.error;
-        }
-        const animationPath = pathValidationAnim.sanitized;
-        const slotName = extractOptionalString(params, 'slotName') ?? 'DefaultSlot';
-        const startTime = extractOptionalNumber(params, 'startTime') ?? 0;
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawAssetPath = extractOptionalString(params, 'assetPath');
+    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
+    if (assetPath && !assetPath.valid) {
+      return assetPath.error;
+    }
+    const rawAnimationPath = extractOptionalString(params, 'animationPath');
+    const animationPath = rawAnimationPath ? validatePath(rawAnimationPath, 'animationPath') : undefined;
+    if (animationPath && !animationPath.valid) {
+      return animationPath.error;
+    }
+    const slotName = extractOptionalString(params, 'slotName') ?? 'DefaultSlot';
+    const startTime = extractOptionalNumber(params, 'startTime') ?? 0;
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'add_montage_slot',
-          assetPath,
-          animationPath,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'add_montage_slot',
+      assetPath: assetPath?.sanitized,
+      animationPath: animationPath?.sanitized,
           slotName,
           startTime,
           save,
@@ -531,29 +519,28 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? 'Animation added to montage slot');
       }
 
-      case 'set_section_timing': {
-        const params = normalizeArgs(args, [
-          { key: 'assetPath', required: true },
-          { key: 'sectionName', required: true },
-          { key: 'startTime' },
-          { key: 'length' },
-          { key: 'save', default: true },
-        ]);
+  case 'set_section_timing': {
+    const params = normalizeArgs(args, [
+      { key: 'assetPath', required: false },
+      { key: 'sectionName', required: true },
+      { key: 'startTime' },
+      { key: 'length' },
+      { key: 'save', default: true },
+    ]);
 
-        const rawAssetPath = extractString(params, 'assetPath');
-        const pathValidation = validatePath(rawAssetPath, 'assetPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const assetPath = pathValidation.sanitized;
-        const sectionName = extractString(params, 'sectionName');
-        const startTime = extractOptionalNumber(params, 'startTime');
-        const length = extractOptionalNumber(params, 'length');
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawAssetPath = extractOptionalString(params, 'assetPath');
+    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
+    if (assetPath && !assetPath.valid) {
+      return assetPath.error;
+    }
+    const sectionName = extractString(params, 'sectionName');
+    const startTime = extractOptionalNumber(params, 'startTime');
+    const length = extractOptionalNumber(params, 'length');
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'set_section_timing',
-          assetPath,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'set_section_timing',
+      assetPath: assetPath?.sanitized,
           sectionName,
           startTime,
           length,
@@ -566,31 +553,30 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? 'Section timing updated');
       }
 
-      case 'add_montage_notify': {
-        const params = normalizeArgs(args, [
-          { key: 'assetPath', required: true },
-          { key: 'notifyClass', required: true },
-          { key: 'time', required: true },
-          { key: 'trackIndex', default: 0 },
-          { key: 'notifyName' },
-          { key: 'save', default: true },
-        ]);
+  case 'add_montage_notify': {
+    const params = normalizeArgs(args, [
+      { key: 'assetPath', required: false },
+      { key: 'notifyClass', required: false },
+      { key: 'time', required: true },
+      { key: 'trackIndex', default: 0 },
+      { key: 'notifyName' },
+      { key: 'save', default: true },
+    ]);
 
-        const rawAssetPath = extractString(params, 'assetPath');
-        const pathValidation = validatePath(rawAssetPath, 'assetPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const assetPath = pathValidation.sanitized;
-        const notifyClass = extractString(params, 'notifyClass');
-        const time = extractOptionalNumber(params, 'time') ?? 0;
-        const trackIndex = extractOptionalNumber(params, 'trackIndex') ?? 0;
-        const notifyName = extractOptionalString(params, 'notifyName');
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawAssetPath = extractOptionalString(params, 'assetPath');
+    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
+    if (assetPath && !assetPath.valid) {
+      return assetPath.error;
+    }
+    const notifyClass = extractOptionalString(params, 'notifyClass');
+    const time = extractOptionalNumber(params, 'time') ?? 0;
+    const trackIndex = extractOptionalNumber(params, 'trackIndex') ?? 0;
+    const notifyName = extractOptionalString(params, 'notifyName');
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'add_montage_notify',
-          assetPath,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'add_montage_notify',
+      assetPath: assetPath?.sanitized,
           notifyClass,
           time,
           trackIndex,
@@ -604,27 +590,26 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? 'Montage notify added');
       }
 
-      case 'set_blend_in': {
-        const params = normalizeArgs(args, [
-          { key: 'assetPath', required: true },
-          { key: 'blendTime', default: 0.25 },
-          { key: 'blendOption', default: 'Linear' },
-          { key: 'save', default: true },
-        ]);
+  case 'set_blend_in': {
+    const params = normalizeArgs(args, [
+      { key: 'assetPath', required: false },
+      { key: 'blendTime', default: 0.25 },
+      { key: 'blendOption', default: 'Linear' },
+      { key: 'save', default: true },
+    ]);
 
-        const rawAssetPath = extractString(params, 'assetPath');
-        const pathValidation = validatePath(rawAssetPath, 'assetPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const assetPath = pathValidation.sanitized;
-        const blendTime = extractOptionalNumber(params, 'blendTime') ?? 0.25;
-        const blendOption = extractOptionalString(params, 'blendOption') ?? 'Linear';
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawAssetPath = extractOptionalString(params, 'assetPath');
+    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
+    if (assetPath && !assetPath.valid) {
+      return assetPath.error;
+    }
+    const blendTime = extractOptionalNumber(params, 'blendTime') ?? 0.25;
+    const blendOption = extractOptionalString(params, 'blendOption') ?? 'Linear';
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'set_blend_in',
-          assetPath,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'set_blend_in',
+      assetPath: assetPath?.sanitized,
           blendTime,
           blendOption,
           save,
@@ -636,27 +621,26 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? 'Blend in settings updated');
       }
 
-      case 'set_blend_out': {
-        const params = normalizeArgs(args, [
-          { key: 'assetPath', required: true },
-          { key: 'blendTime', default: 0.25 },
-          { key: 'blendOption', default: 'Linear' },
-          { key: 'save', default: true },
-        ]);
+  case 'set_blend_out': {
+    const params = normalizeArgs(args, [
+      { key: 'assetPath', required: false },
+      { key: 'blendTime', default: 0.25 },
+      { key: 'blendOption', default: 'Linear' },
+      { key: 'save', default: true },
+    ]);
 
-        const rawAssetPath = extractString(params, 'assetPath');
-        const pathValidation = validatePath(rawAssetPath, 'assetPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const assetPath = pathValidation.sanitized;
-        const blendTime = extractOptionalNumber(params, 'blendTime') ?? 0.25;
-        const blendOption = extractOptionalString(params, 'blendOption') ?? 'Linear';
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawAssetPath = extractOptionalString(params, 'assetPath');
+    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
+    if (assetPath && !assetPath.valid) {
+      return assetPath.error;
+    }
+    const blendTime = extractOptionalNumber(params, 'blendTime') ?? 0.25;
+    const blendOption = extractOptionalString(params, 'blendOption') ?? 'Linear';
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'set_blend_out',
-          assetPath,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'set_blend_out',
+      assetPath: assetPath?.sanitized,
           blendTime,
           blendOption,
           save,
@@ -668,27 +652,26 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? 'Blend out settings updated');
       }
 
-      case 'link_sections': {
-        const params = normalizeArgs(args, [
-          { key: 'assetPath', required: true },
-          { key: 'fromSection', required: true },
-          { key: 'toSection', required: true },
-          { key: 'save', default: true },
-        ]);
+  case 'link_sections': {
+    const params = normalizeArgs(args, [
+      { key: 'assetPath', required: false },
+      { key: 'fromSection', required: true },
+      { key: 'toSection', required: true },
+      { key: 'save', default: true },
+    ]);
 
-        const rawAssetPath = extractString(params, 'assetPath');
-        const pathValidation = validatePath(rawAssetPath, 'assetPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const assetPath = pathValidation.sanitized;
-        const fromSection = extractString(params, 'fromSection');
-        const toSection = extractString(params, 'toSection');
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawAssetPath = extractOptionalString(params, 'assetPath');
+    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
+    if (assetPath && !assetPath.valid) {
+      return assetPath.error;
+    }
+    const fromSection = extractString(params, 'fromSection');
+    const toSection = extractString(params, 'toSection');
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'link_sections',
-          assetPath,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'link_sections',
+      assetPath: assetPath?.sanitized,
           fromSection,
           toSection,
           save,
@@ -701,20 +684,20 @@ export async function handleAnimationAuthoringTools(
       }
 
       // ===== 10.3 Blend Spaces =====
-      case 'create_blend_space_1d': {
-        const params = normalizeArgs(args, [
-          { key: 'name', required: true },
-          { key: 'path', aliases: ['directory'], default: '/Game/Animations' },
-          { key: 'skeletonPath', required: true },
-          { key: 'axisName', default: 'Speed' },
-          { key: 'axisMin', default: 0 },
-          { key: 'axisMax', default: 600 },
-          { key: 'save', default: true },
-        ]);
+  case 'create_blend_space_1d': {
+    const params = normalizeArgs(args, [
+      { key: 'name', required: true },
+      { key: 'path', aliases: ['directory'], default: '/Game/Animations' },
+      { key: 'skeletonPath', required: false },
+      { key: 'axisName', default: 'Speed' },
+      { key: 'axisMin', default: 0 },
+      { key: 'axisMax', default: 600 },
+      { key: 'save', default: true },
+    ]);
 
-        const name = extractString(params, 'name');
-        const path = extractOptionalString(params, 'path') ?? '/Game/Animations';
-        const skeletonPath = extractString(params, 'skeletonPath');
+    const name = extractString(params, 'name');
+    const path = extractOptionalString(params, 'path') ?? '/Game/Animations';
+    const skeletonPath = extractOptionalString(params, 'skeletonPath');
         const axisName = extractOptionalString(params, 'axisName') ?? 'Speed';
         const axisMin = extractOptionalNumber(params, 'axisMin') ?? 0;
         const axisMax = extractOptionalNumber(params, 'axisMax') ?? 600;
@@ -737,23 +720,23 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? `Blend Space 1D '${name}' created`);
       }
 
-      case 'create_blend_space_2d': {
-        const params = normalizeArgs(args, [
-          { key: 'name', required: true },
-          { key: 'path', aliases: ['directory'], default: '/Game/Animations' },
-          { key: 'skeletonPath', required: true },
-          { key: 'horizontalAxisName', default: 'Direction' },
-          { key: 'horizontalMin', default: -180 },
-          { key: 'horizontalMax', default: 180 },
-          { key: 'verticalAxisName', default: 'Speed' },
-          { key: 'verticalMin', default: 0 },
-          { key: 'verticalMax', default: 600 },
-          { key: 'save', default: true },
-        ]);
+  case 'create_blend_space_2d': {
+    const params = normalizeArgs(args, [
+      { key: 'name', required: true },
+      { key: 'path', aliases: ['directory'], default: '/Game/Animations' },
+      { key: 'skeletonPath', required: false },
+      { key: 'horizontalAxisName', default: 'Direction' },
+      { key: 'horizontalMin', default: -180 },
+      { key: 'horizontalMax', default: 180 },
+      { key: 'verticalAxisName', default: 'Speed' },
+      { key: 'verticalMin', default: 0 },
+      { key: 'verticalMax', default: 600 },
+      { key: 'save', default: true },
+    ]);
 
-        const name = extractString(params, 'name');
-        const path = extractOptionalString(params, 'path') ?? '/Game/Animations';
-        const skeletonPath = extractString(params, 'skeletonPath');
+    const name = extractString(params, 'name');
+    const path = extractOptionalString(params, 'path') ?? '/Game/Animations';
+    const skeletonPath = extractOptionalString(params, 'skeletonPath');
         const horizontalAxisName = extractOptionalString(params, 'horizontalAxisName') ?? 'Direction';
         const horizontalMin = extractOptionalNumber(params, 'horizontalMin') ?? -180;
         const horizontalMax = extractOptionalNumber(params, 'horizontalMax') ?? 180;
@@ -782,33 +765,31 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? `Blend Space 2D '${name}' created`);
       }
 
-      case 'add_blend_sample': {
-        const params = normalizeArgs(args, [
-          { key: 'assetPath', required: true },
-          { key: 'animationPath', required: true },
-          { key: 'sampleValue', required: true }, // For 1D: number, for 2D: {x, y}
-          { key: 'save', default: true },
-        ]);
+  case 'add_blend_sample': {
+    const params = normalizeArgs(args, [
+      { key: 'assetPath', required: false },
+      { key: 'animationPath', required: false },
+      { key: 'sampleValue', required: true }, // For 1D: number, for 2D: {x, y}
+      { key: 'save', default: true },
+    ]);
 
-        const rawAssetPath = extractString(params, 'assetPath');
-        const pathValidationAsset = validatePath(rawAssetPath, 'assetPath');
-        if (!pathValidationAsset.valid) {
-          return pathValidationAsset.error;
-        }
-        const assetPath = pathValidationAsset.sanitized;
-        const rawAnimationPath = extractString(params, 'animationPath');
-        const pathValidationAnim = validatePath(rawAnimationPath, 'animationPath');
-        if (!pathValidationAnim.valid) {
-          return pathValidationAnim.error;
-        }
-        const animationPath = pathValidationAnim.sanitized;
-        const sampleValue = params['sampleValue'];
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawAssetPath = extractOptionalString(params, 'assetPath');
+    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
+    if (assetPath && !assetPath.valid) {
+      return assetPath.error;
+    }
+    const rawAnimationPath = extractOptionalString(params, 'animationPath');
+    const animationPath = rawAnimationPath ? validatePath(rawAnimationPath, 'animationPath') : undefined;
+    if (animationPath && !animationPath.valid) {
+      return animationPath.error;
+    }
+    const sampleValue = params['sampleValue'];
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'add_blend_sample',
-          assetPath,
-          animationPath,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'add_blend_sample',
+      assetPath: assetPath?.sanitized,
+      animationPath: animationPath?.sanitized,
           sampleValue,
           save,
         })) as AutomationResponse;
@@ -819,33 +800,32 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? 'Blend sample added');
       }
 
-      case 'set_axis_settings': {
-        const params = normalizeArgs(args, [
-          { key: 'assetPath', required: true },
-          { key: 'axis', required: true }, // 'Horizontal', 'Vertical', or 'X' for 1D
-          { key: 'axisName' },
-          { key: 'minValue' },
-          { key: 'maxValue' },
-          { key: 'gridDivisions' },
-          { key: 'save', default: true },
-        ]);
+  case 'set_axis_settings': {
+    const params = normalizeArgs(args, [
+      { key: 'assetPath', required: false },
+      { key: 'axis', required: true }, // 'Horizontal', 'Vertical', or 'X' for 1D
+      { key: 'axisName' },
+      { key: 'minValue' },
+      { key: 'maxValue' },
+      { key: 'gridDivisions' },
+      { key: 'save', default: true },
+    ]);
 
-        const rawAssetPath = extractString(params, 'assetPath');
-        const pathValidation = validatePath(rawAssetPath, 'assetPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const assetPath = pathValidation.sanitized;
-        const axis = extractString(params, 'axis');
-        const axisName = extractOptionalString(params, 'axisName');
-        const minValue = extractOptionalNumber(params, 'minValue');
-        const maxValue = extractOptionalNumber(params, 'maxValue');
-        const gridDivisions = extractOptionalNumber(params, 'gridDivisions');
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawAssetPath = extractOptionalString(params, 'assetPath');
+    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
+    if (assetPath && !assetPath.valid) {
+      return assetPath.error;
+    }
+    const axis = extractString(params, 'axis');
+    const axisName = extractOptionalString(params, 'axisName');
+    const minValue = extractOptionalNumber(params, 'minValue');
+    const maxValue = extractOptionalNumber(params, 'maxValue');
+    const gridDivisions = extractOptionalNumber(params, 'gridDivisions');
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'set_axis_settings',
-          assetPath,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'set_axis_settings',
+      assetPath: assetPath?.sanitized,
           axis,
           axisName,
           minValue,
@@ -860,27 +840,26 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? 'Axis settings updated');
       }
 
-      case 'set_interpolation_settings': {
-        const params = normalizeArgs(args, [
-          { key: 'assetPath', required: true },
-          { key: 'interpolationType', default: 'Lerp' }, // Lerp, Cubic
-          { key: 'targetWeightInterpolationSpeed', default: 5.0 },
-          { key: 'save', default: true },
-        ]);
+  case 'set_interpolation_settings': {
+    const params = normalizeArgs(args, [
+      { key: 'assetPath', required: false },
+      { key: 'interpolationType', default: 'Lerp' }, // Lerp, Cubic
+      { key: 'targetWeightInterpolationSpeed', default: 5.0 },
+      { key: 'save', default: true },
+    ]);
 
-        const rawAssetPath = extractString(params, 'assetPath');
-        const pathValidation = validatePath(rawAssetPath, 'assetPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const assetPath = pathValidation.sanitized;
-        const interpolationType = extractOptionalString(params, 'interpolationType') ?? 'Lerp';
-        const targetWeightInterpolationSpeed = extractOptionalNumber(params, 'targetWeightInterpolationSpeed') ?? 5.0;
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawAssetPath = extractOptionalString(params, 'assetPath');
+    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
+    if (assetPath && !assetPath.valid) {
+      return assetPath.error;
+    }
+    const interpolationType = extractOptionalString(params, 'interpolationType') ?? 'Lerp';
+    const targetWeightInterpolationSpeed = extractOptionalNumber(params, 'targetWeightInterpolationSpeed') ?? 5.0;
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'set_interpolation_settings',
-          assetPath,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'set_interpolation_settings',
+      assetPath: assetPath?.sanitized,
           interpolationType,
           targetWeightInterpolationSpeed,
           save,
@@ -896,13 +875,13 @@ export async function handleAnimationAuthoringTools(
         const params = normalizeArgs(args, [
           { key: 'name', required: true },
           { key: 'path', aliases: ['directory'], default: '/Game/Animations' },
-          { key: 'skeletonPath', required: true },
+          { key: 'skeletonPath', required: false },
           { key: 'save', default: true },
         ]);
 
         const name = extractString(params, 'name');
         const path = extractOptionalString(params, 'path') ?? '/Game/Animations';
-        const skeletonPath = extractString(params, 'skeletonPath');
+        const skeletonPath = extractOptionalString(params, 'skeletonPath');
         const save = extractOptionalBoolean(params, 'save') ?? true;
 
         const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
@@ -919,35 +898,33 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? `Aim Offset '${name}' created`);
       }
 
-      case 'add_aim_offset_sample': {
-        const params = normalizeArgs(args, [
-          { key: 'assetPath', required: true },
-          { key: 'animationPath', required: true },
-          { key: 'yaw', required: true },
-          { key: 'pitch', required: true },
-          { key: 'save', default: true },
-        ]);
+  case 'add_aim_offset_sample': {
+    const params = normalizeArgs(args, [
+      { key: 'assetPath', required: false },
+      { key: 'animationPath', required: false },
+      { key: 'yaw', required: true },
+      { key: 'pitch', required: true },
+      { key: 'save', default: true },
+    ]);
 
-        const rawAssetPath = extractString(params, 'assetPath');
-        const pathValidationAsset = validatePath(rawAssetPath, 'assetPath');
-        if (!pathValidationAsset.valid) {
-          return pathValidationAsset.error;
-        }
-        const assetPath = pathValidationAsset.sanitized;
-        const rawAnimationPath = extractString(params, 'animationPath');
-        const pathValidationAnim = validatePath(rawAnimationPath, 'animationPath');
-        if (!pathValidationAnim.valid) {
-          return pathValidationAnim.error;
-        }
-        const animationPath = pathValidationAnim.sanitized;
-        const yaw = extractOptionalNumber(params, 'yaw') ?? 0;
-        const pitch = extractOptionalNumber(params, 'pitch') ?? 0;
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawAssetPath = extractOptionalString(params, 'assetPath');
+    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
+    if (assetPath && !assetPath.valid) {
+      return assetPath.error;
+    }
+    const rawAnimationPath = extractOptionalString(params, 'animationPath');
+    const animationPath = rawAnimationPath ? validatePath(rawAnimationPath, 'animationPath') : undefined;
+    if (animationPath && !animationPath.valid) {
+      return animationPath.error;
+    }
+    const yaw = extractOptionalNumber(params, 'yaw') ?? 0;
+    const pitch = extractOptionalNumber(params, 'pitch') ?? 0;
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'add_aim_offset_sample',
-          assetPath,
-          animationPath,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'add_aim_offset_sample',
+      assetPath: assetPath?.sanitized,
+      animationPath: animationPath?.sanitized,
           yaw,
           pitch,
           save,
@@ -966,14 +943,14 @@ export async function handleAnimationAuthoringTools(
         const params = normalizeArgs(args, [
           { key: 'name', required: true },
           { key: 'path', aliases: ['directory', 'savePath'], default: '/Game/Blueprints' },
-          { key: 'skeletonPath', required: true },
+          { key: 'skeletonPath', required: false },
           { key: 'parentClass', aliases: ['parent'], default: 'AnimInstance' },
           { key: 'save', default: true },
         ]);
 
         const name = extractString(params, 'name');
         const path = extractOptionalString(params, 'path') ?? '/Game/Blueprints';
-        const skeletonPath = extractString(params, 'skeletonPath');
+        const skeletonPath = extractOptionalString(params, 'skeletonPath');
         const parentClass = extractOptionalString(params, 'parentClass') ?? 'AnimInstance';
         const save = extractOptionalBoolean(params, 'save') ?? true;
 
@@ -992,25 +969,24 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? `Animation Blueprint '${name}' created`);
       }
 
-      case 'add_state_machine': {
-        const params = normalizeArgs(args, [
-          { key: 'blueprintPath', required: true },
-          { key: 'stateMachineName', required: true },
-          { key: 'save', default: true },
-        ]);
+  case 'add_state_machine': {
+    const params = normalizeArgs(args, [
+      { key: 'blueprintPath', required: false },
+      { key: 'stateMachineName', required: true },
+      { key: 'save', default: true },
+    ]);
 
-        const rawBlueprintPath = extractString(params, 'blueprintPath');
-        const pathValidation = validatePath(rawBlueprintPath, 'blueprintPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const blueprintPath = pathValidation.sanitized;
-        const stateMachineName = extractString(params, 'stateMachineName');
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawBlueprintPath = extractOptionalString(params, 'blueprintPath');
+    const blueprintPath = rawBlueprintPath ? validatePath(rawBlueprintPath, 'blueprintPath') : undefined;
+    if (blueprintPath && !blueprintPath.valid) {
+      return blueprintPath.error;
+    }
+    const stateMachineName = extractString(params, 'stateMachineName');
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'add_state_machine',
-          blueprintPath,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'add_state_machine',
+      blueprintPath: blueprintPath?.sanitized,
           stateMachineName,
           save,
         })) as AutomationResponse;
@@ -1023,7 +999,7 @@ export async function handleAnimationAuthoringTools(
 
       case 'add_state': {
         const params = normalizeArgs(args, [
-          { key: 'blueprintPath', required: true },
+          { key: 'blueprintPath', required: false },
           { key: 'stateMachineName', required: true },
           { key: 'stateName', required: true },
           { key: 'animationPath' },
@@ -1031,25 +1007,24 @@ export async function handleAnimationAuthoringTools(
           { key: 'save', default: true },
         ]);
 
-        const rawBlueprintPath = extractString(params, 'blueprintPath');
-        const pathValidation = validatePath(rawBlueprintPath, 'blueprintPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const blueprintPath = pathValidation.sanitized;
-        const stateMachineName = extractString(params, 'stateMachineName');
-        const stateName = extractString(params, 'stateName');
-        const rawAnimationPath = extractOptionalString(params, 'animationPath');
-        const animationPath = rawAnimationPath ? validatePath(rawAnimationPath, 'animationPath') : undefined;
-        if (animationPath && !animationPath.valid) {
-          return animationPath.error;
-        }
-        const isEntryState = extractOptionalBoolean(params, 'isEntryState') ?? false;
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+      const rawBlueprintPath = extractOptionalString(params, 'blueprintPath');
+      const blueprintPath = rawBlueprintPath ? validatePath(rawBlueprintPath, 'blueprintPath') : undefined;
+      if (blueprintPath && !blueprintPath.valid) {
+        return blueprintPath.error;
+      }
+      const stateMachineName = extractString(params, 'stateMachineName');
+      const stateName = extractString(params, 'stateName');
+      const rawAnimationPath = extractOptionalString(params, 'animationPath');
+      const animationPath = rawAnimationPath ? validatePath(rawAnimationPath, 'animationPath') : undefined;
+      if (animationPath && !animationPath.valid) {
+        return animationPath.error;
+      }
+      const isEntryState = extractOptionalBoolean(params, 'isEntryState') ?? false;
+      const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'add_state',
-          blueprintPath,
+      const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+        subAction: 'add_state',
+        blueprintPath: blueprintPath?.sanitized,
           stateMachineName,
           stateName,
           animationPath: animationPath?.sanitized,
@@ -1065,27 +1040,26 @@ export async function handleAnimationAuthoringTools(
 
       case 'add_transition': {
         const params = normalizeArgs(args, [
-          { key: 'blueprintPath', required: true },
+          { key: 'blueprintPath', required: false },
           { key: 'stateMachineName', required: true },
           { key: 'fromState', required: true },
           { key: 'toState', required: true },
           { key: 'save', default: true },
         ]);
 
-        const rawBlueprintPath = extractString(params, 'blueprintPath');
-        const pathValidation = validatePath(rawBlueprintPath, 'blueprintPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const blueprintPath = pathValidation.sanitized;
-        const stateMachineName = extractString(params, 'stateMachineName');
-        const fromState = extractString(params, 'fromState');
-        const toState = extractString(params, 'toState');
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+      const rawBlueprintPath = extractOptionalString(params, 'blueprintPath');
+      const blueprintPath = rawBlueprintPath ? validatePath(rawBlueprintPath, 'blueprintPath') : undefined;
+      if (blueprintPath && !blueprintPath.valid) {
+        return blueprintPath.error;
+      }
+      const stateMachineName = extractString(params, 'stateMachineName');
+      const fromState = extractString(params, 'fromState');
+      const toState = extractString(params, 'toState');
+      const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'add_transition',
-          blueprintPath,
+      const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+        subAction: 'add_transition',
+        blueprintPath: blueprintPath?.sanitized,
           stateMachineName,
           fromState,
           toState,
@@ -1100,7 +1074,7 @@ export async function handleAnimationAuthoringTools(
 
       case 'set_transition_rules': {
         const params = normalizeArgs(args, [
-          { key: 'blueprintPath', required: true },
+          { key: 'blueprintPath', required: false },
           { key: 'stateMachineName', required: true },
           { key: 'fromState', required: true },
           { key: 'toState', required: true },
@@ -1111,24 +1085,23 @@ export async function handleAnimationAuthoringTools(
           { key: 'save', default: true },
         ]);
 
-        const rawBlueprintPath = extractString(params, 'blueprintPath');
-        const pathValidation = validatePath(rawBlueprintPath, 'blueprintPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const blueprintPath = pathValidation.sanitized;
-        const stateMachineName = extractString(params, 'stateMachineName');
-        const fromState = extractString(params, 'fromState');
-        const toState = extractString(params, 'toState');
-        const blendTime = extractOptionalNumber(params, 'blendTime') ?? 0.2;
-        const blendLogicType = extractOptionalString(params, 'blendLogicType') ?? 'StandardBlend';
-        const automaticTriggerRule = extractOptionalString(params, 'automaticTriggerRule');
-        const automaticTriggerTime = extractOptionalNumber(params, 'automaticTriggerTime');
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+  const rawBlueprintPath = extractOptionalString(params, 'blueprintPath');
+  const blueprintPath = rawBlueprintPath ? validatePath(rawBlueprintPath, 'blueprintPath') : undefined;
+  if (blueprintPath && !blueprintPath.valid) {
+    return blueprintPath.error;
+  }
+  const stateMachineName = extractString(params, 'stateMachineName');
+  const fromState = extractString(params, 'fromState');
+  const toState = extractString(params, 'toState');
+  const blendTime = extractOptionalNumber(params, 'blendTime') ?? 0.2;
+  const blendLogicType = extractOptionalString(params, 'blendLogicType') ?? 'StandardBlend';
+  const automaticTriggerRule = extractOptionalString(params, 'automaticTriggerRule');
+  const automaticTriggerTime = extractOptionalNumber(params, 'automaticTriggerTime');
+  const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'set_transition_rules',
-          blueprintPath,
+  const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+    subAction: 'set_transition_rules',
+    blueprintPath: blueprintPath?.sanitized,
           stateMachineName,
           fromState,
           toState,
@@ -1147,7 +1120,7 @@ export async function handleAnimationAuthoringTools(
 
       case 'add_blend_node': {
         const params = normalizeArgs(args, [
-          { key: 'blueprintPath', required: true },
+          { key: 'blueprintPath', required: false },
           { key: 'blendType', required: true }, // TwoWayBlend, BlendByBool, BlendPosesByBool, etc.
           { key: 'nodeName' },
           { key: 'x', default: 0 },
@@ -1155,21 +1128,20 @@ export async function handleAnimationAuthoringTools(
           { key: 'save', default: true },
         ]);
 
-        const rawBlueprintPath = extractString(params, 'blueprintPath');
-        const pathValidation = validatePath(rawBlueprintPath, 'blueprintPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const blueprintPath = pathValidation.sanitized;
-        const blendType = extractString(params, 'blendType');
-        const nodeName = extractOptionalString(params, 'nodeName');
-        const x = extractOptionalNumber(params, 'x') ?? 0;
-        const y = extractOptionalNumber(params, 'y') ?? 0;
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+  const rawBlueprintPath = extractOptionalString(params, 'blueprintPath');
+  const blueprintPath = rawBlueprintPath ? validatePath(rawBlueprintPath, 'blueprintPath') : undefined;
+  if (blueprintPath && !blueprintPath.valid) {
+    return blueprintPath.error;
+  }
+  const blendType = extractString(params, 'blendType');
+  const nodeName = extractOptionalString(params, 'nodeName');
+  const x = extractOptionalNumber(params, 'x') ?? 0;
+  const y = extractOptionalNumber(params, 'y') ?? 0;
+  const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'add_blend_node',
-          blueprintPath,
+  const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+    subAction: 'add_blend_node',
+    blueprintPath: blueprintPath?.sanitized,
           blendType,
           nodeName,
           x,
@@ -1185,52 +1157,50 @@ export async function handleAnimationAuthoringTools(
 
       case 'add_cached_pose': {
         const params = normalizeArgs(args, [
-          { key: 'blueprintPath', required: true },
+          { key: 'blueprintPath', required: false },
           { key: 'cacheName', required: true },
           { key: 'save', default: true },
         ]);
 
-        const rawBlueprintPath = extractString(params, 'blueprintPath');
-        const pathValidation = validatePath(rawBlueprintPath, 'blueprintPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const blueprintPath = pathValidation.sanitized;
-        const cacheName = extractString(params, 'cacheName');
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+  const rawBlueprintPath = extractOptionalString(params, 'blueprintPath');
+  const blueprintPath = rawBlueprintPath ? validatePath(rawBlueprintPath, 'blueprintPath') : undefined;
+  if (blueprintPath && !blueprintPath.valid) {
+    return blueprintPath.error;
+  }
+  const cacheName = extractString(params, 'cacheName');
+  const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'add_cached_pose',
-          blueprintPath,
-          cacheName,
-          save,
-        })) as AutomationResponse;
+  const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+    subAction: 'add_cached_pose',
+    blueprintPath: blueprintPath?.sanitized,
+    cacheName,
+    save,
+  })) as AutomationResponse;
 
-        if (res.success === false) {
-          return ResponseFactory.error(res.error ?? 'Failed to add cached pose', res.errorCode);
-        }
-        return ResponseFactory.success(res, res.message ?? `Cached pose '${cacheName}' added`);
+  if (res.success === false) {
+    return ResponseFactory.error(res.error ?? 'Failed to add cached pose', res.errorCode);
+  }
+  return ResponseFactory.success(res, res.message ?? `Cached pose '${cacheName}' added`);
       }
 
       case 'add_slot_node': {
         const params = normalizeArgs(args, [
-          { key: 'blueprintPath', required: true },
+          { key: 'blueprintPath', required: false },
           { key: 'slotName', required: true },
           { key: 'save', default: true },
         ]);
 
-        const rawBlueprintPath = extractString(params, 'blueprintPath');
-        const pathValidation = validatePath(rawBlueprintPath, 'blueprintPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const blueprintPath = pathValidation.sanitized;
-        const slotName = extractString(params, 'slotName');
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+  const rawBlueprintPath = extractOptionalString(params, 'blueprintPath');
+  const blueprintPath = rawBlueprintPath ? validatePath(rawBlueprintPath, 'blueprintPath') : undefined;
+  if (blueprintPath && !blueprintPath.valid) {
+    return blueprintPath.error;
+  }
+  const slotName = extractString(params, 'slotName');
+  const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'add_slot_node',
-          blueprintPath,
+  const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+    subAction: 'add_slot_node',
+    blueprintPath: blueprintPath?.sanitized,
           slotName,
           save,
         })) as AutomationResponse;
@@ -1243,23 +1213,22 @@ export async function handleAnimationAuthoringTools(
 
       case 'add_layered_blend_per_bone': {
         const params = normalizeArgs(args, [
-          { key: 'blueprintPath', required: true },
+          { key: 'blueprintPath', required: false },
           { key: 'layerSetup' }, // Array of {branchFilters: [{boneName, blendDepth}]}
           { key: 'save', default: true },
         ]);
 
-        const rawBlueprintPath = extractString(params, 'blueprintPath');
-        const pathValidation = validatePath(rawBlueprintPath, 'blueprintPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const blueprintPath = pathValidation.sanitized;
-        const layerSetup = extractOptionalArray(params, 'layerSetup');
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+  const rawBlueprintPath = extractOptionalString(params, 'blueprintPath');
+  const blueprintPath = rawBlueprintPath ? validatePath(rawBlueprintPath, 'blueprintPath') : undefined;
+  if (blueprintPath && !blueprintPath.valid) {
+    return blueprintPath.error;
+  }
+  const layerSetup = extractOptionalArray(params, 'layerSetup');
+  const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'add_layered_blend_per_bone',
-          blueprintPath,
+  const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+    subAction: 'add_layered_blend_per_bone',
+    blueprintPath: blueprintPath?.sanitized,
           layerSetup,
           save,
         })) as AutomationResponse;
@@ -1272,27 +1241,26 @@ export async function handleAnimationAuthoringTools(
 
       case 'set_anim_graph_node_value': {
         const params = normalizeArgs(args, [
-          { key: 'blueprintPath', required: true },
+          { key: 'blueprintPath', required: false },
           { key: 'nodeName', required: true },
           { key: 'propertyName', required: true },
           { key: 'value', required: true },
           { key: 'save', default: true },
         ]);
 
-        const rawBlueprintPath = extractString(params, 'blueprintPath');
-        const pathValidation = validatePath(rawBlueprintPath, 'blueprintPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const blueprintPath = pathValidation.sanitized;
-        const nodeName = extractString(params, 'nodeName');
-        const propertyName = extractString(params, 'propertyName');
-        const value = params['value'];
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+  const rawBlueprintPath = extractOptionalString(params, 'blueprintPath');
+  const blueprintPath = rawBlueprintPath ? validatePath(rawBlueprintPath, 'blueprintPath') : undefined;
+  if (blueprintPath && !blueprintPath.valid) {
+    return blueprintPath.error;
+  }
+  const nodeName = extractString(params, 'nodeName');
+  const propertyName = extractString(params, 'propertyName');
+  const value = params['value'];
+  const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'set_anim_graph_node_value',
-          blueprintPath,
+  const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+    subAction: 'set_anim_graph_node_value',
+    blueprintPath: blueprintPath?.sanitized,
           nodeName,
           propertyName,
           value,
@@ -1306,26 +1274,29 @@ export async function handleAnimationAuthoringTools(
       }
 
       // ===== 10.5 Control Rig =====
-      case 'create_control_rig': {
-        const params = normalizeArgs(args, [
-          { key: 'name', required: true },
-          { key: 'path', aliases: ['directory'], default: '/Game/ControlRigs' },
-          { key: 'skeletalMeshPath', required: true },
-          { key: 'save', default: true },
-        ]);
+	case 'create_control_rig': {
+			const params = normalizeArgs(args, [
+				{ key: 'name', required: true },
+				{ key: 'path', aliases: ['directory'], default: '/Game/ControlRigs' },
+				{ key: 'skeletalMeshPath', required: false },
+				{ key: 'skeletonPath', required: false },
+				{ key: 'save', default: true },
+			]);
 
-        const name = extractString(params, 'name');
-        const path = extractOptionalString(params, 'path') ?? '/Game/ControlRigs';
-        const skeletalMeshPath = extractString(params, 'skeletalMeshPath');
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+			const name = extractString(params, 'name');
+			const path = extractOptionalString(params, 'path') ?? '/Game/ControlRigs';
+			const skeletalMeshPath = extractOptionalString(params, 'skeletalMeshPath');
+			const skeletonPath = extractOptionalString(params, 'skeletonPath');
+			const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'create_control_rig',
-          name,
-          path,
-          skeletalMeshPath,
-          save,
-        })) as AutomationResponse;
+			const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+				subAction: 'create_control_rig',
+				name,
+				path,
+				skeletalMeshPath,
+				skeletonPath,
+				save,
+			})) as AutomationResponse;
 
         if (res.success === false) {
           return ResponseFactory.error(res.error ?? 'Failed to create control rig', res.errorCode);
@@ -1335,7 +1306,7 @@ export async function handleAnimationAuthoringTools(
 
       case 'add_control': {
         const params = normalizeArgs(args, [
-          { key: 'assetPath', required: true },
+          { key: 'assetPath', required: false },
           { key: 'controlName', required: true },
           { key: 'controlType', default: 'Transform' }, // Transform, Bool, Float, Integer, Vector2D
           { key: 'parentBone' },
@@ -1343,21 +1314,20 @@ export async function handleAnimationAuthoringTools(
           { key: 'save', default: true },
         ]);
 
-        const rawAssetPath = extractString(params, 'assetPath');
-        const pathValidation = validatePath(rawAssetPath, 'assetPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const assetPath = pathValidation.sanitized;
-        const controlName = extractString(params, 'controlName');
-        const controlType = extractOptionalString(params, 'controlType') ?? 'Transform';
-        const parentBone = extractOptionalString(params, 'parentBone');
-        const parentControl = extractOptionalString(params, 'parentControl');
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+  const rawAssetPath = extractOptionalString(params, 'assetPath');
+  const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
+  if (assetPath && !assetPath.valid) {
+    return assetPath.error;
+  }
+  const controlName = extractString(params, 'controlName');
+  const controlType = extractOptionalString(params, 'controlType') ?? 'Transform';
+  const parentBone = extractOptionalString(params, 'parentBone');
+  const parentControl = extractOptionalString(params, 'parentControl');
+  const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'add_control',
-          assetPath,
+  const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+    subAction: 'add_control',
+    assetPath: assetPath?.sanitized,
           controlName,
           controlType,
           parentBone,
@@ -1373,27 +1343,26 @@ export async function handleAnimationAuthoringTools(
 
       case 'add_rig_unit': {
         const params = normalizeArgs(args, [
-          { key: 'assetPath', required: true },
+          { key: 'assetPath', required: false },
           { key: 'unitType', required: true }, // FKIK, Aim, BasicIK, TwoBoneIK, FABRIK, etc.
           { key: 'unitName' },
           { key: 'settings' }, // Unit-specific settings
           { key: 'save', default: true },
         ]);
 
-        const rawAssetPath = extractString(params, 'assetPath');
-        const pathValidation = validatePath(rawAssetPath, 'assetPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const assetPath = pathValidation.sanitized;
-        const unitType = extractString(params, 'unitType');
-        const unitName = extractOptionalString(params, 'unitName');
-        const settings = extractOptionalObject(params, 'settings');
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+  const rawAssetPath = extractOptionalString(params, 'assetPath');
+  const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
+  if (assetPath && !assetPath.valid) {
+    return assetPath.error;
+  }
+  const unitType = extractString(params, 'unitType');
+  const unitName = extractOptionalString(params, 'unitName');
+  const settings = extractOptionalObject(params, 'settings');
+  const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'add_rig_unit',
-          assetPath,
+  const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+    subAction: 'add_rig_unit',
+    assetPath: assetPath?.sanitized,
           unitType,
           unitName,
           settings,
@@ -1408,7 +1377,7 @@ export async function handleAnimationAuthoringTools(
 
       case 'connect_rig_elements': {
         const params = normalizeArgs(args, [
-          { key: 'assetPath', required: true },
+          { key: 'assetPath', required: false },
           { key: 'sourceElement', required: true },
           { key: 'sourcePin', required: true },
           { key: 'targetElement', required: true },
@@ -1416,21 +1385,20 @@ export async function handleAnimationAuthoringTools(
           { key: 'save', default: true },
         ]);
 
-        const rawAssetPath = extractString(params, 'assetPath');
-        const pathValidation = validatePath(rawAssetPath, 'assetPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const assetPath = pathValidation.sanitized;
-        const sourceElement = extractString(params, 'sourceElement');
-        const sourcePin = extractString(params, 'sourcePin');
-        const targetElement = extractString(params, 'targetElement');
-        const targetPin = extractString(params, 'targetPin');
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+  const rawAssetPath = extractOptionalString(params, 'assetPath');
+  const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
+  if (assetPath && !assetPath.valid) {
+    return assetPath.error;
+  }
+  const sourceElement = extractString(params, 'sourceElement');
+  const sourcePin = extractString(params, 'sourcePin');
+  const targetElement = extractString(params, 'targetElement');
+  const targetPin = extractString(params, 'targetPin');
+  const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'connect_rig_elements',
-          assetPath,
+  const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+    subAction: 'connect_rig_elements',
+    assetPath: assetPath?.sanitized,
           sourceElement,
           sourcePin,
           targetElement,
@@ -1448,13 +1416,13 @@ export async function handleAnimationAuthoringTools(
         const params = normalizeArgs(args, [
           { key: 'name', required: true },
           { key: 'path', aliases: ['directory'], default: '/Game/Animations' },
-          { key: 'skeletonPath', required: true },
+          { key: 'skeletonPath', required: false },
           { key: 'save', default: true },
         ]);
 
         const name = extractString(params, 'name');
         const path = extractOptionalString(params, 'path') ?? '/Game/Animations';
-        const skeletonPath = extractString(params, 'skeletonPath');
+        const skeletonPath = extractOptionalString(params, 'skeletonPath');
         const save = extractOptionalBoolean(params, 'save') ?? true;
 
         const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
@@ -1472,26 +1440,29 @@ export async function handleAnimationAuthoringTools(
       }
 
       // ===== 10.6 Retargeting =====
-      case 'create_ik_rig': {
-        const params = normalizeArgs(args, [
-          { key: 'name', required: true },
-          { key: 'path', aliases: ['directory'], default: '/Game/Retargeting' },
-          { key: 'skeletalMeshPath', required: true },
-          { key: 'save', default: true },
-        ]);
+  case 'create_ik_rig': {
+    const params = normalizeArgs(args, [
+      { key: 'name', required: true },
+      { key: 'path', aliases: ['directory'], default: '/Game/Retargeting' },
+      { key: 'skeletalMeshPath', required: false },
+      { key: 'skeletonPath', required: false },
+      { key: 'save', default: true },
+    ]);
 
-        const name = extractString(params, 'name');
-        const path = extractOptionalString(params, 'path') ?? '/Game/Retargeting';
-        const skeletalMeshPath = extractString(params, 'skeletalMeshPath');
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+    const name = extractString(params, 'name');
+    const path = extractOptionalString(params, 'path') ?? '/Game/Retargeting';
+    const skeletalMeshPath = extractOptionalString(params, 'skeletalMeshPath');
+    const skeletonPath = extractOptionalString(params, 'skeletonPath');
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'create_ik_rig',
-          name,
-          path,
-          skeletalMeshPath,
-          save,
-        })) as AutomationResponse;
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'create_ik_rig',
+      name,
+      path,
+      skeletalMeshPath,
+      skeletonPath,
+      save,
+    })) as AutomationResponse;
 
         if (res.success === false) {
           return ResponseFactory.error(res.error ?? 'Failed to create IK rig', res.errorCode);
@@ -1501,7 +1472,7 @@ export async function handleAnimationAuthoringTools(
 
       case 'add_ik_chain': {
         const params = normalizeArgs(args, [
-          { key: 'assetPath', required: true },
+          { key: 'assetPath', required: false },
           { key: 'chainName', required: true },
           { key: 'startBone', required: true },
           { key: 'endBone', required: true },
@@ -1509,21 +1480,20 @@ export async function handleAnimationAuthoringTools(
           { key: 'save', default: true },
         ]);
 
-        const rawAssetPath = extractString(params, 'assetPath');
-        const pathValidation = validatePath(rawAssetPath, 'assetPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const assetPath = pathValidation.sanitized;
-        const chainName = extractString(params, 'chainName');
-        const startBone = extractString(params, 'startBone');
-        const endBone = extractString(params, 'endBone');
-        const goal = extractOptionalString(params, 'goal');
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+  const rawAssetPath = extractOptionalString(params, 'assetPath');
+  const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
+  if (assetPath && !assetPath.valid) {
+    return assetPath.error;
+  }
+  const chainName = extractString(params, 'chainName');
+  const startBone = extractString(params, 'startBone');
+  const endBone = extractString(params, 'endBone');
+  const goal = extractOptionalString(params, 'goal');
+  const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'add_ik_chain',
-          assetPath,
+  const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+    subAction: 'add_ik_chain',
+    assetPath: assetPath?.sanitized,
           chainName,
           startBone,
           endBone,
@@ -1569,25 +1539,24 @@ export async function handleAnimationAuthoringTools(
 
       case 'set_retarget_chain_mapping': {
         const params = normalizeArgs(args, [
-          { key: 'assetPath', required: true },
+          { key: 'assetPath', required: false },
           { key: 'sourceChain', required: true },
           { key: 'targetChain', required: true },
           { key: 'save', default: true },
         ]);
 
-        const rawAssetPath = extractString(params, 'assetPath');
-        const pathValidation = validatePath(rawAssetPath, 'assetPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const assetPath = pathValidation.sanitized;
-        const sourceChain = extractString(params, 'sourceChain');
-        const targetChain = extractString(params, 'targetChain');
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+  const rawAssetPath = extractOptionalString(params, 'assetPath');
+  const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
+  if (assetPath && !assetPath.valid) {
+    return assetPath.error;
+  }
+  const sourceChain = extractString(params, 'sourceChain');
+  const targetChain = extractString(params, 'targetChain');
+  const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'set_retarget_chain_mapping',
-          assetPath,
+  const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+    subAction: 'set_retarget_chain_mapping',
+    assetPath: assetPath?.sanitized,
           sourceChain,
           targetChain,
           save,
@@ -1602,19 +1571,18 @@ export async function handleAnimationAuthoringTools(
       // ===== Utility =====
       case 'get_animation_info': {
         const params = normalizeArgs(args, [
-          { key: 'assetPath', required: true },
+          { key: 'assetPath', required: false },
         ]);
 
-        const rawAssetPath = extractString(params, 'assetPath');
-        const pathValidation = validatePath(rawAssetPath, 'assetPath');
-        if (!pathValidation.valid) {
-          return pathValidation.error;
-        }
-        const assetPath = pathValidation.sanitized;
+  const rawAssetPath = extractOptionalString(params, 'assetPath');
+  const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
+  if (assetPath && !assetPath.valid) {
+    return assetPath.error;
+  }
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'get_animation_info',
-          assetPath,
+  const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+    subAction: 'get_animation_info',
+    assetPath: assetPath?.sanitized,
         })) as AutomationResponse;
 
         if (res.success === false) {

--- a/src/tools/handlers/animation-authoring-handlers.ts
+++ b/src/tools/handlers/animation-authoring-handlers.ts
@@ -106,24 +106,25 @@ export async function handleAnimationAuthoringTools(
 
   case 'set_sequence_length': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: false },
+      { key: 'assetPath', required: true },
       { key: 'numFrames', required: true },
       { key: 'frameRate' },
       { key: 'save', default: true },
     ]);
 
-    const rawAssetPath = extractOptionalString(params, 'assetPath');
-    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
-    if (assetPath && !assetPath.valid) {
-      return assetPath.error;
+    const rawAssetPath = extractString(params, 'assetPath');
+    const assetPathValidation = validatePath(rawAssetPath, 'assetPath');
+    if (!assetPathValidation.valid) {
+      return assetPathValidation.error;
     }
-        const numFrames = extractOptionalNumber(params, 'numFrames') ?? 30;
-        const frameRate = extractOptionalNumber(params, 'frameRate');
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+    const assetPath = assetPathValidation.sanitized;
+    const numFrames = extractOptionalNumber(params, 'numFrames') ?? 30;
+    const frameRate = extractOptionalNumber(params, 'frameRate');
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
     const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
       subAction: 'set_sequence_length',
-      assetPath: assetPath?.sanitized,
+      assetPath,
       numFrames,
           frameRate,
           save,
@@ -137,22 +138,23 @@ export async function handleAnimationAuthoringTools(
 
   case 'add_bone_track': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: false },
+      { key: 'assetPath', required: true },
       { key: 'boneName', required: true },
       { key: 'save', default: true },
     ]);
 
-    const rawAssetPath = extractOptionalString(params, 'assetPath');
-    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
-    if (assetPath && !assetPath.valid) {
-      return assetPath.error;
+    const rawAssetPath = extractString(params, 'assetPath');
+    const assetPathValidation = validatePath(rawAssetPath, 'assetPath');
+    if (!assetPathValidation.valid) {
+      return assetPathValidation.error;
     }
+    const assetPath = assetPathValidation.sanitized;
     const boneName = extractString(params, 'boneName');
     const save = extractOptionalBoolean(params, 'save') ?? true;
 
     const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
       subAction: 'add_bone_track',
-      assetPath: assetPath?.sanitized,
+      assetPath,
           boneName,
           save,
         })) as AutomationResponse;
@@ -165,7 +167,7 @@ export async function handleAnimationAuthoringTools(
 
   case 'set_bone_key': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: false },
+      { key: 'assetPath', required: true },
       { key: 'boneName', required: true },
       { key: 'frame', required: true },
       { key: 'location' }, // {x, y, z}
@@ -174,11 +176,12 @@ export async function handleAnimationAuthoringTools(
       { key: 'save', default: true },
     ]);
 
-    const rawAssetPath = extractOptionalString(params, 'assetPath');
-    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
-    if (assetPath && !assetPath.valid) {
-      return assetPath.error;
+    const rawAssetPath = extractString(params, 'assetPath');
+    const assetPathValidation = validatePath(rawAssetPath, 'assetPath');
+    if (!assetPathValidation.valid) {
+      return assetPathValidation.error;
     }
+    const assetPath = assetPathValidation.sanitized;
     const boneName = extractString(params, 'boneName');
     const frame = extractOptionalNumber(params, 'frame') ?? 0;
     const location = extractOptionalObject(params, 'location');
@@ -188,7 +191,7 @@ export async function handleAnimationAuthoringTools(
 
     const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
       subAction: 'set_bone_key',
-      assetPath: assetPath?.sanitized,
+      assetPath,
       boneName,
       frame,
       location,
@@ -205,7 +208,7 @@ export async function handleAnimationAuthoringTools(
 
   case 'set_curve_key': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: false },
+      { key: 'assetPath', required: true },
       { key: 'curveName', required: true },
       { key: 'frame', required: true },
       { key: 'value', required: true },
@@ -213,11 +216,12 @@ export async function handleAnimationAuthoringTools(
       { key: 'save', default: true },
     ]);
 
-    const rawAssetPath = extractOptionalString(params, 'assetPath');
-    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
-    if (assetPath && !assetPath.valid) {
-      return assetPath.error;
+    const rawAssetPath = extractString(params, 'assetPath');
+    const assetPathValidation = validatePath(rawAssetPath, 'assetPath');
+    if (!assetPathValidation.valid) {
+      return assetPathValidation.error;
     }
+    const assetPath = assetPathValidation.sanitized;
     const curveName = extractString(params, 'curveName');
     const frame = extractOptionalNumber(params, 'frame') ?? 0;
     const value = extractOptionalNumber(params, 'value') ?? 0;
@@ -226,7 +230,7 @@ export async function handleAnimationAuthoringTools(
 
     const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
       subAction: 'set_curve_key',
-      assetPath: assetPath?.sanitized,
+      assetPath,
           curveName,
           frame,
           value,
@@ -242,7 +246,7 @@ export async function handleAnimationAuthoringTools(
 
   case 'add_notify': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: false },
+      { key: 'assetPath', required: true },
       { key: 'notifyClass', required: false },
       { key: 'frame', required: true },
       { key: 'trackIndex', default: 0 },
@@ -250,11 +254,12 @@ export async function handleAnimationAuthoringTools(
       { key: 'save', default: true },
     ]);
 
-    const rawAssetPath = extractOptionalString(params, 'assetPath');
-    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
-    if (assetPath && !assetPath.valid) {
-      return assetPath.error;
+    const rawAssetPath = extractString(params, 'assetPath');
+    const assetPathValidation = validatePath(rawAssetPath, 'assetPath');
+    if (!assetPathValidation.valid) {
+      return assetPathValidation.error;
     }
+    const assetPath = assetPathValidation.sanitized;
     const notifyClass = extractOptionalString(params, 'notifyClass');
     const frame = extractOptionalNumber(params, 'frame') ?? 0;
     const trackIndex = extractOptionalNumber(params, 'trackIndex') ?? 0;
@@ -263,7 +268,7 @@ export async function handleAnimationAuthoringTools(
 
     const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
       subAction: 'add_notify',
-      assetPath: assetPath?.sanitized,
+      assetPath,
       notifyClass,
       frame,
           trackIndex,
@@ -279,7 +284,7 @@ export async function handleAnimationAuthoringTools(
 
   case 'add_notify_state': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: false },
+      { key: 'assetPath', required: true },
       { key: 'notifyClass', required: false },
       { key: 'startFrame', required: true },
       { key: 'endFrame', required: true },
@@ -288,11 +293,12 @@ export async function handleAnimationAuthoringTools(
       { key: 'save', default: true },
     ]);
 
-    const rawAssetPath = extractOptionalString(params, 'assetPath');
-    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
-    if (assetPath && !assetPath.valid) {
-      return assetPath.error;
+    const rawAssetPath = extractString(params, 'assetPath');
+    const assetPathValidation = validatePath(rawAssetPath, 'assetPath');
+    if (!assetPathValidation.valid) {
+      return assetPathValidation.error;
     }
+    const assetPath = assetPathValidation.sanitized;
     const notifyClass = extractOptionalString(params, 'notifyClass');
     const startFrame = extractOptionalNumber(params, 'startFrame') ?? 0;
     const endFrame = extractOptionalNumber(params, 'endFrame') ?? 10;
@@ -302,7 +308,7 @@ export async function handleAnimationAuthoringTools(
 
     const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
       subAction: 'add_notify_state',
-      assetPath: assetPath?.sanitized,
+      assetPath,
           notifyClass,
           startFrame,
           endFrame,
@@ -319,24 +325,25 @@ export async function handleAnimationAuthoringTools(
 
   case 'add_sync_marker': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: false },
+      { key: 'assetPath', required: true },
       { key: 'markerName', required: true },
       { key: 'frame', required: true },
       { key: 'save', default: true },
     ]);
 
-    const rawAssetPath = extractOptionalString(params, 'assetPath');
-    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
-    if (assetPath && !assetPath.valid) {
-      return assetPath.error;
+    const rawAssetPath = extractString(params, 'assetPath');
+    const assetPathValidation = validatePath(rawAssetPath, 'assetPath');
+    if (!assetPathValidation.valid) {
+      return assetPathValidation.error;
     }
+    const assetPath = assetPathValidation.sanitized;
     const markerName = extractString(params, 'markerName');
     const frame = extractOptionalNumber(params, 'frame') ?? 0;
     const save = extractOptionalBoolean(params, 'save') ?? true;
 
     const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
       subAction: 'add_sync_marker',
-      assetPath: assetPath?.sanitized,
+      assetPath,
           markerName,
           frame,
           save,
@@ -350,18 +357,19 @@ export async function handleAnimationAuthoringTools(
 
   case 'set_root_motion_settings': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: false },
+      { key: 'assetPath', required: true },
       { key: 'enableRootMotion', default: true },
       { key: 'rootMotionRootLock', default: 'RefPose' },
       { key: 'forceRootLock', default: false },
       { key: 'save', default: true },
     ]);
 
-    const rawAssetPath = extractOptionalString(params, 'assetPath');
-    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
-    if (assetPath && !assetPath.valid) {
-      return assetPath.error;
+    const rawAssetPath = extractString(params, 'assetPath');
+    const assetPathValidation = validatePath(rawAssetPath, 'assetPath');
+    if (!assetPathValidation.valid) {
+      return assetPathValidation.error;
     }
+    const assetPath = assetPathValidation.sanitized;
     const enableRootMotion = extractOptionalBoolean(params, 'enableRootMotion') ?? true;
     const rootMotionRootLock = extractOptionalString(params, 'rootMotionRootLock') ?? 'RefPose';
     const forceRootLock = extractOptionalBoolean(params, 'forceRootLock') ?? false;
@@ -369,7 +377,7 @@ export async function handleAnimationAuthoringTools(
 
     const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
       subAction: 'set_root_motion_settings',
-      assetPath: assetPath?.sanitized,
+      assetPath,
           enableRootMotion,
           rootMotionRootLock,
           forceRootLock,
@@ -384,7 +392,7 @@ export async function handleAnimationAuthoringTools(
 
   case 'set_additive_settings': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: false },
+      { key: 'assetPath', required: true },
       { key: 'additiveAnimType', default: 'NoAdditive' }, // NoAdditive, LocalSpaceAdditive, MeshSpaceAdditive
       { key: 'basePoseType', default: 'RefPose' }, // RefPose, AnimationFrame, AnimationScaled
       { key: 'basePoseAnimation' },
@@ -392,11 +400,12 @@ export async function handleAnimationAuthoringTools(
       { key: 'save', default: true },
     ]);
 
-    const rawAssetPath = extractOptionalString(params, 'assetPath');
-    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
-    if (assetPath && !assetPath.valid) {
-      return assetPath.error;
+    const rawAssetPath = extractString(params, 'assetPath');
+    const assetPathValidation = validatePath(rawAssetPath, 'assetPath');
+    if (!assetPathValidation.valid) {
+      return assetPathValidation.error;
     }
+    const assetPath = assetPathValidation.sanitized;
     const additiveAnimType = extractOptionalString(params, 'additiveAnimType') ?? 'NoAdditive';
     const basePoseType = extractOptionalString(params, 'basePoseType') ?? 'RefPose';
     const basePoseAnimation = extractOptionalString(params, 'basePoseAnimation');
@@ -405,7 +414,7 @@ export async function handleAnimationAuthoringTools(
 
     const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
       subAction: 'set_additive_settings',
-      assetPath: assetPath?.sanitized,
+      assetPath,
           additiveAnimType,
           basePoseType,
           basePoseAnimation,
@@ -452,24 +461,25 @@ export async function handleAnimationAuthoringTools(
 
   case 'add_montage_section': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: false },
+      { key: 'assetPath', required: true },
       { key: 'sectionName', required: true },
       { key: 'startTime', required: true },
       { key: 'save', default: true },
     ]);
 
-    const rawAssetPath = extractOptionalString(params, 'assetPath');
-    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
-    if (assetPath && !assetPath.valid) {
-      return assetPath.error;
+    const rawAssetPath = extractString(params, 'assetPath');
+    const assetPathValidation = validatePath(rawAssetPath, 'assetPath');
+    if (!assetPathValidation.valid) {
+      return assetPathValidation.error;
     }
+    const assetPath = assetPathValidation.sanitized;
     const sectionName = extractString(params, 'sectionName');
     const startTime = extractOptionalNumber(params, 'startTime') ?? 0;
     const save = extractOptionalBoolean(params, 'save') ?? true;
 
     const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
       subAction: 'add_montage_section',
-      assetPath: assetPath?.sanitized,
+      assetPath,
           sectionName,
           startTime,
           save,
@@ -483,31 +493,33 @@ export async function handleAnimationAuthoringTools(
 
   case 'add_montage_slot': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: false },
-      { key: 'animationPath', required: false },
+      { key: 'assetPath', required: true },
+      { key: 'animationPath', required: true },
       { key: 'slotName', default: 'DefaultSlot' },
       { key: 'startTime', default: 0 },
       { key: 'save', default: true },
     ]);
 
-    const rawAssetPath = extractOptionalString(params, 'assetPath');
-    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
-    if (assetPath && !assetPath.valid) {
-      return assetPath.error;
+    const rawAssetPath = extractString(params, 'assetPath');
+    const assetPathValidation = validatePath(rawAssetPath, 'assetPath');
+    if (!assetPathValidation.valid) {
+      return assetPathValidation.error;
     }
-    const rawAnimationPath = extractOptionalString(params, 'animationPath');
-    const animationPath = rawAnimationPath ? validatePath(rawAnimationPath, 'animationPath') : undefined;
-    if (animationPath && !animationPath.valid) {
-      return animationPath.error;
+    const assetPath = assetPathValidation.sanitized;
+    const rawAnimationPath = extractString(params, 'animationPath');
+    const animationPathValidation = validatePath(rawAnimationPath, 'animationPath');
+    if (!animationPathValidation.valid) {
+      return animationPathValidation.error;
     }
+    const animationPath = animationPathValidation.sanitized;
     const slotName = extractOptionalString(params, 'slotName') ?? 'DefaultSlot';
     const startTime = extractOptionalNumber(params, 'startTime') ?? 0;
     const save = extractOptionalBoolean(params, 'save') ?? true;
 
     const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
       subAction: 'add_montage_slot',
-      assetPath: assetPath?.sanitized,
-      animationPath: animationPath?.sanitized,
+      assetPath,
+      animationPath,
           slotName,
           startTime,
           save,
@@ -521,18 +533,19 @@ export async function handleAnimationAuthoringTools(
 
   case 'set_section_timing': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: false },
+      { key: 'assetPath', required: true },
       { key: 'sectionName', required: true },
       { key: 'startTime' },
       { key: 'length' },
       { key: 'save', default: true },
     ]);
 
-    const rawAssetPath = extractOptionalString(params, 'assetPath');
-    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
-    if (assetPath && !assetPath.valid) {
-      return assetPath.error;
+    const rawAssetPath = extractString(params, 'assetPath');
+    const assetPathValidation = validatePath(rawAssetPath, 'assetPath');
+    if (!assetPathValidation.valid) {
+      return assetPathValidation.error;
     }
+    const assetPath = assetPathValidation.sanitized;
     const sectionName = extractString(params, 'sectionName');
     const startTime = extractOptionalNumber(params, 'startTime');
     const length = extractOptionalNumber(params, 'length');
@@ -540,7 +553,7 @@ export async function handleAnimationAuthoringTools(
 
     const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
       subAction: 'set_section_timing',
-      assetPath: assetPath?.sanitized,
+      assetPath,
           sectionName,
           startTime,
           length,
@@ -555,7 +568,7 @@ export async function handleAnimationAuthoringTools(
 
   case 'add_montage_notify': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: false },
+      { key: 'assetPath', required: true },
       { key: 'notifyClass', required: false },
       { key: 'time', required: true },
       { key: 'trackIndex', default: 0 },
@@ -563,11 +576,12 @@ export async function handleAnimationAuthoringTools(
       { key: 'save', default: true },
     ]);
 
-    const rawAssetPath = extractOptionalString(params, 'assetPath');
-    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
-    if (assetPath && !assetPath.valid) {
-      return assetPath.error;
+    const rawAssetPath = extractString(params, 'assetPath');
+    const assetPathValidation = validatePath(rawAssetPath, 'assetPath');
+    if (!assetPathValidation.valid) {
+      return assetPathValidation.error;
     }
+    const assetPath = assetPathValidation.sanitized;
     const notifyClass = extractOptionalString(params, 'notifyClass');
     const time = extractOptionalNumber(params, 'time') ?? 0;
     const trackIndex = extractOptionalNumber(params, 'trackIndex') ?? 0;
@@ -576,7 +590,7 @@ export async function handleAnimationAuthoringTools(
 
     const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
       subAction: 'add_montage_notify',
-      assetPath: assetPath?.sanitized,
+      assetPath,
           notifyClass,
           time,
           trackIndex,
@@ -592,24 +606,25 @@ export async function handleAnimationAuthoringTools(
 
   case 'set_blend_in': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: false },
+      { key: 'assetPath', required: true },
       { key: 'blendTime', default: 0.25 },
       { key: 'blendOption', default: 'Linear' },
       { key: 'save', default: true },
     ]);
 
-    const rawAssetPath = extractOptionalString(params, 'assetPath');
-    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
-    if (assetPath && !assetPath.valid) {
-      return assetPath.error;
+    const rawAssetPath = extractString(params, 'assetPath');
+    const assetPathValidation = validatePath(rawAssetPath, 'assetPath');
+    if (!assetPathValidation.valid) {
+      return assetPathValidation.error;
     }
+    const assetPath = assetPathValidation.sanitized;
     const blendTime = extractOptionalNumber(params, 'blendTime') ?? 0.25;
     const blendOption = extractOptionalString(params, 'blendOption') ?? 'Linear';
     const save = extractOptionalBoolean(params, 'save') ?? true;
 
     const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
       subAction: 'set_blend_in',
-      assetPath: assetPath?.sanitized,
+      assetPath,
           blendTime,
           blendOption,
           save,
@@ -623,24 +638,25 @@ export async function handleAnimationAuthoringTools(
 
   case 'set_blend_out': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: false },
+      { key: 'assetPath', required: true },
       { key: 'blendTime', default: 0.25 },
       { key: 'blendOption', default: 'Linear' },
       { key: 'save', default: true },
     ]);
 
-    const rawAssetPath = extractOptionalString(params, 'assetPath');
-    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
-    if (assetPath && !assetPath.valid) {
-      return assetPath.error;
+    const rawAssetPath = extractString(params, 'assetPath');
+    const assetPathValidation = validatePath(rawAssetPath, 'assetPath');
+    if (!assetPathValidation.valid) {
+      return assetPathValidation.error;
     }
+    const assetPath = assetPathValidation.sanitized;
     const blendTime = extractOptionalNumber(params, 'blendTime') ?? 0.25;
     const blendOption = extractOptionalString(params, 'blendOption') ?? 'Linear';
     const save = extractOptionalBoolean(params, 'save') ?? true;
 
     const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
       subAction: 'set_blend_out',
-      assetPath: assetPath?.sanitized,
+      assetPath,
           blendTime,
           blendOption,
           save,
@@ -654,24 +670,25 @@ export async function handleAnimationAuthoringTools(
 
   case 'link_sections': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: false },
+      { key: 'assetPath', required: true },
       { key: 'fromSection', required: true },
       { key: 'toSection', required: true },
       { key: 'save', default: true },
     ]);
 
-    const rawAssetPath = extractOptionalString(params, 'assetPath');
-    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
-    if (assetPath && !assetPath.valid) {
-      return assetPath.error;
+    const rawAssetPath = extractString(params, 'assetPath');
+    const assetPathValidation = validatePath(rawAssetPath, 'assetPath');
+    if (!assetPathValidation.valid) {
+      return assetPathValidation.error;
     }
+    const assetPath = assetPathValidation.sanitized;
     const fromSection = extractString(params, 'fromSection');
     const toSection = extractString(params, 'toSection');
     const save = extractOptionalBoolean(params, 'save') ?? true;
 
     const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
       subAction: 'link_sections',
-      assetPath: assetPath?.sanitized,
+      assetPath,
           fromSection,
           toSection,
           save,
@@ -767,29 +784,31 @@ export async function handleAnimationAuthoringTools(
 
   case 'add_blend_sample': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: false },
-      { key: 'animationPath', required: false },
+      { key: 'assetPath', required: true },
+      { key: 'animationPath', required: true },
       { key: 'sampleValue', required: true }, // For 1D: number, for 2D: {x, y}
       { key: 'save', default: true },
     ]);
 
-    const rawAssetPath = extractOptionalString(params, 'assetPath');
-    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
-    if (assetPath && !assetPath.valid) {
-      return assetPath.error;
+    const rawAssetPath = extractString(params, 'assetPath');
+    const assetPathValidation = validatePath(rawAssetPath, 'assetPath');
+    if (!assetPathValidation.valid) {
+      return assetPathValidation.error;
     }
-    const rawAnimationPath = extractOptionalString(params, 'animationPath');
-    const animationPath = rawAnimationPath ? validatePath(rawAnimationPath, 'animationPath') : undefined;
-    if (animationPath && !animationPath.valid) {
-      return animationPath.error;
+    const assetPath = assetPathValidation.sanitized;
+    const rawAnimationPath = extractString(params, 'animationPath');
+    const animationPathValidation = validatePath(rawAnimationPath, 'animationPath');
+    if (!animationPathValidation.valid) {
+      return animationPathValidation.error;
     }
+    const animationPath = animationPathValidation.sanitized;
     const sampleValue = params['sampleValue'];
     const save = extractOptionalBoolean(params, 'save') ?? true;
 
     const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
       subAction: 'add_blend_sample',
-      assetPath: assetPath?.sanitized,
-      animationPath: animationPath?.sanitized,
+      assetPath,
+      animationPath,
           sampleValue,
           save,
         })) as AutomationResponse;
@@ -802,7 +821,7 @@ export async function handleAnimationAuthoringTools(
 
   case 'set_axis_settings': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: false },
+      { key: 'assetPath', required: true },
       { key: 'axis', required: true }, // 'Horizontal', 'Vertical', or 'X' for 1D
       { key: 'axisName' },
       { key: 'minValue' },
@@ -811,11 +830,12 @@ export async function handleAnimationAuthoringTools(
       { key: 'save', default: true },
     ]);
 
-    const rawAssetPath = extractOptionalString(params, 'assetPath');
-    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
-    if (assetPath && !assetPath.valid) {
-      return assetPath.error;
+    const rawAssetPath = extractString(params, 'assetPath');
+    const assetPathValidation = validatePath(rawAssetPath, 'assetPath');
+    if (!assetPathValidation.valid) {
+      return assetPathValidation.error;
     }
+    const assetPath = assetPathValidation.sanitized;
     const axis = extractString(params, 'axis');
     const axisName = extractOptionalString(params, 'axisName');
     const minValue = extractOptionalNumber(params, 'minValue');
@@ -825,7 +845,7 @@ export async function handleAnimationAuthoringTools(
 
     const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
       subAction: 'set_axis_settings',
-      assetPath: assetPath?.sanitized,
+      assetPath,
           axis,
           axisName,
           minValue,
@@ -842,24 +862,25 @@ export async function handleAnimationAuthoringTools(
 
   case 'set_interpolation_settings': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: false },
+      { key: 'assetPath', required: true },
       { key: 'interpolationType', default: 'Lerp' }, // Lerp, Cubic
       { key: 'targetWeightInterpolationSpeed', default: 5.0 },
       { key: 'save', default: true },
     ]);
 
-    const rawAssetPath = extractOptionalString(params, 'assetPath');
-    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
-    if (assetPath && !assetPath.valid) {
-      return assetPath.error;
+    const rawAssetPath = extractString(params, 'assetPath');
+    const assetPathValidation = validatePath(rawAssetPath, 'assetPath');
+    if (!assetPathValidation.valid) {
+      return assetPathValidation.error;
     }
+    const assetPath = assetPathValidation.sanitized;
     const interpolationType = extractOptionalString(params, 'interpolationType') ?? 'Lerp';
     const targetWeightInterpolationSpeed = extractOptionalNumber(params, 'targetWeightInterpolationSpeed') ?? 5.0;
     const save = extractOptionalBoolean(params, 'save') ?? true;
 
     const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
       subAction: 'set_interpolation_settings',
-      assetPath: assetPath?.sanitized,
+      assetPath,
           interpolationType,
           targetWeightInterpolationSpeed,
           save,
@@ -900,31 +921,33 @@ export async function handleAnimationAuthoringTools(
 
   case 'add_aim_offset_sample': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: false },
-      { key: 'animationPath', required: false },
+      { key: 'assetPath', required: true },
+      { key: 'animationPath', required: true },
       { key: 'yaw', required: true },
       { key: 'pitch', required: true },
       { key: 'save', default: true },
     ]);
 
-    const rawAssetPath = extractOptionalString(params, 'assetPath');
-    const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
-    if (assetPath && !assetPath.valid) {
-      return assetPath.error;
+    const rawAssetPath = extractString(params, 'assetPath');
+    const assetPathValidation = validatePath(rawAssetPath, 'assetPath');
+    if (!assetPathValidation.valid) {
+      return assetPathValidation.error;
     }
-    const rawAnimationPath = extractOptionalString(params, 'animationPath');
-    const animationPath = rawAnimationPath ? validatePath(rawAnimationPath, 'animationPath') : undefined;
-    if (animationPath && !animationPath.valid) {
-      return animationPath.error;
+    const assetPath = assetPathValidation.sanitized;
+    const rawAnimationPath = extractString(params, 'animationPath');
+    const animationPathValidation = validatePath(rawAnimationPath, 'animationPath');
+    if (!animationPathValidation.valid) {
+      return animationPathValidation.error;
     }
+    const animationPath = animationPathValidation.sanitized;
     const yaw = extractOptionalNumber(params, 'yaw') ?? 0;
     const pitch = extractOptionalNumber(params, 'pitch') ?? 0;
     const save = extractOptionalBoolean(params, 'save') ?? true;
 
     const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
       subAction: 'add_aim_offset_sample',
-      assetPath: assetPath?.sanitized,
-      animationPath: animationPath?.sanitized,
+      assetPath,
+      animationPath,
           yaw,
           pitch,
           save,
@@ -971,22 +994,23 @@ export async function handleAnimationAuthoringTools(
 
   case 'add_state_machine': {
     const params = normalizeArgs(args, [
-      { key: 'blueprintPath', required: false },
+      { key: 'blueprintPath', required: true },
       { key: 'stateMachineName', required: true },
       { key: 'save', default: true },
     ]);
 
-    const rawBlueprintPath = extractOptionalString(params, 'blueprintPath');
-    const blueprintPath = rawBlueprintPath ? validatePath(rawBlueprintPath, 'blueprintPath') : undefined;
-    if (blueprintPath && !blueprintPath.valid) {
-      return blueprintPath.error;
+    const rawBlueprintPath = extractString(params, 'blueprintPath');
+    const blueprintPathValidation = validatePath(rawBlueprintPath, 'blueprintPath');
+    if (!blueprintPathValidation.valid) {
+      return blueprintPathValidation.error;
     }
+    const blueprintPath = blueprintPathValidation.sanitized;
     const stateMachineName = extractString(params, 'stateMachineName');
     const save = extractOptionalBoolean(params, 'save') ?? true;
 
     const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
       subAction: 'add_state_machine',
-      blueprintPath: blueprintPath?.sanitized,
+      blueprintPath,
           stateMachineName,
           save,
         })) as AutomationResponse;
@@ -997,34 +1021,35 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? `State machine '${stateMachineName}' added`);
       }
 
-      case 'add_state': {
-        const params = normalizeArgs(args, [
-          { key: 'blueprintPath', required: false },
-          { key: 'stateMachineName', required: true },
-          { key: 'stateName', required: true },
-          { key: 'animationPath' },
-          { key: 'isEntryState', default: false },
-          { key: 'save', default: true },
-        ]);
+  case 'add_state': {
+    const params = normalizeArgs(args, [
+      { key: 'blueprintPath', required: true },
+      { key: 'stateMachineName', required: true },
+      { key: 'stateName', required: true },
+      { key: 'animationPath' },
+      { key: 'isEntryState', default: false },
+      { key: 'save', default: true },
+    ]);
 
-      const rawBlueprintPath = extractOptionalString(params, 'blueprintPath');
-      const blueprintPath = rawBlueprintPath ? validatePath(rawBlueprintPath, 'blueprintPath') : undefined;
-      if (blueprintPath && !blueprintPath.valid) {
-        return blueprintPath.error;
-      }
-      const stateMachineName = extractString(params, 'stateMachineName');
-      const stateName = extractString(params, 'stateName');
-      const rawAnimationPath = extractOptionalString(params, 'animationPath');
-      const animationPath = rawAnimationPath ? validatePath(rawAnimationPath, 'animationPath') : undefined;
-      if (animationPath && !animationPath.valid) {
-        return animationPath.error;
-      }
-      const isEntryState = extractOptionalBoolean(params, 'isEntryState') ?? false;
-      const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawBlueprintPath = extractString(params, 'blueprintPath');
+    const blueprintPathValidation = validatePath(rawBlueprintPath, 'blueprintPath');
+    if (!blueprintPathValidation.valid) {
+      return blueprintPathValidation.error;
+    }
+    const blueprintPath = blueprintPathValidation.sanitized;
+    const stateMachineName = extractString(params, 'stateMachineName');
+    const stateName = extractString(params, 'stateName');
+    const rawAnimationPath = extractOptionalString(params, 'animationPath');
+    const animationPath = rawAnimationPath ? validatePath(rawAnimationPath, 'animationPath') : undefined;
+    if (animationPath && !animationPath.valid) {
+      return animationPath.error;
+    }
+    const isEntryState = extractOptionalBoolean(params, 'isEntryState') ?? false;
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-      const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-        subAction: 'add_state',
-        blueprintPath: blueprintPath?.sanitized,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'add_state',
+      blueprintPath,
           stateMachineName,
           stateName,
           animationPath: animationPath?.sanitized,
@@ -1038,28 +1063,29 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? `State '${stateName}' added`);
       }
 
-      case 'add_transition': {
-        const params = normalizeArgs(args, [
-          { key: 'blueprintPath', required: false },
-          { key: 'stateMachineName', required: true },
-          { key: 'fromState', required: true },
-          { key: 'toState', required: true },
-          { key: 'save', default: true },
-        ]);
+  case 'add_transition': {
+    const params = normalizeArgs(args, [
+      { key: 'blueprintPath', required: true },
+      { key: 'stateMachineName', required: true },
+      { key: 'fromState', required: true },
+      { key: 'toState', required: true },
+      { key: 'save', default: true },
+    ]);
 
-      const rawBlueprintPath = extractOptionalString(params, 'blueprintPath');
-      const blueprintPath = rawBlueprintPath ? validatePath(rawBlueprintPath, 'blueprintPath') : undefined;
-      if (blueprintPath && !blueprintPath.valid) {
-        return blueprintPath.error;
-      }
-      const stateMachineName = extractString(params, 'stateMachineName');
-      const fromState = extractString(params, 'fromState');
-      const toState = extractString(params, 'toState');
-      const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawBlueprintPath = extractString(params, 'blueprintPath');
+    const blueprintPathValidation = validatePath(rawBlueprintPath, 'blueprintPath');
+    if (!blueprintPathValidation.valid) {
+      return blueprintPathValidation.error;
+    }
+    const blueprintPath = blueprintPathValidation.sanitized;
+    const stateMachineName = extractString(params, 'stateMachineName');
+    const fromState = extractString(params, 'fromState');
+    const toState = extractString(params, 'toState');
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-      const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-        subAction: 'add_transition',
-        blueprintPath: blueprintPath?.sanitized,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'add_transition',
+      blueprintPath,
           stateMachineName,
           fromState,
           toState,
@@ -1072,36 +1098,37 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? `Transition from '${fromState}' to '${toState}' added`);
       }
 
-      case 'set_transition_rules': {
-        const params = normalizeArgs(args, [
-          { key: 'blueprintPath', required: false },
-          { key: 'stateMachineName', required: true },
-          { key: 'fromState', required: true },
-          { key: 'toState', required: true },
-          { key: 'blendTime', default: 0.2 },
-          { key: 'blendLogicType', default: 'StandardBlend' },
-          { key: 'automaticTriggerRule' }, // e.g., 'TimeRemaining'
-          { key: 'automaticTriggerTime' },
-          { key: 'save', default: true },
-        ]);
+  case 'set_transition_rules': {
+    const params = normalizeArgs(args, [
+      { key: 'blueprintPath', required: true },
+      { key: 'stateMachineName', required: true },
+      { key: 'fromState', required: true },
+      { key: 'toState', required: true },
+      { key: 'blendTime', default: 0.2 },
+      { key: 'blendLogicType', default: 'StandardBlend' },
+      { key: 'automaticTriggerRule' }, // e.g., 'TimeRemaining'
+      { key: 'automaticTriggerTime' },
+      { key: 'save', default: true },
+    ]);
 
-  const rawBlueprintPath = extractOptionalString(params, 'blueprintPath');
-  const blueprintPath = rawBlueprintPath ? validatePath(rawBlueprintPath, 'blueprintPath') : undefined;
-  if (blueprintPath && !blueprintPath.valid) {
-    return blueprintPath.error;
-  }
-  const stateMachineName = extractString(params, 'stateMachineName');
-  const fromState = extractString(params, 'fromState');
-  const toState = extractString(params, 'toState');
-  const blendTime = extractOptionalNumber(params, 'blendTime') ?? 0.2;
-  const blendLogicType = extractOptionalString(params, 'blendLogicType') ?? 'StandardBlend';
-  const automaticTriggerRule = extractOptionalString(params, 'automaticTriggerRule');
-  const automaticTriggerTime = extractOptionalNumber(params, 'automaticTriggerTime');
-  const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawBlueprintPath = extractString(params, 'blueprintPath');
+    const blueprintPathValidation = validatePath(rawBlueprintPath, 'blueprintPath');
+    if (!blueprintPathValidation.valid) {
+      return blueprintPathValidation.error;
+    }
+    const blueprintPath = blueprintPathValidation.sanitized;
+    const stateMachineName = extractString(params, 'stateMachineName');
+    const fromState = extractString(params, 'fromState');
+    const toState = extractString(params, 'toState');
+    const blendTime = extractOptionalNumber(params, 'blendTime') ?? 0.2;
+    const blendLogicType = extractOptionalString(params, 'blendLogicType') ?? 'StandardBlend';
+    const automaticTriggerRule = extractOptionalString(params, 'automaticTriggerRule');
+    const automaticTriggerTime = extractOptionalNumber(params, 'automaticTriggerTime');
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-  const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-    subAction: 'set_transition_rules',
-    blueprintPath: blueprintPath?.sanitized,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'set_transition_rules',
+      blueprintPath,
           stateMachineName,
           fromState,
           toState,
@@ -1118,30 +1145,31 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? 'Transition rules updated');
       }
 
-      case 'add_blend_node': {
-        const params = normalizeArgs(args, [
-          { key: 'blueprintPath', required: false },
-          { key: 'blendType', required: true }, // TwoWayBlend, BlendByBool, BlendPosesByBool, etc.
-          { key: 'nodeName' },
-          { key: 'x', default: 0 },
-          { key: 'y', default: 0 },
-          { key: 'save', default: true },
-        ]);
+  case 'add_blend_node': {
+    const params = normalizeArgs(args, [
+      { key: 'blueprintPath', required: true },
+      { key: 'blendType', required: true }, // TwoWayBlend, BlendByBool, BlendPosesByBool, etc.
+      { key: 'nodeName' },
+      { key: 'x', default: 0 },
+      { key: 'y', default: 0 },
+      { key: 'save', default: true },
+    ]);
 
-  const rawBlueprintPath = extractOptionalString(params, 'blueprintPath');
-  const blueprintPath = rawBlueprintPath ? validatePath(rawBlueprintPath, 'blueprintPath') : undefined;
-  if (blueprintPath && !blueprintPath.valid) {
-    return blueprintPath.error;
-  }
-  const blendType = extractString(params, 'blendType');
-  const nodeName = extractOptionalString(params, 'nodeName');
-  const x = extractOptionalNumber(params, 'x') ?? 0;
-  const y = extractOptionalNumber(params, 'y') ?? 0;
-  const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawBlueprintPath = extractString(params, 'blueprintPath');
+    const blueprintPathValidation = validatePath(rawBlueprintPath, 'blueprintPath');
+    if (!blueprintPathValidation.valid) {
+      return blueprintPathValidation.error;
+    }
+    const blueprintPath = blueprintPathValidation.sanitized;
+    const blendType = extractString(params, 'blendType');
+    const nodeName = extractOptionalString(params, 'nodeName');
+    const x = extractOptionalNumber(params, 'x') ?? 0;
+    const y = extractOptionalNumber(params, 'y') ?? 0;
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-  const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-    subAction: 'add_blend_node',
-    blueprintPath: blueprintPath?.sanitized,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'add_blend_node',
+      blueprintPath,
           blendType,
           nodeName,
           x,
@@ -1155,24 +1183,25 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? 'Blend node added');
       }
 
-      case 'add_cached_pose': {
-        const params = normalizeArgs(args, [
-          { key: 'blueprintPath', required: false },
-          { key: 'cacheName', required: true },
-          { key: 'save', default: true },
-        ]);
+  case 'add_cached_pose': {
+    const params = normalizeArgs(args, [
+      { key: 'blueprintPath', required: true },
+      { key: 'cacheName', required: true },
+      { key: 'save', default: true },
+    ]);
 
-  const rawBlueprintPath = extractOptionalString(params, 'blueprintPath');
-  const blueprintPath = rawBlueprintPath ? validatePath(rawBlueprintPath, 'blueprintPath') : undefined;
-  if (blueprintPath && !blueprintPath.valid) {
-    return blueprintPath.error;
-  }
-  const cacheName = extractString(params, 'cacheName');
-  const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawBlueprintPath = extractString(params, 'blueprintPath');
+    const blueprintPathValidation = validatePath(rawBlueprintPath, 'blueprintPath');
+    if (!blueprintPathValidation.valid) {
+      return blueprintPathValidation.error;
+    }
+    const blueprintPath = blueprintPathValidation.sanitized;
+    const cacheName = extractString(params, 'cacheName');
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-  const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-    subAction: 'add_cached_pose',
-    blueprintPath: blueprintPath?.sanitized,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'add_cached_pose',
+      blueprintPath,
     cacheName,
     save,
   })) as AutomationResponse;
@@ -1183,24 +1212,25 @@ export async function handleAnimationAuthoringTools(
   return ResponseFactory.success(res, res.message ?? `Cached pose '${cacheName}' added`);
       }
 
-      case 'add_slot_node': {
-        const params = normalizeArgs(args, [
-          { key: 'blueprintPath', required: false },
-          { key: 'slotName', required: true },
-          { key: 'save', default: true },
-        ]);
+  case 'add_slot_node': {
+    const params = normalizeArgs(args, [
+      { key: 'blueprintPath', required: true },
+      { key: 'slotName', required: true },
+      { key: 'save', default: true },
+    ]);
 
-  const rawBlueprintPath = extractOptionalString(params, 'blueprintPath');
-  const blueprintPath = rawBlueprintPath ? validatePath(rawBlueprintPath, 'blueprintPath') : undefined;
-  if (blueprintPath && !blueprintPath.valid) {
-    return blueprintPath.error;
-  }
-  const slotName = extractString(params, 'slotName');
-  const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawBlueprintPath = extractString(params, 'blueprintPath');
+    const blueprintPathValidation = validatePath(rawBlueprintPath, 'blueprintPath');
+    if (!blueprintPathValidation.valid) {
+      return blueprintPathValidation.error;
+    }
+    const blueprintPath = blueprintPathValidation.sanitized;
+    const slotName = extractString(params, 'slotName');
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-  const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-    subAction: 'add_slot_node',
-    blueprintPath: blueprintPath?.sanitized,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'add_slot_node',
+      blueprintPath,
           slotName,
           save,
         })) as AutomationResponse;
@@ -1211,24 +1241,25 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? `Slot node '${slotName}' added`);
       }
 
-      case 'add_layered_blend_per_bone': {
-        const params = normalizeArgs(args, [
-          { key: 'blueprintPath', required: false },
-          { key: 'layerSetup' }, // Array of {branchFilters: [{boneName, blendDepth}]}
-          { key: 'save', default: true },
-        ]);
+  case 'add_layered_blend_per_bone': {
+    const params = normalizeArgs(args, [
+      { key: 'blueprintPath', required: true },
+      { key: 'layerSetup' }, // Array of {branchFilters: [{boneName, blendDepth}]}
+      { key: 'save', default: true },
+    ]);
 
-  const rawBlueprintPath = extractOptionalString(params, 'blueprintPath');
-  const blueprintPath = rawBlueprintPath ? validatePath(rawBlueprintPath, 'blueprintPath') : undefined;
-  if (blueprintPath && !blueprintPath.valid) {
-    return blueprintPath.error;
-  }
-  const layerSetup = extractOptionalArray(params, 'layerSetup');
-  const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawBlueprintPath = extractString(params, 'blueprintPath');
+    const blueprintPathValidation = validatePath(rawBlueprintPath, 'blueprintPath');
+    if (!blueprintPathValidation.valid) {
+      return blueprintPathValidation.error;
+    }
+    const blueprintPath = blueprintPathValidation.sanitized;
+    const layerSetup = extractOptionalArray(params, 'layerSetup');
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-  const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-    subAction: 'add_layered_blend_per_bone',
-    blueprintPath: blueprintPath?.sanitized,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'add_layered_blend_per_bone',
+      blueprintPath,
           layerSetup,
           save,
         })) as AutomationResponse;
@@ -1239,28 +1270,29 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? 'Layered blend per bone added');
       }
 
-      case 'set_anim_graph_node_value': {
-        const params = normalizeArgs(args, [
-          { key: 'blueprintPath', required: false },
-          { key: 'nodeName', required: true },
-          { key: 'propertyName', required: true },
-          { key: 'value', required: true },
-          { key: 'save', default: true },
-        ]);
+  case 'set_anim_graph_node_value': {
+    const params = normalizeArgs(args, [
+      { key: 'blueprintPath', required: true },
+      { key: 'nodeName', required: true },
+      { key: 'propertyName', required: true },
+      { key: 'value', required: true },
+      { key: 'save', default: true },
+    ]);
 
-  const rawBlueprintPath = extractOptionalString(params, 'blueprintPath');
-  const blueprintPath = rawBlueprintPath ? validatePath(rawBlueprintPath, 'blueprintPath') : undefined;
-  if (blueprintPath && !blueprintPath.valid) {
-    return blueprintPath.error;
-  }
-  const nodeName = extractString(params, 'nodeName');
-  const propertyName = extractString(params, 'propertyName');
-  const value = params['value'];
-  const save = extractOptionalBoolean(params, 'save') ?? true;
+    const rawBlueprintPath = extractString(params, 'blueprintPath');
+    const blueprintPathValidation = validatePath(rawBlueprintPath, 'blueprintPath');
+    if (!blueprintPathValidation.valid) {
+      return blueprintPathValidation.error;
+    }
+    const blueprintPath = blueprintPathValidation.sanitized;
+    const nodeName = extractString(params, 'nodeName');
+    const propertyName = extractString(params, 'propertyName');
+    const value = params['value'];
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-  const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-    subAction: 'set_anim_graph_node_value',
-    blueprintPath: blueprintPath?.sanitized,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'set_anim_graph_node_value',
+      blueprintPath,
           nodeName,
           propertyName,
           value,
@@ -1412,24 +1444,29 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? 'Rig elements connected');
       }
 
-      case 'create_pose_library': {
-        const params = normalizeArgs(args, [
-          { key: 'name', required: true },
-          { key: 'path', aliases: ['directory'], default: '/Game/Animations' },
-          { key: 'skeletonPath', required: false },
-          { key: 'save', default: true },
-        ]);
+  case 'create_pose_library': {
+    const params = normalizeArgs(args, [
+      { key: 'name', required: true },
+      { key: 'path', aliases: ['directory'], default: '/Game/Animations' },
+      { key: 'skeletonPath', required: true },
+      { key: 'save', default: true },
+    ]);
 
-        const name = extractString(params, 'name');
-        const path = extractOptionalString(params, 'path') ?? '/Game/Animations';
-        const skeletonPath = extractOptionalString(params, 'skeletonPath');
-        const save = extractOptionalBoolean(params, 'save') ?? true;
+    const name = extractString(params, 'name');
+    const path = extractOptionalString(params, 'path') ?? '/Game/Animations';
+    const rawSkeletonPath = extractString(params, 'skeletonPath');
+    const skeletonPathValidation = validatePath(rawSkeletonPath, 'skeletonPath');
+    if (!skeletonPathValidation.valid) {
+      return skeletonPathValidation.error;
+    }
+    const skeletonPath = skeletonPathValidation.sanitized;
+    const save = extractOptionalBoolean(params, 'save') ?? true;
 
-        const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-          subAction: 'create_pose_library',
-          name,
-          path,
-          skeletonPath,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'create_pose_library',
+      name,
+      path,
+      skeletonPath,
           save,
         })) as AutomationResponse;
 
@@ -1568,21 +1605,22 @@ export async function handleAnimationAuthoringTools(
         return ResponseFactory.success(res, res.message ?? `Chain mapping '${sourceChain}' -> '${targetChain}' set`);
       }
 
-      // ===== Utility =====
-      case 'get_animation_info': {
-        const params = normalizeArgs(args, [
-          { key: 'assetPath', required: false },
-        ]);
+  // ===== Utility =====
+  case 'get_animation_info': {
+    const params = normalizeArgs(args, [
+      { key: 'assetPath', required: true },
+    ]);
 
-  const rawAssetPath = extractOptionalString(params, 'assetPath');
-  const assetPath = rawAssetPath ? validatePath(rawAssetPath, 'assetPath') : undefined;
-  if (assetPath && !assetPath.valid) {
-    return assetPath.error;
-  }
+    const rawAssetPath = extractString(params, 'assetPath');
+    const assetPathValidation = validatePath(rawAssetPath, 'assetPath');
+    if (!assetPathValidation.valid) {
+      return assetPathValidation.error;
+    }
+    const assetPath = assetPathValidation.sanitized;
 
-  const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
-    subAction: 'get_animation_info',
-    assetPath: assetPath?.sanitized,
+    const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
+      subAction: 'get_animation_info',
+      assetPath,
         })) as AutomationResponse;
 
         if (res.success === false) {

--- a/src/tools/handlers/animation-handlers.ts
+++ b/src/tools/handlers/animation-handlers.ts
@@ -299,20 +299,18 @@ export async function handleAnimationTools(action: string, args: HandlerArgs, to
     const params = normalizeArgs(args, [
       { key: 'name', required: true },
       { key: 'path', aliases: ['directory'], default: '/Game/Animations' },
-      { key: 'skeletonPath', required: false },
-      { key: 'boneTracks', required: false },
+      { key: 'skeletonPath', required: true },
+      { key: 'boneTracks', required: true },
       { key: 'numFrames', default: 30 },
       { key: 'frameRate', default: 30 },
       { key: 'save', default: true }
     ]);
 
     let savePath: string;
-    let skeletonPath: string | undefined;
+    let skeletonPath: string;
     try {
       savePath = sanitizePath(String(params.path || '/Game/Animations'));
-      if (params.skeletonPath && typeof params.skeletonPath === 'string') {
-        skeletonPath = sanitizePath(String(params.skeletonPath));
-      }
+      skeletonPath = sanitizePath(String(params.skeletonPath));
     } catch (e) {
       return cleanObject({
         success: false,
@@ -321,8 +319,14 @@ export async function handleAnimationTools(action: string, args: HandlerArgs, to
       });
     }
 
-    // boneTracks is optional - C++ handler will validate if required
-    const boneTracks = Array.isArray(params.boneTracks) ? params.boneTracks : undefined;
+    if (!Array.isArray(params.boneTracks)) {
+      return cleanObject({
+        success: false,
+        error: 'MISSING_REQUIRED_PARAM',
+        message: 'boneTracks is required and must be an array for create_procedural_anim'
+      });
+    }
+    const boneTracks = params.boneTracks;
 
     return cleanObject(await executeAutomationRequest(tools, 'animation_physics', {
       action: 'create_procedural_anim',
@@ -448,31 +452,39 @@ export async function handleAnimationTools(action: string, args: HandlerArgs, to
         time: mutableArgs.time ?? mutableArgs.startTime
       })) as Record<string, unknown>;
     }
-case 'configure_vehicle': {
-      const params = normalizeArgs(args, [
-        { key: 'actorName', required: false },
-        { key: 'vehicleName', required: false },
-        { key: 'vehicleType', default: 'WheeledVehicle4W' },
-        { key: 'wheels' },
-        { key: 'engine' },
-        { key: 'transmission' },
-        { key: 'mass', default: 1500 },
-        { key: 'dragCoefficient', default: 0.3 }
-      ]);
+ case 'configure_vehicle': {
+    const params = normalizeArgs(args, [
+      { key: 'actorName', required: false },
+      { key: 'vehicleName', required: false },
+      { key: 'vehicleType', default: 'WheeledVehicle4W' },
+      { key: 'wheels' },
+      { key: 'engine' },
+      { key: 'transmission' },
+      { key: 'mass', default: 1500 },
+      { key: 'dragCoefficient', default: 0.3 }
+    ]);
 
-      return cleanObject(await executeAutomationRequest(tools, 'animation_physics', {
-        action: 'configure_vehicle',
-        subAction: 'configure_vehicle',
-        actorName: params.actorName,
-        vehicleName: params.vehicleName,
-        vehicleType: params.vehicleType,
-        wheels: params.wheels,
-        engine: params.engine,
-        transmission: params.transmission,
-        mass: params.mass,
-        dragCoefficient: params.dragCoefficient
-      })) as Record<string, unknown>;
+    if (!params.actorName && !params.vehicleName) {
+      return cleanObject({
+        success: false,
+        error: 'MISSING_REQUIRED_PARAM',
+        message: 'At least one of actorName or vehicleName is required for configure_vehicle'
+      });
     }
+
+    return cleanObject(await executeAutomationRequest(tools, 'animation_physics', {
+      action: 'configure_vehicle',
+      subAction: 'configure_vehicle',
+      actorName: params.actorName,
+      vehicleName: params.vehicleName,
+      vehicleType: params.vehicleType,
+      wheels: params.wheels,
+      engine: params.engine,
+      transmission: params.transmission,
+      mass: params.mass,
+      dragCoefficient: params.dragCoefficient
+    })) as Record<string, unknown>;
+  }
     case 'setup_physics_simulation': {
       // Validate and sanitize paths
       let savePath: string | undefined;

--- a/src/tools/handlers/animation-handlers.ts
+++ b/src/tools/handlers/animation-handlers.ts
@@ -295,51 +295,48 @@ export async function handleAnimationTools(action: string, args: HandlerArgs, to
         enableFootPlacement: mutableArgs.enableFootPlacement
       })) as Record<string, unknown>;
     }
-    case 'create_procedural_anim': {
-      const params = normalizeArgs(args, [
-        { key: 'name', required: true },
-        { key: 'path', aliases: ['directory'], default: '/Game/Animations' },
-        { key: 'skeletonPath', required: true },
-        { key: 'boneTracks', required: true },
-        { key: 'numFrames', default: 30 },
-        { key: 'frameRate', default: 30 },
-        { key: 'save', default: true }
-      ]);
+  case 'create_procedural_anim': {
+    const params = normalizeArgs(args, [
+      { key: 'name', required: true },
+      { key: 'path', aliases: ['directory'], default: '/Game/Animations' },
+      { key: 'skeletonPath', required: false },
+      { key: 'boneTracks', required: false },
+      { key: 'numFrames', default: 30 },
+      { key: 'frameRate', default: 30 },
+      { key: 'save', default: true }
+    ]);
 
-      let savePath: string;
-      let skeletonPath: string;
-      try {
-        savePath = sanitizePath(String(params.path || '/Game/Animations'));
+    let savePath: string;
+    let skeletonPath: string | undefined;
+    try {
+      savePath = sanitizePath(String(params.path || '/Game/Animations'));
+      if (params.skeletonPath && typeof params.skeletonPath === 'string') {
         skeletonPath = sanitizePath(String(params.skeletonPath));
-      } catch (e) {
-        return cleanObject({
-          success: false,
-          error: 'SECURITY_VIOLATION',
-          message: e instanceof Error ? e.message : 'Invalid path: path traversal or illegal characters detected'
-        });
       }
-
-      if (!Array.isArray(params.boneTracks)) {
-        return cleanObject({
-          success: false,
-          error: 'INVALID_ARGUMENT',
-          message: 'boneTracks must be an array of bone track definitions'
-        });
-      }
-
-      return cleanObject(await executeAutomationRequest(tools, 'animation_physics', {
-        action: 'create_procedural_anim',
-        subAction: 'create_procedural_anim',
-        name: params.name,
-        path: savePath,
-        savePath,
-        skeletonPath,
-        boneTracks: params.boneTracks,
-        numFrames: params.numFrames,
-        frameRate: params.frameRate,
-        save: params.save
-      })) as Record<string, unknown>;
+    } catch (e) {
+      return cleanObject({
+        success: false,
+        error: 'SECURITY_VIOLATION',
+        message: e instanceof Error ? e.message : 'Invalid path: path traversal or illegal characters detected'
+      });
     }
+
+    // boneTracks is optional - C++ handler will validate if required
+    const boneTracks = Array.isArray(params.boneTracks) ? params.boneTracks : undefined;
+
+    return cleanObject(await executeAutomationRequest(tools, 'animation_physics', {
+      action: 'create_procedural_anim',
+      subAction: 'create_procedural_anim',
+      name: params.name,
+      path: savePath,
+      savePath,
+      skeletonPath,
+      boneTracks,
+      numFrames: params.numFrames,
+      frameRate: params.frameRate,
+      save: params.save
+    })) as Record<string, unknown>;
+  }
     case 'create_blend_tree': {
       // Validate blueprint path
       let blueprintPath: string | undefined;
@@ -451,13 +448,14 @@ export async function handleAnimationTools(action: string, args: HandlerArgs, to
         time: mutableArgs.time ?? mutableArgs.startTime
       })) as Record<string, unknown>;
     }
-    case 'configure_vehicle': {
+case 'configure_vehicle': {
       const params = normalizeArgs(args, [
-        { key: 'actorName', required: true },
-        { key: 'vehicleType', default: 'WheeledVehicle4W' }, // WheeledVehicle4W, WheeledVehicle, Tank
-        { key: 'wheels' }, // Array of {boneName, offset, radius, width, friction}
-        { key: 'engine' }, // {maxRPM, maxTorque, gears}
-        { key: 'transmission' }, // {gearRatios, finalDrive}
+        { key: 'actorName', required: false },
+        { key: 'vehicleName', required: false },
+        { key: 'vehicleType', default: 'WheeledVehicle4W' },
+        { key: 'wheels' },
+        { key: 'engine' },
+        { key: 'transmission' },
         { key: 'mass', default: 1500 },
         { key: 'dragCoefficient', default: 0.3 }
       ]);
@@ -466,6 +464,7 @@ export async function handleAnimationTools(action: string, args: HandlerArgs, to
         action: 'configure_vehicle',
         subAction: 'configure_vehicle',
         actorName: params.actorName,
+        vehicleName: params.vehicleName,
         vehicleType: params.vehicleType,
         wheels: params.wheels,
         engine: params.engine,


### PR DESCRIPTION
## Summary
- Make `skeletonPath`, `skeletalMeshPath`, `assetPath`, `blueprintPath`, `animationPath`, and `notifyClass` optional in both TS and C++ animation handlers to align the dual-process contract and eliminate misleading error messages when optional paths are omitted
- Harden `add_notify`/`add_notify_state`/`add_montage_notify` C++ handlers: resolve notify class **before** modifying the asset (prevents ghost `FAnimNotifyEvent` entries), return explicit `CLASS_NOT_FOUND` error on failed class lookup instead of silently creating `Notify=nullptr` events, and require at least one of `notifyClass` or `notifyName`
- Add `skeletonPath` support to `create_control_rig` UE 5.1–5.4 fallback path and `create_ik_rig` C++ handler
- Add `vehicleName` backward-compat param to `configure_vehicle` TS handler
- Remove unreachable `IsValidBoneTrackName` dead code in `set_bone_key`
- Replace deprecated `GetBoneTrackIndexByName` with `IsValidBoneTrackName` in `add_bone_track`/`set_bone_key`

## Changes

### C++ Plugin (`McpAutomationBridge_AnimationAuthoringHandlers.cpp`)
- 6 animation creation handlers (`create_animation_sequence`, `create_montage`, `create_blend_space_1d/2d`, `create_aim_offset`, `create_anim_blueprint`): `skeletonPath` now optional — only loads and validates when non-empty
- 3 notify handlers: class resolution moved before `AddDefaulted_GetRef()`, explicit `CLASS_NOT_FOUND` error, `Notifies.Pop()` cleanup on `NewObject` failure
- `create_control_rig` UE 5.1–5.4 fallback: reads `skeletonPath`, loads `USkeleton`, sets preview mesh
- `create_ik_rig`: reads `skeletonPath`, loads `USkeleton`, gets preview mesh via `GetPreviewMesh()`
- `set_bone_key`: removed unreachable second `IsValidBoneTrackName` check

### TypeScript Server
- `animation-authoring-handlers.ts`: 30+ action cases — path params switched to `required: false` + `extractOptionalString`, `notifyClass` made optional, `skeletonPath` added to `create_ik_rig`
- `animation-handlers.ts`: `skeletonPath`/`boneTracks` optional for `create_procedural_anim`, `actorName` optional + `vehicleName` added for `configure_vehicle`

## Testing
- TypeScript build: clean (`npm run build:core`)
- Unit tests: 210/210 pass (`npm run test:unit`)
- C++ plugin: rebuilt (v0.1.4 UE5.7 Linux), synced to test project
- Integration tests: deferred (requires UE Editor restart to load new plugin binary)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chir24/unreal_mcp/pull/385" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
