### PR TITLE
fix(level): get_level_info AssetRegistry fallback when level not loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Game Feature Plugin path validation** – `SanitizeProjectRelativePath` now uses `FPackageName::IsValidLongPackageName` instead of a manual `/Content/` heuristic, correctly recognizing all registered engine mount points (game feature plugins like `/MyGameFeature/`, `/ShooterCore/`, `/ALS/`, etc.).
+- **`manage_level: get_level_info` no longer requires the level to be loaded** – previously returned `LEVEL_NOT_FOUND` for any map asset path that hadn't already been `load_level`'d. Now falls back to `IAssetRegistry::GetAssetByObjectPath` and returns `objectPath`, `assetName`, `packageName`, `assetClass`, and the asset's `tagsAndValues` map alongside `loaded: false`. The loaded case is unchanged but now also includes `loaded: true`. Does not auto-load the level.
 
 ---
 

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_LevelHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_LevelHandlers.cpp
@@ -1977,14 +1977,14 @@ TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
       Payload->TryGetStringField(TEXT("levelPath"), LevelPath);
       if (LevelPath.IsEmpty()) Payload->TryGetStringField(TEXT("level_path"), LevelPath);
     }
-    
+
     UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
     if (!World) {
       SendAutomationResponse(RequestingSocket, RequestId, false,
                              TEXT("No editor world available"), nullptr, TEXT("NO_WORLD"));
       return true;
     }
-    
+
     ULevel* TargetLevel = nullptr;
     if (!LevelPath.IsEmpty()) {
       TArray<ULevel*> Levels = GetAllLevelsFromWorld(World);
@@ -1997,20 +1997,74 @@ TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
     } else {
       TargetLevel = World->GetCurrentLevel();
     }
-    
-    if (!TargetLevel) {
-      SendAutomationResponse(RequestingSocket, RequestId, false,
-                             FString::Printf(TEXT("Level not found: %s"), *LevelPath),
-                             nullptr, TEXT("LEVEL_NOT_FOUND"));
+
+    if (TargetLevel) {
+      // Loaded path: preserve existing JSON shape, only ADD `loaded: true`.
+      TSharedPtr<FJsonObject> Result = McpHandlerUtils::CreateResultObject();
+      Result->SetStringField(TEXT("levelPath"), TargetLevel->GetOutermost() ? TargetLevel->GetOutermost()->GetName() : TEXT(""));
+      Result->SetStringField(TEXT("levelName"), TargetLevel->GetName());
+      Result->SetNumberField(TEXT("actorCount"), TargetLevel->Actors.Num());
+      Result->SetBoolField(TEXT("loaded"), true);
+
+      SendAutomationResponse(RequestingSocket, RequestId, true, TEXT("Level info retrieved"), Result);
       return true;
     }
-    
-    TSharedPtr<FJsonObject> Result = McpHandlerUtils::CreateResultObject();
-    Result->SetStringField(TEXT("levelPath"), TargetLevel->GetOutermost() ? TargetLevel->GetOutermost()->GetName() : TEXT(""));
-    Result->SetStringField(TEXT("levelName"), TargetLevel->GetName());
-    Result->SetNumberField(TEXT("actorCount"), TargetLevel->Actors.Num());
-    
-    SendAutomationResponse(RequestingSocket, RequestId, true, TEXT("Level info retrieved"), Result);
+
+    // Not loaded as a UWorld — fall back to AssetRegistry lookup so callers can
+    // query metadata for any map asset without forcing a load. We do NOT auto-load.
+    if (!LevelPath.IsEmpty()) {
+      IAssetRegistry& AssetRegistry =
+          FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry").Get();
+
+      // Accept either a package path ("/Game/Maps/Foo") or a full object path
+      // ("/Game/Maps/Foo.Foo"). FSoftObjectPath handles both forms.
+      FAssetData AssetData;
+      #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
+      AssetData = AssetRegistry.GetAssetByObjectPath(FSoftObjectPath(LevelPath));
+      if (!AssetData.IsValid()) {
+        // Try appending `.<ShortName>` to a bare package path.
+        const FString ShortName = FPackageName::GetShortName(LevelPath);
+        if (!ShortName.IsEmpty() && !LevelPath.Contains(TEXT("."))) {
+          const FString ObjectPath = LevelPath + TEXT(".") + ShortName;
+          AssetData = AssetRegistry.GetAssetByObjectPath(FSoftObjectPath(ObjectPath));
+        }
+      }
+      #else
+      AssetData = AssetRegistry.GetAssetByObjectPath(FName(*LevelPath));
+      if (!AssetData.IsValid()) {
+        const FString ShortName = FPackageName::GetShortName(LevelPath);
+        if (!ShortName.IsEmpty() && !LevelPath.Contains(TEXT("."))) {
+          const FString ObjectPath = LevelPath + TEXT(".") + ShortName;
+          AssetData = AssetRegistry.GetAssetByObjectPath(FName(*ObjectPath));
+        }
+      }
+      #endif
+
+      if (AssetData.IsValid()) {
+        TSharedPtr<FJsonObject> Result = McpHandlerUtils::CreateResultObject();
+        Result->SetBoolField(TEXT("loaded"), false);
+        Result->SetStringField(TEXT("levelPath"), AssetData.PackageName.ToString());
+        Result->SetStringField(TEXT("levelName"), AssetData.AssetName.ToString());
+        Result->SetStringField(TEXT("packageName"), AssetData.PackageName.ToString());
+        Result->SetStringField(TEXT("assetName"), AssetData.AssetName.ToString());
+        Result->SetStringField(TEXT("objectPath"), MCP_ASSET_DATA_GET_OBJECT_PATH(AssetData));
+        Result->SetStringField(TEXT("assetClass"), MCP_ASSET_DATA_GET_CLASS_PATH(AssetData));
+
+        TSharedPtr<FJsonObject> TagsObj = McpHandlerUtils::CreateResultObject();
+        for (const auto& Kvp : AssetData.TagsAndValues) {
+          TagsObj->SetStringField(Kvp.Key.ToString(), Kvp.Value.AsString());
+        }
+        Result->SetObjectField(TEXT("tagsAndValues"), TagsObj);
+
+        SendAutomationResponse(RequestingSocket, RequestId, true,
+                               TEXT("Level info retrieved (asset registry, not loaded)"), Result);
+        return true;
+      }
+    }
+
+    SendAutomationResponse(RequestingSocket, RequestId, false,
+                           FString::Printf(TEXT("Level not found: %s"), *LevelPath),
+                           nullptr, TEXT("LEVEL_NOT_FOUND"));
     return true;
   }
   if (EffectiveAction == TEXT("set_level_world_settings")) {


### PR DESCRIPTION
## Summary

`manage_level: get_level_info` returned `LEVEL_NOT_FOUND` for any map asset path that hadn't been `load_level`'d first. This forces callers into a load-then-query pattern that is slow and side-effecting.

## Fix
Add an `IAssetRegistry::GetAssetByObjectPath(FSoftObjectPath(path))` fallback. If the level is not loaded as a `UWorld`, return whatever info is derivable from `FAssetData` plus `loaded: false`. If the level IS loaded, behavior is unchanged plus a new `loaded: true` field. **No JSON keys removed or renamed** — only added.

The handler now also accepts a bare package path (e.g., `/Game/Maps/Foo`) and falls back to `<package>.<ShortName>` when the explicit object path doesn't resolve.

## New JSON shape (unloaded case)
```json
{
  "loaded": false,
  "levelPath":   "/Game/Maps/Foo",
  "levelName":   "Foo",
  "packageName": "/Game/Maps/Foo",
  "assetName":   "Foo",
  "objectPath":  "/Game/Maps/Foo.Foo",
  "assetClass":  "/Script/Engine.World",
  "tagsAndValues": { ... }
}
```

If the path is empty AND there's no current level, OR the AssetRegistry has no matching asset → still returns `LEVEL_NOT_FOUND` as before.

## Test plan
- [ ] `get_level_info` for a never-loaded map returns `loaded: false` + asset metadata
- [ ] `get_level_info` for a currently-loaded level returns full info + `loaded: true`
- [ ] Bogus path still returns `LEVEL_NOT_FOUND`
- [ ] Empty path with no current level returns `LEVEL_NOT_FOUND`
- [ ] Package-only path (`/Game/Maps/Foo` without `.Foo`) auto-suffixes and resolves
