### PR TITLE
fix(inspect): resolve Blueprint generated classes via _C suffix and UBlueprint fallback

### DIFF
--- a/plugins/McpAutomationBridge/CHANGELOG.md
+++ b/plugins/McpAutomationBridge/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to the MCP Automation Bridge plugin will be documented in th
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- `inspect:inspect_class` now resolves Blueprint generated classes — previously returned `CLASS_NOT_FOUND` for `BP_*` short names because the lookup only used `FindObject<UClass>` against the as-given name. The handler now delegates to the central `ResolveClassByName` helper.
+- `ResolveClassByName` and `ResolveUClass` helpers gained a Blueprint resolution chain: try the input as-is, retry with a `_C` generated-class suffix, strip a trailing `_C` and `LoadAsset` the underlying `UBlueprint` (returning `GeneratedClass`), and fall back to an Asset Registry lookup of `UBlueprint` assets by short `AssetName`. The `TObjectIterator` fallback also now matches `BP_Foo` against an in-memory `BP_Foo_C` class.
+- `blueprint_create` parent-class resolution now falls back to `ResolveClassByName`, so callers can specify a Blueprint parent by short name (e.g. `BP_BaseCharacter`) or full asset path (`/Game/.../BP_Foo.BP_Foo_C`).
+
+---
+
 ## [0.6.0] - 2026-04-05
 
 ### Security

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridgeHelpers.h
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridgeHelpers.h
@@ -1465,20 +1465,30 @@ static inline bool McpSafeLoadMap(const FString& MapPath, bool bForceCleanup = t
 // to load an asset by path (UBlueprint or UClass), then fall back to scanning
 // loaded classes by name or path suffix. This replaces previous usages of
 // FindObject<...>(ANY_PACKAGE, ...) which is deprecated.
+//
+// Blueprint resolution: Unreal Blueprint generated classes live at
+// "/Game/Path/BP_Foo.BP_Foo_C". Callers frequently pass either the asset short
+// name ("BP_Foo"), the asset path without the generated-class suffix
+// ("/Game/Path/BP_Foo.BP_Foo"), or the full generated-class path. This helper
+// handles all three by trying the input as-is, retrying with a "_C" suffix,
+// and falling back to UBlueprint::GeneratedClass via the Asset Registry.
 static inline UClass *ResolveClassByName(const FString &ClassNameOrPath) {
   if (ClassNameOrPath.IsEmpty())
     return nullptr;
 
-  // 1) If it's an asset path, prefer loading the asset and deriving the class
-  // Skip /Script/ paths as they are native classes, not assets
+  // 1) If it's an asset path, prefer loading the asset and deriving the class.
+  //    Skip /Script/ paths as they are native classes, not assets.
   if ((ClassNameOrPath.StartsWith(TEXT("/")) ||
        ClassNameOrPath.Contains(TEXT("/"))) &&
       !ClassNameOrPath.StartsWith(TEXT("/Script/"))) {
-    UObject *Loaded = nullptr;
-// Prefer EditorAssetLibrary when available
-#if WITH_EDITOR
-    Loaded = UEditorAssetLibrary::LoadAsset(ClassNameOrPath);
-#endif
+    // For paths that include the generated-class "_C" suffix
+    // (e.g. /Game/Foo.Foo_C), strip it before LoadAsset since
+    // EditorAssetLibrary loads UObject assets, not UClass directly.
+    FString AssetLoadPath = ClassNameOrPath;
+    if (AssetLoadPath.EndsWith(TEXT("_C"))) {
+      AssetLoadPath.LeftChopInline(2);
+    }
+    UObject *Loaded = UEditorAssetLibrary::LoadAsset(AssetLoadPath);
     if (Loaded) {
       if (UBlueprint *BP = Cast<UBlueprint>(Loaded))
         return BP->GeneratedClass;
@@ -1490,6 +1500,21 @@ static inline UClass *ResolveClassByName(const FString &ClassNameOrPath) {
   // 2) Try a direct FindObject using nullptr/explicit outer (expects full path)
   if (UClass *Direct = FindObject<UClass>(nullptr, *ClassNameOrPath))
     return Direct;
+
+  // 2.1) Blueprint generated-class fallback: append _C and retry FindObject.
+  //      Covers callers that passed "/Game/Foo.Foo" (UBlueprint object path)
+  //      or a bare short name "BP_Foo" for an already-loaded Blueprint.
+  if (!ClassNameOrPath.EndsWith(TEXT("_C"))) {
+    const FString WithCSuffix = ClassNameOrPath + TEXT("_C");
+    if (UClass *BPClass = FindObject<UClass>(nullptr, *WithCSuffix))
+      return BPClass;
+    // For full asset paths, try loading the generated class explicitly.
+    if (ClassNameOrPath.StartsWith(TEXT("/")) &&
+        !ClassNameOrPath.StartsWith(TEXT("/Script/"))) {
+      if (UClass *BPClassLoaded = LoadObject<UClass>(nullptr, *WithCSuffix))
+        return BPClassLoaded;
+    }
+  }
 
   // 2.5) Try guessing generic engine locations for common components (e.g.
   // StaticMeshComponent -> /Script/Engine.StaticMeshComponent) This helps when
@@ -1520,8 +1545,46 @@ static inline UClass *ResolveClassByName(const FString &ClassNameOrPath) {
     }
   }
 
+  // 2.7) Asset Registry lookup for Blueprint short names (e.g. "BP_Foo").
+  //      Resolves a Blueprint asset by name and returns its GeneratedClass,
+  //      so callers don't have to know the /Game/... path.
+  if (!ClassNameOrPath.Contains(TEXT("/")) &&
+      !ClassNameOrPath.Contains(TEXT("."))) {
+    // Strip a trailing "_C" so we look up the UBlueprint asset by base name.
+    FString BPShortName = ClassNameOrPath;
+    if (BPShortName.EndsWith(TEXT("_C"))) {
+      BPShortName.LeftChopInline(2);
+    }
+    if (FModuleManager::Get().IsModuleLoaded(TEXT("AssetRegistry"))) {
+      FAssetRegistryModule &ARM =
+          FModuleManager::LoadModuleChecked<FAssetRegistryModule>(
+              TEXT("AssetRegistry"));
+      TArray<FAssetData> BPAssets;
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
+      ARM.Get().GetAssetsByClass(UBlueprint::StaticClass()->GetClassPathName(),
+                                 BPAssets);
+#else
+      // UE 5.0: legacy FName overload
+      ARM.Get().GetAssetsByClass(FName(TEXT("Blueprint")), BPAssets);
+#endif
+      for (const FAssetData &AD : BPAssets) {
+        if (AD.AssetName.ToString().Equals(BPShortName,
+                                           ESearchCase::IgnoreCase)) {
+          if (UBlueprint *BP = Cast<UBlueprint>(AD.GetAsset())) {
+            if (BP->GeneratedClass)
+              return BP->GeneratedClass;
+          }
+        }
+      }
+    }
+  }
+
   // 3) Fallback: iterate loaded classes and match by short name or path suffix
   UClass *BestMatch = nullptr;
+  // For "BP_Foo" requests, the in-memory generated class is named "BP_Foo_C".
+  const FString BPSuffixedName = ClassNameOrPath.EndsWith(TEXT("_C"))
+                                     ? FString()
+                                     : ClassNameOrPath + TEXT("_C");
   for (TObjectIterator<UClass> It; It; ++It) {
     UClass *C = *It;
     if (!C)
@@ -1532,6 +1595,12 @@ static inline UClass *ResolveClassByName(const FString &ClassNameOrPath) {
       // Prefer /Script/ (native) classes over others if multiple match
       if (C->GetPathName().StartsWith(TEXT("/Script/")))
         return C;
+      if (!BestMatch)
+        BestMatch = C;
+    }
+    // Generated-class match: input "BP_Foo" matches loaded class "BP_Foo_C".
+    else if (!BPSuffixedName.IsEmpty() &&
+             C->GetName().Equals(BPSuffixedName, ESearchCase::IgnoreCase)) {
       if (!BestMatch)
         BestMatch = C;
     }
@@ -3050,8 +3119,16 @@ static inline bool FindBlueprintNormalizedPath(const FString &Req,
  * Resolve a UClass from a string that may be a full path, a blueprint class
  * path, or a short class name.
  *
- * @param Input The input string representing the class (examples:
- * "/Script/Engine.Actor", "/Game/MyBP.MyBP_C", or "Actor").
+ * Blueprint generated classes live at "/Game/Path/MyBP.MyBP_C". Callers may
+ * pass any of the following forms; this helper tries them all:
+ *   - "/Script/Engine.Actor"     (native class)
+ *   - "/Game/MyBP.MyBP_C"        (full BP generated-class path)
+ *   - "/Game/MyBP.MyBP"          (BP object path; we retry with _C)
+ *   - "/Game/MyBP"               (asset path; we load + use GeneratedClass)
+ *   - "MyBP" / "BP_Foo"          (short name; we delegate to ResolveClassByName
+ *                                 which also probes the Asset Registry)
+ *
+ * @param Input The input string representing the class.
  * @returns A pointer to the resolved UClass if found, `nullptr` otherwise.
  */
 static inline UClass *ResolveUClass(const FString &Input) {
@@ -3068,14 +3145,39 @@ static inline UClass *ResolveUClass(const FString &Input) {
   if (Found)
     return Found;
 
-  // 3. Handle Blueprint Generated Classes explicitly
-  // parsing "MyBP" -> "/Game/MyBP.MyBP_C" logic is hard without path,
-  // but if input ends in _C, treat as class path.
-  if (Input.EndsWith(TEXT("_C"))) {
-    // Already tried loading, maybe it needs a package path fix?
-    // Assuming the user provided a full path if they included _C.
-    return nullptr;
+  // 3. Blueprint generated-class fallback: append _C and retry.
+  //    Handles "/Game/MyBP.MyBP" -> "/Game/MyBP.MyBP_C" and short BP names
+  //    where the in-memory class is "BP_Foo_C".
+  if (!Input.EndsWith(TEXT("_C"))) {
+    const FString WithCSuffix = Input + TEXT("_C");
+    Found = FindObject<UClass>(nullptr, *WithCSuffix);
+    if (Found)
+      return Found;
+    if (Input.StartsWith(TEXT("/")) && !Input.StartsWith(TEXT("/Script/"))) {
+      Found = LoadObject<UClass>(nullptr, *WithCSuffix);
+      if (Found)
+        return Found;
+    }
   }
+
+  // 3a. If we have an asset path for a UBlueprint, load it and return its
+  //     GeneratedClass. Skip /Script/ paths (not assets). Editor-only.
+#if WITH_EDITOR
+  if (Input.StartsWith(TEXT("/")) && !Input.StartsWith(TEXT("/Script/"))) {
+    FString AssetLoadPath = Input;
+    if (AssetLoadPath.EndsWith(TEXT("_C"))) {
+      AssetLoadPath.LeftChopInline(2);
+    }
+    if (UObject *Loaded = UEditorAssetLibrary::LoadAsset(AssetLoadPath)) {
+      if (UBlueprint *BP = Cast<UBlueprint>(Loaded)) {
+        if (BP->GeneratedClass)
+          return BP->GeneratedClass;
+      }
+      if (UClass *AsClass = Cast<UClass>(Loaded))
+        return AsClass;
+    }
+  }
+#endif
 
   // 4. Short name resolution
   // Check common script packages
@@ -3098,12 +3200,30 @@ static inline UClass *ResolveUClass(const FString &Input) {
 
   // 5. Native class search by iteration (slow fallback, but useful for obscure
   // plugins)
-  // Only doing this for exact short name matches to avoid false positives
+  // Only doing this for exact short name matches to avoid false positives.
+  // Also accepts the "_C" suffixed form for Blueprint-generated classes.
+  const FString InputWithC = Input.EndsWith(TEXT("_C"))
+                                 ? FString()
+                                 : Input + TEXT("_C");
   for (TObjectIterator<UClass> It; It; ++It) {
-    if (It->GetName() == Input) {
+    const FString IterName = It->GetName();
+    if (IterName == Input) {
+      return *It;
+    }
+    if (!InputWithC.IsEmpty() && IterName == InputWithC) {
       return *It;
     }
   }
+
+  // 6. Asset Registry fallback for Blueprint short names (delegated to
+  //    ResolveClassByName, which knows how to look up UBlueprint by AssetName
+  //    and return its GeneratedClass). Editor-only.
+#if WITH_EDITOR
+  if (!Input.Contains(TEXT("/")) && !Input.Contains(TEXT("."))) {
+    if (UClass *FromRegistry = ResolveClassByName(Input))
+      return FromRegistry;
+  }
+#endif
 
   return nullptr;
 }

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_BlueprintCreationHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_BlueprintCreationHandlers.cpp
@@ -575,6 +575,13 @@ bool FBlueprintCreationHandlers::HandleBlueprintCreate(
           }
         }
       }
+      // Final fallback: delegate to the centralized helper, which handles
+      // Blueprint generated classes (auto-appends "_C") and looks up
+      // UBlueprint by short name via the Asset Registry. Lets users specify
+      // a BP parent like "BP_BaseCharacter" or "/Game/BP_Foo.BP_Foo_C".
+      if (!ResolvedParent) {
+        ResolvedParent = ResolveClassByName(ParentClassSpec);
+      }
     }
   }
   if (!ResolvedParent && bRequestedFunctionLibraryByParentSpec) {

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_EnvironmentHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_EnvironmentHandlers.cpp
@@ -2056,11 +2056,17 @@ bool UMcpAutomationBridgeSubsystem::HandleInspectAction(
             Payload->TryGetStringField(TEXT("className"), ClassName);
             if (!ClassName.IsEmpty())
             {
-                // Try to find the class
-                UClass* TargetClass = FindObject<UClass>(nullptr, *ClassName);
+                // Resolve via the centralized helper, which handles:
+                //   - native classes by short name or /Script/...
+                //   - Blueprint generated classes (auto-appends "_C")
+                //   - UBlueprint asset paths -> GeneratedClass
+                //   - Asset Registry lookup for BP short names like "BP_Foo"
+                // (Game-thread safe: invoked through the subsystem dispatcher.)
+                UClass* TargetClass = ResolveClassByName(ClassName);
                 if (!TargetClass && !ClassName.Contains(TEXT(".")))
                 {
-                    // Try with /Script/Engine prefix for common classes
+                    // Final fallback: try with /Script/Engine prefix for
+                    // unloaded native classes (covers an existing edge case).
                     TargetClass = FindObject<UClass>(nullptr, *FString::Printf(TEXT("/Script/Engine.%s"), *ClassName));
                 }
                 if (TargetClass)


### PR DESCRIPTION
## Summary

`inspect: inspect_class` returned `CLASS_NOT_FOUND` for Blueprint classes given as short asset names like `BP_Foo` — even though those Blueprints exist in the project. Same was true for some other paths that ended up calling the same resolution helpers.

## Root cause
`FindObject<UClass>` and `LoadClass<UObject>` were called with the input as-is, but a UE Blueprint's runtime UClass lives at `BP_Foo_C` (with the `_C` generated-class suffix), and BPs not yet loaded won't be in the object tree at all.

## Fix
The `inspect_class` handler now delegates to a strengthened `ResolveClassByName` helper (`McpAutomationBridgeHelpers.h`). New resolution chain (fast-path preserved; fallbacks only run on miss):

1. `FindObject<UClass>` / `LoadObject<UClass>` on input as-is.
2. Append `_C` and retry (handles `/Game/Foo.Foo` and bare BP short names whose loaded UClass is `BP_Foo_C`).
3. Strip trailing `_C`, `UEditorAssetLibrary::LoadAsset`; if it's a `UBlueprint`, return `GeneratedClass`.
4. Asset Registry: enumerate `UBlueprint` assets, case-insensitive `AssetName` match, return `GeneratedClass` (UE 5.0 vs 5.1+ path-name compat handled via existing `MCP_ASSET_DATA_GET_CLASS_PATH` macros).
5. `TObjectIterator` fallback also matches `BP_Foo` against an in-memory `BP_Foo_C` class.

`blueprint_create` parent-class resolution gets the same fallback for free, so callers can specify a Blueprint parent by short name (`BP_BaseCharacter`) or full asset path (`/Game/.../BP_Foo.BP_Foo_C`).

## Test plan
- [ ] `inspect_class` with `BP_Foo` (short name) returns the generated class info
- [ ] `inspect_class` with `BP_Foo_C` works (no regression)
- [ ] `inspect_class` with full `/Game/.../BP_Foo.BP_Foo_C` works
- [ ] `inspect_class` with full `/Game/.../BP_Foo.BP_Foo` works (auto-appends `_C`)
- [ ] Native UClass paths like `/Script/Engine.PlayerController` still resolve via the fast path
- [ ] `blueprint_create` accepts a Blueprint parent by short name
