### PR TITLE
fix(asset_query): default recursivePaths=true for classNames-only search

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_AssetQueryHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_AssetQueryHandlers.cpp
@@ -446,8 +446,9 @@ bool UMcpAutomationBridgeSubsystem::HandleAssetQueryAction(
         FString SearchText;
         Payload->TryGetStringField(TEXT("searchText"), SearchText);
 
-        // Parse recursion (default to false for safety, but true when searchText is provided)
-        bool bRecursivePaths = !SearchText.IsEmpty(); // default true for text search
+        // Parse recursion: default to true so that classNames-only / path-only searches
+        // traverse the full content tree. Callers can opt out with recursivePaths=false.
+        bool bRecursivePaths = true;
         if (Payload->HasField(TEXT("recursivePaths")))
         {
             Payload->TryGetBoolField(TEXT("recursivePaths"), bRecursivePaths);


### PR DESCRIPTION
## Summary

`manage_asset(action: "search_assets", classNames: [...])` returns 0 results in typical UE projects when no `searchText` or explicit `recursivePaths` is provided. Root cause: `bRecursivePaths` defaults to `!SearchText.IsEmpty()`, so classNames-only / path-only calls run a non-recursive search on the default `/Game` path — which usually has no top-level assets.

## Changes

- `McpAutomationBridge_AssetQueryHandlers.cpp` (`HandleAssetQueryAction`, `search_assets` subAction): change `bRecursivePaths` default from `!SearchText.IsEmpty()` to `true`. The explicit `recursivePaths=false` override branch is unchanged, so callers that want top-level-only behavior can still opt out.

## Related Issues

None directly. Discovered while comparing direct WebSocket calls (which set `recursivePaths: true` explicitly) against MCP wrapper calls (which do not set it for `classNames`-only queries) — this confirmed the divergence was a default-value bug, not a wrapper transformation issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Tested with Unreal Engine (version: 5.7)
- [x] Tested MCP client integration (client: Claude Code)

Verified in UE 5.7 editor against a project containing 4 DataTables nested under sub-directories:

| Call | Before | After |
|---|---|---|
| `search_assets(classNames: ["DataTable"])` | 0 | 4 |
| `search_assets(classNames: ["/Script/Engine.DataTable"])` | 0 | 4 |
| `search_assets(searchText: "DT")` | 4 | 4 (no regression) |
| `search_assets(packagePaths: [...], recursivePaths: false)` | top-level only | top-level only (opt-out preserved) |

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Updated relevant documentation (if needed) — N/A
- [ ] Added/updated tests (if applicable) — manual editor verification only
- [ ] CI passes — pending after push

🤖 Generated with [Claude Code](https://claude.com/claude-code)