### PR TITLE
feat(nav): add find_path subAction for navmesh reachability queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`find_path` sub-action for `manage_navigation`** — synchronous navmesh pathfinding query via `UNavigationSystemV1::FindPathToLocationSynchronously`. Payload accepts `start`/`end` world-space points and an optional `agent_class` (AActor/APawn class path used as the pathfinding context). Response includes `success`, `path_length`, ordered `waypoints[]`, `partial`, and `nav_data_used` (e.g. `"RecastNavMesh"`). Enables automated reachability/connectivity checks against a built navmesh — previously the handler exposed link/modifier setup but no actual path query.
 - **Native MCP Streamable HTTP Transport** — built-in HTTP/SSE MCP server directly in the C++ plugin, no TypeScript bridge or Node.js required. AI clients connect via `http://localhost:3000/mcp`. Supports SSE streaming, multiple concurrent sessions, dynamic tool management. Opt-in via `bEnableNativeMCP` project setting.
 - **`execute_python` action** in `system_control` — execute Python code inline or from `.py` files with stdout/stderr capture, execution time tracking, and RAII temp file cleanup. Max code size: 1 MB.
 - **Capability token authentication** for native MCP transport — validates `X-MCP-Capability-Token` header when `bRequireCapabilityToken` is enabled.

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ MCP_AUTOMATION_HOST=0.0.0.0
 | `manage_lighting` | Spawn lights, GI, shadows, build lighting, list_light_types |
 | `manage_level_structure` | Level creation, sublevels, World Partition, data layers, HLOD |
 | `manage_volumes` | Trigger volumes, blocking, physics, audio, navigation volumes |
-| `manage_navigation` | NavMesh settings, nav modifiers, nav links, smart links, pathfinding |
+| `manage_navigation` | NavMesh settings, nav modifiers, nav links, smart links, `find_path` pathfinding queries |
 | `build_environment` | Landscape, Foliage, Procedural |
 | `manage_splines` | Spline creation, spline mesh deformation |
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -1066,6 +1066,9 @@ The following phases represent the comprehensive expansion to enable **full proj
 - [x] `create_smart_link`
 - [x] `configure_smart_link_behavior`
 
+### 25.4 Pathfinding Queries
+- [x] `find_path` (start, end, optional `agent_class`; returns waypoints, total length, partial flag, owning nav data)
+
 ---
 
 ## Phase 26: Spline System (Complete)

--- a/docs/handler-mapping.md
+++ b/docs/handler-mapping.md
@@ -1074,6 +1074,8 @@ This document maps the TypeScript tool definitions to their corresponding C++ ha
 | `configure_smart_link_behavior` | `McpAutomationBridge_NavigationHandlers.cpp` | `HandleManageNavigationAction` | Configures UNavLinkCustomComponent settings |
 | **Utility** | | | |
 | `get_navigation_info` | `McpAutomationBridge_NavigationHandlers.cpp` | `HandleManageNavigationAction` | Returns NavMesh stats, agent properties, link counts |
+| **Pathfinding Queries** | | | |
+| `find_path` | `McpAutomationBridge_NavigationHandlers.cpp` | `HandleManageNavigationAction` | Runs `UNavigationSystemV1::FindPathToLocationSynchronously`; returns waypoints, total length, partial flag, owning nav data |
 
 ## 38. Splines Manager (`manage_splines`) - Phase 26
 

--- a/docs/native-automation-progress.md
+++ b/docs/native-automation-progress.md
@@ -384,6 +384,8 @@ All `blueprint_*` authoring commands now require editor support and execute nati
 | `configure_smart_link_behavior` | ✅ Done | Configures UNavLinkCustomComponent (area classes, broadcast, obstacles) |
 | **Utility** | | |
 | `get_navigation_info` | ✅ Done | Returns NavMesh stats, agent properties, link/volume counts |
+| **Pathfinding Queries** | | |
+| `find_path` | ✅ Done | Synchronous `FindPathToLocationSynchronously` query; returns waypoints, total length, partial flag, and owning nav data class |
 
 ### Phase 26: Spline System (`manage_splines`)
 

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Tools/McpTool_ManageNavigation.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Tools/McpTool_ManageNavigation.cpp
@@ -1,4 +1,4 @@
-// McpTool_ManageNavigation.cpp — manage_navigation tool definition (12 actions)
+// McpTool_ManageNavigation.cpp — manage_navigation tool definition (13 actions)
 
 #include "McpVersionCompatibility.h"
 #include "MCP/McpToolDefinition.h"
@@ -13,7 +13,8 @@ public:
 	FString GetDescription() const override
 	{
 		return TEXT("Configure NavMesh settings, add nav modifiers, "
-			"create nav links and smart links for pathfinding.");
+			"create nav links and smart links for pathfinding, "
+			"and run synchronous navmesh path queries (find_path).");
 	}
 
 	FString GetCategory() const override { return TEXT("gameplay"); }
@@ -33,7 +34,8 @@ public:
 				TEXT("set_nav_link_type"),
 				TEXT("create_smart_link"),
 				TEXT("configure_smart_link_behavior"),
-				TEXT("get_navigation_info")
+				TEXT("get_navigation_info"),
+				TEXT("find_path")
 			}, TEXT("Navigation action to perform"))
 			.String(TEXT("navMeshPath"), TEXT("Path to NavMesh data asset."))
 			.String(TEXT("actorName"), TEXT("Name of the actor."))
@@ -104,6 +106,15 @@ public:
 			})
 			.String(TEXT("filter"), TEXT("General search filter."))
 			.Bool(TEXT("save"), TEXT("Save the asset(s) after the operation."))
+			.Object(TEXT("start"), TEXT("World-space start point for find_path query."),
+				[](FMcpSchemaBuilder& S) {
+				S.Number(TEXT("x")).Number(TEXT("y")).Number(TEXT("z"));
+			})
+			.Object(TEXT("end"), TEXT("World-space end point for find_path query."),
+				[](FMcpSchemaBuilder& S) {
+				S.Number(TEXT("x")).Number(TEXT("y")).Number(TEXT("z"));
+			})
+			.String(TEXT("agent_class"), TEXT("Optional AActor/APawn class path; its default nav agent properties select the nav data used for find_path."))
 			.Required({TEXT("action")})
 			.Build();
 	}

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_NavigationHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_NavigationHandlers.cpp
@@ -24,6 +24,7 @@
 //
 // Section 4: Utility Handlers
 //   - HandleGetNavigationInfo           : Get navigation system status and settings
+//   - HandleFindPath                    : Synchronous navmesh pathfinding query
 //   - HandleManageNavigationAction      : Main dispatcher for navigation actions
 //
 // PAYLOAD/RESPONSE FORMATS:
@@ -89,6 +90,8 @@
 // Navigation System Includes
 // =============================================================================
 #include "NavigationSystem.h"
+#include "NavigationPath.h"
+#include "NavigationData.h"
 #include "NavMesh/RecastNavMesh.h"
 #include "NavMesh/NavMeshBoundsVolume.h"
 #include "NavModifierComponent.h"
@@ -1624,6 +1627,180 @@ static bool HandleGetNavigationInfo(
     return true;
 }
 
+/**
+ * HandleFindPath
+ * --------------
+ * Synchronous navmesh pathfinding query between two world-space points.
+ *
+ * Payload:
+ *   start:       { x, y, z }   (required)
+ *   end:         { x, y, z }   (required)
+ *   agent_class: string        (optional — class path of an AActor/APawn whose
+ *                               default nav agent properties select the nav data;
+ *                               defaults to NavSys default nav agent)
+ *
+ * Response (success):
+ *   success:        bool       (path was found and is at least partial)
+ *   path_length:    number     (sum of segment lengths between consecutive PathPoints)
+ *   waypoints:      array      ([{x,y,z}, ...] — first entry is start, last is end/closest reachable)
+ *   partial:        bool       (true if the goal was unreachable but a partial path was returned)
+ *   nav_data_used:  string     (class name of owning nav data, e.g. "RecastNavMesh")
+ *
+ * Response (failure):
+ *   success: false  + error message + errorCode (NO_WORLD, NO_NAV_SYSTEM,
+ *           AGENT_NOT_REGISTERED, NOT_FOUND, NO_PATH).
+ */
+static bool HandleFindPath(
+    UMcpAutomationBridgeSubsystem* Self,
+    const FString& RequestId,
+    const TSharedPtr<FJsonObject>& Payload,
+    TSharedPtr<FMcpBridgeWebSocket> Socket)
+{
+    if (!Payload.IsValid())
+    {
+        Self->SendAutomationResponse(Socket, RequestId, false,
+            TEXT("Missing payload for find_path"), nullptr, TEXT("INVALID_PAYLOAD"));
+        return true;
+    }
+
+    // Required: start, end (must be present as objects, not just defaulted to ZeroVector)
+    const TSharedPtr<FJsonObject>* StartObj = nullptr;
+    const TSharedPtr<FJsonObject>* EndObj = nullptr;
+    if (!Payload->TryGetObjectField(TEXT("start"), StartObj) || !StartObj->IsValid() ||
+        !Payload->TryGetObjectField(TEXT("end"),   EndObj)   || !EndObj->IsValid())
+    {
+        Self->SendAutomationResponse(Socket, RequestId, false,
+            TEXT("find_path requires 'start' and 'end' objects with x/y/z fields"),
+            nullptr, TEXT("INVALID_PAYLOAD"));
+        return true;
+    }
+
+    const FVector StartLoc = GetJsonVectorFieldNav(Payload, TEXT("start"));
+    const FVector EndLoc   = GetJsonVectorFieldNav(Payload, TEXT("end"));
+
+    UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+    if (!World)
+    {
+        Self->SendAutomationResponse(Socket, RequestId, false,
+            TEXT("No editor world available"), nullptr, TEXT("NO_WORLD"));
+        return true;
+    }
+
+    UNavigationSystemV1* NavSys = FNavigationSystem::GetCurrent<UNavigationSystemV1>(World);
+    if (!NavSys)
+    {
+        Self->SendAutomationResponse(Socket, RequestId, false,
+            TEXT("Navigation system not available in current world"),
+            nullptr, TEXT("NO_NAV_SYSTEM"));
+        return true;
+    }
+
+    // Optional agent class — used as PathfindingContext so the nav data picked
+    // matches that actor's nav agent properties.
+    AActor* PathfindingContext = nullptr;
+    FString AgentClassPath = GetJsonStringFieldNav(Payload, TEXT("agent_class"));
+    if (!AgentClassPath.IsEmpty())
+    {
+        if (!IsValidNavigationPath(AgentClassPath))
+        {
+            Self->SendAutomationResponse(Socket, RequestId, false,
+                TEXT("Invalid agent_class: must not contain path traversal (..) or invalid format"),
+                nullptr, TEXT("SECURITY_VIOLATION"));
+            return true;
+        }
+        UClass* AgentClass = LoadObject<UClass>(nullptr, *AgentClassPath);
+        if (!AgentClass)
+        {
+            // Allow short class names too (e.g., "Character") via StaticLoadClass-like fallback
+            AgentClass = FindObject<UClass>(nullptr, *AgentClassPath);
+        }
+        if (!AgentClass || !AgentClass->IsChildOf(AActor::StaticClass()))
+        {
+            Self->SendAutomationResponse(Socket, RequestId, false,
+                FString::Printf(TEXT("agent_class not found or not an AActor subclass: %s"),
+                    *AgentClassPath),
+                nullptr, TEXT("AGENT_NOT_REGISTERED"));
+            return true;
+        }
+        PathfindingContext = AgentClass->GetDefaultObject<AActor>();
+    }
+
+    UNavigationPath* NavPath = NavSys->FindPathToLocationSynchronously(
+        World, StartLoc, EndLoc, PathfindingContext, /*FilterClass=*/nullptr);
+
+    if (!NavPath)
+    {
+        Self->SendAutomationResponse(Socket, RequestId, false,
+            TEXT("Pathfinding query returned no result (no nav data, or query rejected)"),
+            nullptr, TEXT("NO_PATH"));
+        return true;
+    }
+
+    // GC-safety: FindPathToLocationSynchronously returns a UNavigationPath that is NOT
+    // referenced from any GC root by default. Subsequent JSON allocations in this
+    // handler can trigger garbage collection, which would invalidate NavPath mid-read
+    // and corrupt the engine's nav-tick state on later frames. Pin it to the root set
+    // for the duration of the read, then release. Copy out all needed fields BEFORE
+    // any UObject allocation so we never re-deref NavPath after JSON work begins.
+    NavPath->AddToRoot();
+
+    const bool bIsValid   = NavPath->IsValid();
+    const bool bIsPartial = NavPath->IsPartial();
+    const TArray<FVector> Points = NavPath->PathPoints;  // copy by value
+
+    FString NavDataUsed;
+    if (FNavPathSharedPtr SharedPath = NavPath->GetPath())
+    {
+        if (const ANavigationData* OwningData = SharedPath->GetNavigationDataUsed())
+        {
+            NavDataUsed = OwningData->GetClass()->GetName();
+        }
+    }
+
+    NavPath->RemoveFromRoot();
+    NavPath = nullptr;  // do not use past this point
+
+    TSharedPtr<FJsonObject> Result = McpHandlerUtils::CreateResultObject();
+
+    // Compute total length and emit waypoints from the local copy
+    TArray<TSharedPtr<FJsonValue>> Waypoints;
+    double PathLength = 0.0;
+    for (int32 i = 0; i < Points.Num(); ++i)
+    {
+        TSharedPtr<FJsonObject> Pt = MakeShared<FJsonObject>();
+        Pt->SetNumberField(TEXT("x"), Points[i].X);
+        Pt->SetNumberField(TEXT("y"), Points[i].Y);
+        Pt->SetNumberField(TEXT("z"), Points[i].Z);
+        Waypoints.Add(MakeShared<FJsonValueObject>(Pt));
+
+        if (i > 0)
+        {
+            PathLength += FVector::Dist(Points[i - 1], Points[i]);
+        }
+    }
+
+    Result->SetBoolField(TEXT("success"), bIsValid);
+    Result->SetNumberField(TEXT("path_length"), PathLength);
+    Result->SetArrayField(TEXT("waypoints"), Waypoints);
+    Result->SetBoolField(TEXT("partial"), bIsPartial);
+    Result->SetStringField(TEXT("nav_data_used"), NavDataUsed);
+
+    if (!bIsValid)
+    {
+        // Path object exists but no valid path could be built (e.g., points outside navmesh).
+        Result->SetStringField(TEXT("error"),
+            TEXT("No valid path between the requested points (outside navmesh or unreachable)"));
+        Self->SendAutomationResponse(Socket, RequestId, false,
+            TEXT("Pathfinding returned no valid path"), Result, TEXT("NO_PATH"));
+        return true;
+    }
+
+    Self->SendAutomationResponse(Socket, RequestId, true,
+        bIsPartial ? TEXT("Partial path found") : TEXT("Path found"),
+        Result);
+    return true;
+}
+
 #endif // WITH_EDITOR
 
 // =============================================================================
@@ -1650,6 +1827,7 @@ static bool HandleGetNavigationInfo(
  *   - create_smart_link
  *   - configure_smart_link_behavior
  *   - get_navigation_info
+ *   - find_path
  */
 bool UMcpAutomationBridgeSubsystem::HandleManageNavigationAction(
     const FString& RequestId,
@@ -1701,6 +1879,12 @@ bool UMcpAutomationBridgeSubsystem::HandleManageNavigationAction(
     // =========================================================================
     if (SubAction == TEXT("get_navigation_info"))
         return HandleGetNavigationInfo(this, RequestId, Payload, Socket);
+
+    // =========================================================================
+    // Pathfinding Queries
+    // =========================================================================
+    if (SubAction == TEXT("find_path"))
+        return HandleFindPath(this, RequestId, Payload, Socket);
 
     // Unknown action
     SendAutomationResponse(Socket, RequestId, false,


### PR DESCRIPTION
## Summary

Adds a `find_path` subAction to `manage_navigation`. The handler currently exposes 12 navmesh **configuration** subActions (`configure_nav_mesh_settings`, `rebuild_navigation`, etc.) but no actual **pathfinding query**. This means there's no programmatic way to verify navmesh-based reachability in a level — you can configure the navmesh but not ask "can the player walk from A to B?"

This is the highest-value of a series of PRs: it turns the bridge into a real reachability checker without needing PIE.

## API
**Request:**
```json
{
  "tool": "manage_navigation",
  "action": "find_path",
  "start": {"x": 0, "y": 0, "z": 100},
  "end":   {"x": 2000, "y": 500, "z": 100},
  "agent_class": "/Script/Engine.Character"
}
```
- `start`, `end`: required vec3
- `agent_class`: optional string. Loaded via `LoadObject<UClass>` (with `FindObject` fallback) and its CDO is used as the pathfinding context, so the nav data picked matches the actor's nav agent properties.

**Success response:**
```json
{
  "success": true,
  "message": "Path found",
  "result": {
    "success": true,
    "path_length": 2154.83,
    "waypoints": [{"x":0,"y":0,"z":100}, {"x":800,"y":200,"z":100}, {"x":2000,"y":500,"z":100}],
    "partial": false,
    "nav_data_used": "RecastNavMesh"
  }
}
```

**Failure response (points unreachable):**
```json
{
  "success": false,
  "message": "Pathfinding returned no valid path",
  "errorCode": "NO_PATH",
  "result": {
    "success": false, "path_length": 0, "waypoints": [], "partial": false,
    "nav_data_used": "",
    "error": "No valid path between the requested points (outside navmesh or unreachable)"
  }
}
```

Other error codes: `INVALID_PAYLOAD`, `NO_WORLD`, `NO_NAV_SYSTEM`, `AGENT_NOT_REGISTERED`, `SECURITY_VIOLATION`. Error JSON shape matches existing peer subActions like `get_navigation_info`.

## Implementation
- `UNavigationSystemV1::FindPathToLocationSynchronously(World, Start, End, /*Context=*/AgentCDO, /*FilterClass=*/nullptr)` returns `UNavigationPath*`.
- Reads `PathPoints`, `IsValid()`, `IsPartial()`. Nav-data identification goes through `NavPath->GetPath()->GetNavigationDataUsed()` — `UNavigationPath::GetOwningNavData()` does not exist in UE 5.4-5.7 (verified against `Engine/Source/Runtime/NavigationSystem/Public/NavigationPath.h`), so we go through the `FNavPathSharedPtr` returned by `GetPath()` to reach the underlying `FNavigationPath::GetNavigationDataUsed()`.
- Editor-only; game thread guaranteed by the subsystem dispatcher.
- `NavigationSystem` was already in `PrivateDependencyModuleNames` — no Build.cs change needed.

## Test plan
- [ ] Reachable points in a level with a Recast navmesh return `success: true` with non-zero `path_length`
- [ ] Points where one end is outside the navmesh return `NO_PATH`
- [ ] Points blocked by a wall (no nav corridor between them) return `NO_PATH` even though both ends have local nav coverage — **this is the canonical use case**
- [ ] `partial: true` flagged when only a partial path is returned
- [ ] Bogus `agent_class` returns `AGENT_NOT_REGISTERED` rather than crashing
- [ ] Empty payload returns `INVALID_PAYLOAD`

## Why this matters
With this in place + `start_pie` (separate PR), the McpAutomationBridge becomes a real automated QA tool for level reachability, not just a navmesh configurator.
