### PR TITLE
feat(system): implement start_pie / stop_pie actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Native MCP Streamable HTTP Transport** — built-in HTTP/SSE MCP server directly in the C++ plugin, no TypeScript bridge or Node.js required. AI clients connect via `http://localhost:3000/mcp`. Supports SSE streaming, multiple concurrent sessions, dynamic tool management. Opt-in via `bEnableNativeMCP` project setting.
+- **`start_pie` / `stop_pie` actions** in `system_control` — start/stop a Play-In-Editor session via `GEditor->RequestPlaySession(FRequestPlaySessionParams)` / `GEditor->RequestEndPlayMap()`. Optional fields on `start_pie`: `mode` (`viewport` / `new_window` / `simulate`), `start_location` (`{x,y,z}`), `spawn_at_player_start` (default `true`). Fixes "System control action 'start_pie' not implemented" error.
 - **`execute_python` action** in `system_control` — execute Python code inline or from `.py` files with stdout/stderr capture, execution time tracking, and RAII temp file cleanup. Max code size: 1 MB.
 - **Capability token authentication** for native MCP transport — validates `X-MCP-Capability-Token` header when `bRequireCapabilityToken` is enabled.
 - **36 self-describing C++ tool definitions** with `FMcpSchemaBuilder` fluent API — replaces JSON schema loader.

--- a/docs/handler-mapping.md
+++ b/docs/handler-mapping.md
@@ -199,6 +199,8 @@ This document maps the TypeScript tool definitions to their corresponding C++ ha
 | `lumen_update_scene` | `McpAutomationBridge_RenderHandlers.cpp` | `HandleRenderAction` | |
 | `set_project_setting` | `McpAutomationBridge_EnvironmentHandlers.cpp` | `HandleSystemControlAction` | |
 | `execute_python` | `McpAutomationBridge_SystemControlHandlers.cpp` | `HandleSystemControlAction` | Requires Python Editor Script Plugin. Max 1 MB code. Async timeout warning at 60s. |
+| `start_pie` | `McpAutomationBridge_SystemControlHandlers.cpp` → `McpAutomationBridge_ControlHandlers.cpp` | `HandleSystemControlAction` → `HandleControlEditorPlay` | Calls `GEditor->RequestPlaySession(FRequestPlaySessionParams)` on the game thread. Optional: `mode` (`viewport`/`new_window`/`simulate`), `start_location`, `spawn_at_player_start` (default `true`). |
+| `stop_pie` | `McpAutomationBridge_SystemControlHandlers.cpp` → `McpAutomationBridge_ControlHandlers.cpp` | `HandleSystemControlAction` → `HandleControlEditorStop` | Calls `GEditor->RequestEndPlayMap()`. |
 | `create_hud` | `McpAutomationBridge_UiHandlers.cpp` | `HandleUiAction` | Sub-action of `system_control` |
 | `set_widget_text` | `McpAutomationBridge_UiHandlers.cpp` | `HandleUiAction` | Sub-action of `system_control` |
 | `set_widget_image` | `McpAutomationBridge_UiHandlers.cpp` | `HandleUiAction` | Sub-action of `system_control` |

--- a/plugins/McpAutomationBridge/CHANGELOG.md
+++ b/plugins/McpAutomationBridge/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the MCP Automation Bridge plugin will be documented in th
 
 ---
 
+## [Unreleased]
+
+### Added
+- **`start_pie` / `stop_pie` actions** in `system_control` — start/stop a Play-In-Editor session via `GEditor->RequestPlaySession(FRequestPlaySessionParams)` and `GEditor->RequestEndPlayMap()`. Routed through `HandleControlEditorPlay` / `HandleControlEditorStop`, which now also accept optional payload fields on `start_pie`:
+  - `mode`: `"viewport"` (default), `"new_window"`, or `"simulate"`
+  - `start_location`: `{x, y, z}` — explicit world-space spawn (overrides Player Start)
+  - `spawn_at_player_start`: `bool`, default `true`
+  Fixes "System control action 'start_pie' not implemented" error.
+
+### Changed
+- `HandleControlEditorPlay` and `HandleControlEditorStop` now null-check `GEditor` before dereferencing and emit `EDITOR_NOT_AVAILABLE` instead of crashing.
+
+---
+
 ## [0.6.0] - 2026-04-05
 
 ### Security

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Tools/McpTool_SystemControl.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Tools/McpTool_SystemControl.cpp
@@ -13,7 +13,8 @@ public:
 	FString GetDescription() const override
 	{
 		return TEXT("Run profiling, set quality/CVars, execute console commands, "
-			"execute Python scripts, run UBT, and manage widgets.");
+			"execute Python scripts, run UBT, manage widgets, and start/stop "
+			"Play-In-Editor (PIE) sessions.");
 	}
 
 	FString GetCategory() const override { return TEXT("core"); }
@@ -45,7 +46,9 @@ public:
 				TEXT("get_project_settings"),
 				TEXT("validate_assets"),
 				TEXT("set_project_setting"),
-				TEXT("execute_python")
+				TEXT("execute_python"),
+				TEXT("start_pie"),
+				TEXT("stop_pie")
 			}, TEXT("Action"))
 			.String(TEXT("profileType"), TEXT(""))
 			.String(TEXT("category"), TEXT(""))
@@ -68,6 +71,17 @@ public:
 			.String(TEXT("configName"), TEXT(""))
 			.String(TEXT("code"), TEXT("Python code to execute inline"))
 			.String(TEXT("file"), TEXT("Path to .py file to execute"))
+			.String(TEXT("mode"),
+				TEXT("PIE play mode (start_pie): viewport (default), new_window, or simulate."))
+			.Object(TEXT("start_location"),
+				TEXT("PIE spawn location (start_pie). Overrides Player Start."),
+				[](FMcpSchemaBuilder& S) {
+					S.Number(TEXT("x"))
+					 .Number(TEXT("y"))
+					 .Number(TEXT("z"));
+				})
+			.Bool(TEXT("spawn_at_player_start"),
+				TEXT("If true (default), PIE spawns at the Player Start actor (start_pie)."))
 			.Required({TEXT("action")})
 			.Build();
 	}

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_ControlHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_ControlHandlers.cpp
@@ -2625,6 +2625,14 @@ bool UMcpAutomationBridgeSubsystem::HandleControlEditorPlay(
     const FString &RequestId, const TSharedPtr<FJsonObject> &Payload,
     TSharedPtr<FMcpBridgeWebSocket> Socket) {
 #if WITH_EDITOR
+  if (!GEditor) {
+    SendStandardErrorResponse(this, Socket, RequestId,
+                              TEXT("EDITOR_NOT_AVAILABLE"),
+                              TEXT("GEditor is null; cannot start PIE"),
+                              nullptr);
+    return true;
+  }
+
   if (GEditor->PlayWorld) {
     TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
     Resp->SetBoolField(TEXT("success"), true);
@@ -2635,27 +2643,83 @@ bool UMcpAutomationBridgeSubsystem::HandleControlEditorPlay(
     return true;
   }
 
+  // -------------------------------------------------------------------------
+  // Optional payload fields:
+  //   mode: "viewport" (default) | "new_window" | "simulate"
+  //   start_location: { x, y, z } — explicit world-space spawn location
+  //   spawn_at_player_start: bool (default true) — use Player Start actor;
+  //                          ignored when start_location is provided
+  // -------------------------------------------------------------------------
+  FString ModeString;
+  if (Payload.IsValid()) {
+    Payload->TryGetStringField(TEXT("mode"), ModeString);
+  }
+  const FString LowerMode = ModeString.ToLower();
+
   FRequestPlaySessionParams PlayParams;
-  PlayParams.WorldType = EPlaySessionWorldType::PlayInEditor;
+  if (LowerMode == TEXT("simulate")) {
+    PlayParams.WorldType = EPlaySessionWorldType::SimulateInEditor;
+  } else {
+    // Both "viewport" (default) and "new_window" use PlayInEditor; the
+    // distinction is made via DestinationSlateViewport below.
+    PlayParams.WorldType = EPlaySessionWorldType::PlayInEditor;
+  }
+
 #if MCP_HAS_LEVEL_EDITOR_PLAY_SETTINGS
   PlayParams.EditorPlaySettings = GetMutableDefault<ULevelEditorPlaySettings>();
 #endif
+
+  // Honor explicit start location, otherwise let UE pick (Player Start).
+  bool bUsedExplicitStart = false;
+  if (Payload.IsValid() && Payload->HasField(TEXT("start_location"))) {
+    const FVector StartLocation =
+        ExtractVectorField(Payload, TEXT("start_location"), FVector::ZeroVector);
+    PlayParams.StartLocation = StartLocation;
+    PlayParams.StartRotation = FRotator::ZeroRotator;
+    bUsedExplicitStart = true;
+  } else {
+    bool bSpawnAtPlayerStart = true;
+    if (Payload.IsValid()) {
+      Payload->TryGetBoolField(TEXT("spawn_at_player_start"),
+                               bSpawnAtPlayerStart);
+    }
+    if (!bSpawnAtPlayerStart) {
+      // Spawn at world origin if caller explicitly opts out of Player Start.
+      PlayParams.StartLocation = FVector::ZeroVector;
+      PlayParams.StartRotation = FRotator::ZeroRotator;
+    }
+    // Otherwise leave StartLocation unset so UE uses the Player Start actor.
+  }
+
+  // Wire the destination viewport unless caller asked for a new window.
 #if MCP_HAS_LEVEL_EDITOR_MODULE
-  if (FLevelEditorModule *LevelEditorModule =
-          FModuleManager::GetModulePtr<FLevelEditorModule>(
-              TEXT("LevelEditor"))) {
-    TSharedPtr<IAssetViewport> DestinationViewport =
-        LevelEditorModule->GetFirstActiveViewport();
-    if (DestinationViewport.IsValid())
-      PlayParams.DestinationSlateViewport = DestinationViewport;
+  const bool bUseNewWindow = (LowerMode == TEXT("new_window"));
+  if (!bUseNewWindow) {
+    if (FLevelEditorModule *LevelEditorModule =
+            FModuleManager::GetModulePtr<FLevelEditorModule>(
+                TEXT("LevelEditor"))) {
+      TSharedPtr<IAssetViewport> DestinationViewport =
+          LevelEditorModule->GetFirstActiveViewport();
+      if (DestinationViewport.IsValid())
+        PlayParams.DestinationSlateViewport = DestinationViewport;
+    }
   }
 #endif
 
   GEditor->RequestPlaySession(PlayParams);
+
   TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
   Resp->SetBoolField(TEXT("success"), true);
+  Resp->SetStringField(TEXT("mode"),
+                       LowerMode.IsEmpty() ? TEXT("viewport") : LowerMode);
+  Resp->SetBoolField(TEXT("explicitStartLocation"), bUsedExplicitStart);
+  // PIE world is created asynchronously after RequestPlaySession; the world
+  // pointer becomes available once the session actually starts (next tick).
+  Resp->SetStringField(TEXT("status"), TEXT("requested"));
+
   SendAutomationResponse(Socket, RequestId, true,
-                         TEXT("Play in Editor started"), Resp, FString());
+                         TEXT("Play in Editor session requested"), Resp,
+                         FString());
   return true;
 #else
   return false;
@@ -2666,6 +2730,14 @@ bool UMcpAutomationBridgeSubsystem::HandleControlEditorStop(
     const FString &RequestId, const TSharedPtr<FJsonObject> &Payload,
     TSharedPtr<FMcpBridgeWebSocket> Socket) {
 #if WITH_EDITOR
+  if (!GEditor) {
+    SendStandardErrorResponse(this, Socket, RequestId,
+                              TEXT("EDITOR_NOT_AVAILABLE"),
+                              TEXT("GEditor is null; cannot stop PIE"),
+                              nullptr);
+    return true;
+  }
+
   if (!GEditor->PlayWorld) {
     TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
     Resp->SetBoolField(TEXT("success"), true);

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_SystemControlHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_SystemControlHandlers.cpp
@@ -33,14 +33,16 @@ bool UMcpAutomationBridgeSubsystem::HandleSystemControlAction(
   }
   
   const FString Lower = SubAction.ToLower();
-  
+
   // Check if this handler should process this sub-action
   if (!Lower.StartsWith(TEXT("run_ubt")) &&
       !Lower.StartsWith(TEXT("run_tests")) &&
       !Lower.StartsWith(TEXT("test_progress")) &&
       !Lower.StartsWith(TEXT("test_stale")) &&
       Lower != TEXT("export_asset") &&
-      Lower != TEXT("execute_python")) {
+      Lower != TEXT("execute_python") &&
+      Lower != TEXT("start_pie") &&
+      Lower != TEXT("stop_pie")) {
     return false; // Not handled by this function
   }
 
@@ -50,6 +52,27 @@ bool UMcpAutomationBridgeSubsystem::HandleSystemControlAction(
                         TEXT("System control payload missing"),
                         TEXT("INVALID_PAYLOAD"));
     return true;
+  }
+
+  // -------------------------------------------------------------------------
+  // PIE (Play-In-Editor) session control
+  //
+  // start_pie / stop_pie delegate to the editor-control implementations
+  // (HandleControlEditorPlay / HandleControlEditorStop), which use the
+  // FRequestPlaySessionParams API directly. Handlers run on the game thread
+  // (dispatched by the subsystem), satisfying the GEditor->RequestPlaySession
+  // game-thread requirement.
+  //
+  // Optional payload fields (forwarded to HandleControlEditorPlay):
+  //   - mode: "viewport" (default) | "new_window" | "simulate"
+  //   - start_location: { x, y, z }
+  //   - spawn_at_player_start: bool, default true
+  // -------------------------------------------------------------------------
+  if (Lower == TEXT("start_pie")) {
+    return HandleControlEditorPlay(RequestId, Payload, RequestingSocket);
+  }
+  if (Lower == TEXT("stop_pie")) {
+    return HandleControlEditorStop(RequestId, Payload, RequestingSocket);
   }
 
   if (Lower == TEXT("run_ubt")) {


### PR DESCRIPTION
## Summary

Implements `start_pie` and `stop_pie` actions on the `system_control` tool. Previously these returned `"System control action 'start_pie' not implemented"`, leaving no programmatic way to start/stop a Play-In-Editor session via the bridge.

The fix discovered that `HandleControlEditorPlay` / `HandleControlEditorStop` already existed and used `FRequestPlaySessionParams` correctly — they were just only wired to the `control_editor` action. This change adds the routing entries so `system_control` can reach them too, and extends `HandleControlEditorPlay` with optional payload fields:

- `mode`: `"viewport"` (default), `"new_window"`, `"simulate"`
- `start_location`: `{x, y, z}` — explicit world-space spawn that overrides Player Start
- `spawn_at_player_start`: `bool` (default `true`)

Both PIE handlers now null-check `GEditor` and emit `EDITOR_NOT_AVAILABLE` instead of crashing.

## Why
While doing a foot-reachability audit on a UE 5.7 walking-sim project, the missing `start_pie` blocked any automated playthrough — a navmesh-volume static check can't catch geometry-blocked stairways, so PIE walking is necessary. The existing `console_command: PIE` doesn't work (PIE isn't a console verb).

## Test plan
- [ ] `system_control: start_pie` returns `status: "requested"` and a PIE world spawns next tick
- [ ] `system_control: start_pie` with `mode: "simulate"` enters Simulate-In-Editor instead
- [ ] `system_control: start_pie` with `start_location` spawns at that point
- [ ] `system_control: stop_pie` ends the active session
- [ ] `system_control: start_pie` with `GEditor == nullptr` (commandlet mode) returns `EDITOR_NOT_AVAILABLE` instead of crashing
- [ ] `control_editor: play` still works (no regression in old path)

## Open questions for the maintainer
1. Should `control_editor: play` also accept the new `mode`/`start_location`/`spawn_at_player_start` fields? Current PR: yes (both routes go through the same handler), but easy to scope down.
2. Should `start_pie` synchronously return the `PlayWorld` pointer? UE creates it next tick, so synchronous would be `nullptr`. Current: `status: "requested"`, caller can poll `is_pie_active`.
3. UE 5.0/5.1 compile compatibility: I did not gate `EPlaySessionWorldType::SimulateInEditor` and `FRequestPlaySessionParams::StartLocation` with version macros; should be fine across the supported range, but happy to add `__has_include` guards if CI surfaces issues.
