### PR TITLE
fix(config): restore default fallbacks for env vars after Zod v4 upgrade

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -36,7 +36,7 @@ export const EnvSchema = z.object({
   // Server Settings
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
   LOG_LEVEL: z.enum(['debug', 'info', 'warn', 'error']).default('debug'),
-  MCP_ROUTE_STDOUT_LOGS: z.preprocess(stringToBoolean, z.boolean().default(true)),
+  MCP_ROUTE_STDOUT_LOGS: z.preprocess(stringToBoolean, z.boolean()).default(true),
 
   // Unreal Settings
   UE_PROJECT_PATH: z.string().optional(),
@@ -44,13 +44,13 @@ export const EnvSchema = z.object({
 
 
   // Connection Settings
-  MCP_AUTOMATION_PORT: z.preprocess((v) => stringToNumber(v, 8091), z.number().default(8091)),
+  MCP_AUTOMATION_PORT: z.preprocess((v) => stringToNumber(v, 8091), z.number()).default(8091),
   MCP_AUTOMATION_HOST: z.string().default('127.0.0.1'),
-  MCP_AUTOMATION_CLIENT_MODE: z.preprocess(stringToBoolean, z.boolean().default(false)),
+  MCP_AUTOMATION_CLIENT_MODE: z.preprocess(stringToBoolean, z.boolean()).default(false),
 
   // Timeouts
-  MCP_CONNECTION_TIMEOUT_MS: z.preprocess((v) => stringToNumber(v, 5000), z.number().default(5000)),
-  MCP_REQUEST_TIMEOUT_MS: z.preprocess((v) => stringToNumber(v, 30000), z.number().default(30000)),
+  MCP_CONNECTION_TIMEOUT_MS: z.preprocess((v) => stringToNumber(v, 5000), z.number()).default(5000),
+  MCP_REQUEST_TIMEOUT_MS: z.preprocess((v) => stringToNumber(v, 30000), z.number()).default(30000),
 
   // Tool Categories (comma-separated: core,world,authoring,gameplay,utility,all)
   MCP_DEFAULT_CATEGORIES: z.string().default('core'),

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { EnvSchema } from '../../src/config.js';
 
 describe('EnvSchema env var defaults (Zod v4 compatibility)', () => {
@@ -67,5 +67,32 @@ describe('EnvSchema env var defaults (Zod v4 compatibility)', () => {
             MCP_AUTOMATION_PORT: 'abc',
         });
         expect(result.MCP_AUTOMATION_PORT).toBe(8091);
+    });
+});
+
+describe('config module load (regression: src/config.ts must not throw on empty env)', () => {
+    const originalEnv = process.env;
+
+    afterEach(() => {
+        process.env = originalEnv;
+        vi.resetModules();
+    });
+
+    it('importing src/config.js with no affected env vars set yields documented defaults', async () => {
+        process.env = { ...originalEnv };
+        delete process.env.MCP_ROUTE_STDOUT_LOGS;
+        delete process.env.MCP_AUTOMATION_PORT;
+        delete process.env.MCP_AUTOMATION_CLIENT_MODE;
+        delete process.env.MCP_CONNECTION_TIMEOUT_MS;
+        delete process.env.MCP_REQUEST_TIMEOUT_MS;
+        vi.resetModules();
+
+        const mod = await import('../../src/config.js');
+
+        expect(mod.config.MCP_ROUTE_STDOUT_LOGS).toBe(true);
+        expect(mod.config.MCP_AUTOMATION_PORT).toBe(8091);
+        expect(mod.config.MCP_AUTOMATION_CLIENT_MODE).toBe(false);
+        expect(mod.config.MCP_CONNECTION_TIMEOUT_MS).toBe(5000);
+        expect(mod.config.MCP_REQUEST_TIMEOUT_MS).toBe(30000);
     });
 });

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { EnvSchema } from '../../src/config.js';
+
+describe('EnvSchema env var defaults (Zod v4 compatibility)', () => {
+    it('parse({}) returns documented defaults for preprocessed boolean fields', () => {
+        const result = EnvSchema.parse({});
+        expect(result.MCP_ROUTE_STDOUT_LOGS).toBe(true);
+        expect(result.MCP_AUTOMATION_CLIENT_MODE).toBe(false);
+    });
+
+    it('parse({}) returns documented defaults for preprocessed number fields', () => {
+        const result = EnvSchema.parse({});
+        expect(result.MCP_AUTOMATION_PORT).toBe(8091);
+        expect(result.MCP_CONNECTION_TIMEOUT_MS).toBe(5000);
+        expect(result.MCP_REQUEST_TIMEOUT_MS).toBe(30000);
+    });
+
+    it('parse({}) returns documented defaults for plain (non-preprocessed) fields', () => {
+        const result = EnvSchema.parse({});
+        expect(result.NODE_ENV).toBe('development');
+        expect(result.LOG_LEVEL).toBe('debug');
+        expect(result.MCP_AUTOMATION_HOST).toBe('127.0.0.1');
+        expect(result.MCP_DEFAULT_CATEGORIES).toBe('core');
+        expect(result.MCP_ADDITIONAL_PATH_PREFIXES).toBe('');
+    });
+
+    it('respects user-set boolean strings ("true"/"false")', () => {
+        const result = EnvSchema.parse({
+            MCP_ROUTE_STDOUT_LOGS: 'false',
+            MCP_AUTOMATION_CLIENT_MODE: 'true',
+        });
+        expect(result.MCP_ROUTE_STDOUT_LOGS).toBe(false);
+        expect(result.MCP_AUTOMATION_CLIENT_MODE).toBe(true);
+    });
+
+    it('respects user-set number strings', () => {
+        const result = EnvSchema.parse({
+            MCP_AUTOMATION_PORT: '3000',
+            MCP_CONNECTION_TIMEOUT_MS: '1000',
+            MCP_REQUEST_TIMEOUT_MS: '60000',
+        });
+        expect(result.MCP_AUTOMATION_PORT).toBe(3000);
+        expect(result.MCP_CONNECTION_TIMEOUT_MS).toBe(1000);
+        expect(result.MCP_REQUEST_TIMEOUT_MS).toBe(60000);
+    });
+
+    it('partial input mixes user values and defaults', () => {
+        const result = EnvSchema.parse({
+            MCP_AUTOMATION_PORT: '7777',
+        });
+        expect(result.MCP_AUTOMATION_PORT).toBe(7777);
+        expect(result.MCP_ROUTE_STDOUT_LOGS).toBe(true);
+        expect(result.MCP_AUTOMATION_CLIENT_MODE).toBe(false);
+        expect(result.MCP_CONNECTION_TIMEOUT_MS).toBe(5000);
+        expect(result.MCP_REQUEST_TIMEOUT_MS).toBe(30000);
+    });
+
+    it('garbage boolean strings fall back to false (preprocess contract)', () => {
+        const result = EnvSchema.parse({
+            MCP_ROUTE_STDOUT_LOGS: 'not-a-bool',
+        });
+        expect(result.MCP_ROUTE_STDOUT_LOGS).toBe(false);
+    });
+
+    it('non-numeric port strings fall back to documented default', () => {
+        const result = EnvSchema.parse({
+            MCP_AUTOMATION_PORT: 'abc',
+        });
+        expect(result.MCP_AUTOMATION_PORT).toBe(8091);
+    });
+});


### PR DESCRIPTION
## Summary

Restore env var default fallbacks in `EnvSchema` after the upgrade to `zod ^4.2.1` started rejecting `z.preprocess(fn, schema.default(value))` patterns with `Invalid input: expected nonoptional, received undefined`. The same regression also breaks the `try/catch` safe-defaults fallback in `config.ts` (because `EnvSchema.parse({})` re-throws), so the server fails to start when none of the affected env vars are set.

## Changes

- `src/config.ts`: move `.default(value)` from the inner schema to the outer `z.preprocess(...)` wrapper for 5 fields:
  - `MCP_ROUTE_STDOUT_LOGS`
  - `MCP_AUTOMATION_PORT`
  - `MCP_AUTOMATION_CLIENT_MODE`
  - `MCP_CONNECTION_TIMEOUT_MS`
  - `MCP_REQUEST_TIMEOUT_MS`
- Add `tests/unit/config.test.ts` covering empty / full / partial env input plus string/number coercion edge cases.

### Why this works

In Zod v4 strict object mode, the outermost schema for each property must carry the `.default(...)` (or be `.optional()`) for a missing key. With the previous shape `z.preprocess(fn, schema.default(value))`, the outer is `z.preprocess(...)` (without a default), so a missing key is treated as `nonoptional` and rejected before the inner default ever applies. Moving `.default(...)` outside makes the outer wrapper carry the default, which is the v4-compatible idiom.

## Related Issues

None filed upstream — discovered while running `node dist/cli.js` in a clean shell.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🧪 Test addition/update

## Testing

- [ ] Tested with Unreal Engine (version: N/A — TypeScript config-loading change, no engine surface touched)
- [ ] Tested MCP client integration (client: N/A — same reason)
- [x] Added/updated tests

### Repro (before fix)

```
$ node dist/cli.js
[Config] ❌ Invalid configuration: { MCP_ROUTE_STDOUT_LOGS: { _errors: [ 'Invalid input: expected nonoptional, received undefined' ] }, ... }
[CLI] Failed to start server: ZodError
```

### Verification (after fix)

| Scenario | Result |
|---|---|
| Empty env (no vars set) | All 5 fields use documented defaults: `ROUTE_STDOUT_LOGS=true`, `PORT=8091`, `CLIENT_MODE=false`, `CONNECTION=5000ms`, `REQUEST=30000ms` |
| All 5 vars set | User values respected exactly |
| Partial (only PORT + REQUEST_TIMEOUT) | Set values respected; the other 3 fall back to defaults |

### Test suite impact

| | Before fix | After fix |
|---|---|---|
| Test files | 19 (9 failed \| 10 passed) | 20 (20 passed) |
| Tests | 112 passed | 218 passed |

The 9 previously-failing test files were not flaky — their imports transitively loaded `src/config.ts`, which threw at module-load time because both the primary `parse(process.env)` and the `parse({})` fallback hit the same v4 validation. Once the schema is fixed, all 9 files load and their existing tests register normally.

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Updated relevant documentation (if needed) — no doc updates required; defaults match `EnvSchema` source-of-truth
- [x] Added/updated tests (if applicable)
- [x] CI passes locally — `npm run type-check`, `npm run lint`, `npx vitest run` all clean
