### PR TITLE
fix(scripts): correct path handling and PowerShell escaping in package-plugin.bat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`scripts/package-plugin.bat` path resolution** — `shift` mutates `%0`, so `%~dp0` was returning the wrong directory when the script was called from the repo root. Fixed by capturing `SCRIPT_DIR`/`REPO_ROOT` via `pushd`/`popd` before any `shift`. Also normalizes the second argument (output dir) to an absolute path so relative paths like `.\output` work correctly, and fixes the UE version extraction PowerShell command which had a `$(...)` escaping issue with cmd.exe.
 - **Game Feature Plugin path validation** – `SanitizeProjectRelativePath` now uses `FPackageName::IsValidLongPackageName` instead of a manual `/Content/` heuristic, correctly recognizing all registered engine mount points (game feature plugins like `/MyGameFeature/`, `/ShooterCore/`, `/ALS/`, etc.).
 - **`manage_level: get_level_info` no longer requires the level to be loaded** – previously returned `LEVEL_NOT_FOUND` for any map asset path that hadn't already been `load_level`'d. Now falls back to `IAssetRegistry::GetAssetByObjectPath` and returns `objectPath`, `assetName`, `packageName`, `assetClass`, and the asset's `tagsAndValues` map alongside `loaded: false`. The loaded case is unchanged but now also includes `loaded: true`. Does not auto-load the level.
 

--- a/scripts/package-plugin.bat
+++ b/scripts/package-plugin.bat
@@ -10,6 +10,13 @@ REM   scripts\package-plugin.bat C:\UE\UE_5.6 C:\output
 REM   scripts\package-plugin.bat C:\UE\UE_5.6 C:\output -NoDefaultPlugins
 REM
 
+REM ─── Resolve script/repo paths BEFORE any shift (shift mutates %0) ─────────
+
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%.." >nul
+set "REPO_ROOT=%CD%"
+popd >nul
+
 REM ─── Arguments ─────────────────────────────────────────────────────────────
 
 set "ENGINE_DIR=%~1"
@@ -35,10 +42,8 @@ shift
 goto parse_args
 :done_args
 
-if "!OUTPUT_DIR!"=="" set "OUTPUT_DIR=%cd%\build"
-
-set "SCRIPT_DIR=%~dp0"
-set "REPO_ROOT=%SCRIPT_DIR%.."
+if "!OUTPUT_DIR!"=="" set "OUTPUT_DIR=%REPO_ROOT%\build"
+for %%I in ("!OUTPUT_DIR!") do set "OUTPUT_DIR=%%~fI"
 set "PLUGIN_FILE=%REPO_ROOT%\plugins\McpAutomationBridge\McpAutomationBridge.uplugin"
 
 if not exist "%PLUGIN_FILE%" (
@@ -58,7 +63,7 @@ REM ─── Extract version info ───────────────
 set "UE_VER=unknown"
 set "UE_VERSION_FILE=%ENGINE_DIR%\Engine\Build\Build.version"
 if exist "%UE_VERSION_FILE%" (
-    for /f "delims=" %%V in ('powershell -NoProfile -Command "$v = Get-Content '%UE_VERSION_FILE%' | ConvertFrom-Json; Write-Output \"$($v.MajorVersion).$($v.MinorVersion)\""') do set "UE_VER=%%V"
+    for /f "delims=" %%V in ('powershell -NoProfile -Command "$v = Get-Content '%UE_VERSION_FILE%' | ConvertFrom-Json; $maj=$v.MajorVersion; $min=$v.MinorVersion; Write-Output \"$maj.$min\""') do set "UE_VER=%%V"
 )
 
 set "PLUGIN_VER=0.0.0"

--- a/scripts/package-plugin.bat
+++ b/scripts/package-plugin.bat
@@ -63,11 +63,11 @@ REM ─── Extract version info ───────────────
 set "UE_VER=unknown"
 set "UE_VERSION_FILE=%ENGINE_DIR%\Engine\Build\Build.version"
 if exist "%UE_VERSION_FILE%" (
-    for /f "delims=" %%V in ('powershell -NoProfile -Command "$v = Get-Content '%UE_VERSION_FILE%' | ConvertFrom-Json; $maj=$v.MajorVersion; $min=$v.MinorVersion; Write-Output \"$maj.$min\""') do set "UE_VER=%%V"
+    for /f "delims=" %%V in ('powershell -NoProfile -Command "$v = Get-Content -LiteralPath $env:UE_VERSION_FILE | ConvertFrom-Json; $maj=$v.MajorVersion; $min=$v.MinorVersion; Write-Output \"$maj.$min\""') do set "UE_VER=%%V"
 )
 
 set "PLUGIN_VER=0.0.0"
-for /f "delims=" %%V in ('powershell -NoProfile -Command "$d = Get-Content '%PLUGIN_FILE%' | ConvertFrom-Json; Write-Output $d.VersionName"') do set "PLUGIN_VER=%%V"
+for /f "delims=" %%V in ('powershell -NoProfile -Command "$d = Get-Content -LiteralPath $env:PLUGIN_FILE | ConvertFrom-Json; Write-Output $d.VersionName"') do set "PLUGIN_VER=%%V"
 
 set "PACKAGE_DIR=%OUTPUT_DIR%\McpAutomationBridge"
 set "ZIP_NAME=McpAutomationBridge-v%PLUGIN_VER%-UE%UE_VER%-Win64.zip"
@@ -100,7 +100,7 @@ REM ─── Post-process: set Installed=true ───────────
 set "OUTPUT_UPLUGIN=%PACKAGE_DIR%\McpAutomationBridge.uplugin"
 if exist "%OUTPUT_UPLUGIN%" (
     echo Setting Installed=true in output .uplugin...
-    powershell -NoProfile -Command "try { $ErrorActionPreference='Stop'; $f='%OUTPUT_UPLUGIN%'; $d=Get-Content $f | ConvertFrom-Json; $d | Add-Member -Force -NotePropertyName Installed -NotePropertyValue $true; $d | ConvertTo-Json -Depth 10 | Set-Content $f } catch { Write-Error $_; exit 1 }"
+    powershell -NoProfile -Command "try { $ErrorActionPreference='Stop'; $f=$env:OUTPUT_UPLUGIN; $d=Get-Content -LiteralPath $f | ConvertFrom-Json; $d | Add-Member -Force -NotePropertyName Installed -NotePropertyValue $true; $d | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $f } catch { Write-Error $_; exit 1 }"
     if errorlevel 1 (
         echo ERROR: Failed to set Installed=true in .uplugin
         exit /b 1
@@ -112,7 +112,7 @@ REM ─── Zip ────────────────────�
 echo Creating archive: %ZIP_NAME%
 cd /d "%OUTPUT_DIR%"
 if exist "%ZIP_NAME%" del "%ZIP_NAME%"
-powershell -NoProfile -Command "try { $ErrorActionPreference='Stop'; Get-ChildItem -Path 'McpAutomationBridge' -Recurse | Where-Object { $_.Extension -ne '.pdb' -and $_.FullName -notmatch '\\Intermediate\\' } | Compress-Archive -DestinationPath '%ZIP_NAME%' -Force } catch { Write-Error $_; exit 1 }"
+powershell -NoProfile -Command "try { $ErrorActionPreference='Stop'; Get-ChildItem -LiteralPath 'McpAutomationBridge' -Recurse | Where-Object { $_.Extension -ne '.pdb' -and $_.FullName -notmatch '\\Intermediate\\' } | Compress-Archive -DestinationPath $env:ZIP_NAME -Force } catch { Write-Error $_; exit 1 }"
 if errorlevel 1 (
     echo ERROR: Failed to create zip archive.
     exit /b 1


### PR DESCRIPTION
## Summary

Fixed these issues on `package-plugin.bat`

- `scripts/package-plugin.bat` did not work when invoked from the repo root as documented in the `README.md` (`scripts\package-plugin.bat <UE_PATH>`). It only worked when the current working directory was `./scripts`.
- The second argument (output directory), especially relative paths, was also not honored.
- The script failed with an error saying `.$($v.MinorVersion was unexpected at this time.`

## Changes

- Move `SCRIPT_DIR` / `REPO_ROOT` capture **before** any `shift`. `shift` rotates `%0` as well as `%1`, `%2`, … (`%1` → `%0`, `%2` → `%1`, …), so referencing `%~dp0` after argument parsing returned the directory of a shifted positional argument instead of the script's own directory.
- Compute `REPO_ROOT` by `pushd`-ing into `%SCRIPT_DIR%..` so that the OS resolves the trailing `..`, then capture the resulting `%CD%` and `popd` back. This avoids leaving an unnormalized `scripts\..` segment in the path that some downstream tools mishandle.
- Normalize `OUTPUT_DIR` to an absolute path via `for %%I in ("!OUTPUT_DIR!") do set "OUTPUT_DIR=%%~fI"`, so relative arguments such as `.\output` are passed correctly to `RunUAT`.
- Replace the UE version extraction PowerShell command from `$($v.MajorVersion).$($v.MinorVersion)` to `$maj=$v.MajorVersion; $min=$v.MinorVersion; Write-Output "$maj.$min"`. The former failed in cmd.exe due to broken escaping of `(`.
- Add a one-line entry under `[Unreleased] / Fixed` in `CHANGELOG.md`.

### Verified on a real environment (UE 5.7)

```
PS D:\github\Unreal_mcp> scripts\package-plugin.bat "D:\Program Files\Epic Games\UE_5.7" .\output
============================================
  Package McpAutomationBridge Plugin
============================================
  Plugin version : 0.1.4
  UE version     : 5.7
  Platform       : Win64
  Engine         : D:\Program Files\Epic Games\UE_5.7
  Output         : D:\github\Unreal_mcp\output\McpAutomationBridge-v0.1.4-UE5.7-Win64.zip
============================================
Building plugin...
Running AutomationTool...
...
Parsing command line: BuildPlugin -Plugin=D:\github\Unreal_mcp\plugins\McpAutomationBridge\McpAutomationBridge.uplugin -Package=D:\github\Unreal_mcp\output\McpAutomationBridge -TargetPlatforms=Win64 -Rocket
```

Before this fix, the same command failed with `ERROR: Plugin file not found: D:\github\plugins\McpAutomationBridge\McpAutomationBridge.uplugin` because `REPO_ROOT` was incorrectly resolved to `D:\github`.

## Related Issues

No related issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration/build change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test addition/update

## Testing

- [x] Tested with Unreal Engine (version: **5.7**)
- [ ] Tested MCP client integration (client: ___)
- [ ] Added/updated tests

Verified the following three invocation patterns on a real machine:

1. `scripts\package-plugin.bat "D:\Program Files\Epic Games\UE_5.7"` — default output (`<repo>\build`)
2. `scripts\package-plugin.bat "D:\Program Files\Epic Games\UE_5.7" D:\tmp\plugin-out` — absolute output path
3. `scripts\package-plugin.bat "D:\Program Files\Epic Games\UE_5.7" .\output` — relative output path (closest to the form shown in the README)

In every case the script no longer fails with `Plugin file not found`, and RunUAT starts the build with the correct paths.

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Updated relevant documentation (if needed) — no README update needed; the documented command now works as intended for the first time thanks to this fix
- [x] Added/updated tests (if applicable) — skipped (Windows batch script)
- [x] CI passes
