### PR TITLE
fix(save): handle prompt save return codes

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_TextureHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_TextureHandlers.cpp
@@ -283,7 +283,10 @@ static bool SaveTextureAsset(UTexture2D* Texture)
     // verify persistence on disk instead of falling back to UEditorAssetLibrary.
     TArray<UPackage*> PackagesToSave;
     PackagesToSave.Add(Package);
-    const bool bPromptSaveSucceeded = FEditorFileUtils::PromptForCheckoutAndSave(PackagesToSave, false, false);
+    const FEditorFileUtils::EPromptReturnCode PromptSaveResult =
+        FEditorFileUtils::PromptForCheckoutAndSave(PackagesToSave, false, false);
+    const bool bPromptSaveSucceeded =
+        PromptSaveResult == FEditorFileUtils::PR_Success;
     FString PackageFilename;
     const bool bHasFilename = FPackageName::TryConvertLongPackageNameToFilename(
         Package->GetName(), PackageFilename, FPackageName::GetAssetPackageExtension());

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpSafeOperations.h
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpSafeOperations.h
@@ -218,7 +218,10 @@ inline bool McpSafeAssetSave(UObject* Asset)
 
     TArray<UPackage*> PackagesToSave;
     PackagesToSave.Add(Package);
-    const bool bPromptSaveSucceeded = FEditorFileUtils::PromptForCheckoutAndSave(PackagesToSave, false, false);
+    const FEditorFileUtils::EPromptReturnCode PromptSaveResult =
+        FEditorFileUtils::PromptForCheckoutAndSave(PackagesToSave, false, false);
+    const bool bPromptSaveSucceeded =
+        PromptSaveResult == FEditorFileUtils::PR_Success;
     const bool bExistsOnDisk = PackageExistsOnDisk();
 
     if (bPromptSaveSucceeded || bExistsOnDisk)


### PR DESCRIPTION
## Summary

Fixes the McpAutomationBridge save paths failing to compile with UE 5.7/MSVC when `FEditorFileUtils::PromptForCheckoutAndSave` returns `EPromptReturnCode`. The affected save helpers now treat only `PR_Success` as a successful prompt-save result while preserving the existing on-disk fallback behavior.

## Changes

- Store `PromptForCheckoutAndSave` results as `FEditorFileUtils::EPromptReturnCode` instead of `bool`.
- Compare prompt-save results explicitly with `FEditorFileUtils::PR_Success` in `McpSafeAssetSave`.
- Apply the same explicit return-code handling to texture asset save logic.

## Related Issues

None.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration/build change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test addition/update

## Testing

- [x] Tested with Unreal Engine (version: 5.7)
- [ ] Tested MCP client integration (client: not run; this is a compile-time return-type fix and no editor runtime behavior was changed)
- [ ] Added/updated tests

Validation performed:

- Ran `E:\games\UE_5.7\Engine\Binaries\DotNET\UnrealBuildTool\UnrealBuildTool.exe test_thirdEditor Win64 Development -Project=D:\me\code\ue\test_third\test_third.uproject -WaitMutex -NoHotReloadFromIDE`.
- Result: succeeded.
- Runtime MCP verification was not run because the fix only resolves compile-time enum-to-bool conversion errors and preserves existing save success semantics.

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Updated relevant documentation (if needed)
- [ ] Added/updated tests (if applicable)
- [ ] CI passes
