### PR TITLE
fix: harden MCP tool parity and live workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A comprehensive Model Context Protocol (MCP) server that enables AI assistants t
 | **Asset Management** | Browse, import, duplicate, rename, delete assets; create materials |
 | **Actor Control** | Spawn, delete, transform, physics, tags, components |
 | **Editor Control** | PIE sessions, camera, viewport, screenshots, bookmarks |
-| **Level Management** | Load/save levels, streaming, World Partition, data layers |
+| **Level Management** | Load/save levels, streaming, lighting |
 | **Animation & Physics** | Animation BPs, state machines, ragdolls, vehicles, constraints |
 | **Visual Effects** | Niagara particles, GPU simulations, procedural effects, debug shapes |
 | **Sequencer** | Cinematics, timeline control, camera animations, keyframes |
@@ -346,7 +346,7 @@ MCP_AUTOMATION_HOST=0.0.0.0
 | `manage_blueprint` | Blueprints, SCS components, graph editing, UMG widgets, layout, bindings, animations |
 | `control_actor` | Spawn, delete, transform, physics, tags |
 | `control_editor` | PIE, Camera, viewport, screenshots |
-| `manage_level` | Load/Save, World Partition, streaming |
+| `manage_level` | Load/save, streaming, lighting |
 | `system_control` | UBT, Tests, Logs, Project Settings, CVars, Python Execution |
 | `inspect` | Object Introspection |
 | `manage_tools` | Dynamic tool management (enable/disable at runtime) |

--- a/docs/handler-mapping.md
+++ b/docs/handler-mapping.md
@@ -101,13 +101,30 @@ This document maps the TypeScript tool definitions to their corresponding C++ ha
 
 | Action | C++ Handler File | C++ Function | Notes |
 | :--- | :--- | :--- | :--- |
-| `load` | `McpAutomationBridge_EditorFunctionHandlers.cpp` | `HandleLevelAction` | |
-| `save` | `McpAutomationBridge_EditorFunctionHandlers.cpp` | `HandleLevelAction` | |
-| `create_level` | `McpAutomationBridge_EditorFunctionHandlers.cpp` | `HandleLevelAction` | |
+| `load` | `McpAutomationBridge_LevelHandlers.cpp` | `HandleLevelAction` | Alias for `load_level` |
+| `load_level` | `McpAutomationBridge_LevelHandlers.cpp` | `HandleLevelAction` | Opens a map package |
+| `save` | `McpAutomationBridge_LevelHandlers.cpp` | `HandleLevelAction` | Alias for `save_level` |
+| `save_level` | `McpAutomationBridge_LevelHandlers.cpp` | `HandleLevelAction` | Saves the current level |
+| `save_as` | `McpAutomationBridge_LevelHandlers.cpp` | `HandleLevelAction` | Alias for `save_level_as` |
+| `save_level_as` | `McpAutomationBridge_LevelHandlers.cpp` | `HandleLevelAction` | Saves current level to a new path |
+| `stream` | `McpAutomationBridge_LevelHandlers.cpp` | `HandleLevelAction` | Loads/updates a streaming level |
+| `unload` | `McpAutomationBridge_LevelHandlers.cpp` | `HandleLevelAction` | Alias for `unload_level` |
+| `unload_level` | `McpAutomationBridge_LevelHandlers.cpp` | `HandleLevelAction` | Forces streaming unload |
+| `create_level` | `McpAutomationBridge_LevelHandlers.cpp` | `HandleLevelAction` | Creates and opens a new level |
+| `create_light` | `McpAutomationBridge_LevelHandlers.cpp` | `HandleLevelAction` | Spawns a level light |
+| `build_lighting` | `McpAutomationBridge_LevelHandlers.cpp` | `HandleLevelAction` | Starts editor lighting build |
+| `set_metadata` | `McpAutomationBridge_LevelHandlers.cpp` | `HandleLevelAction` | Delegates to asset metadata handling |
 | `export_level` | `McpAutomationBridge_LevelHandlers.cpp` | `HandleLevelAction` | |
 | `import_level` | `McpAutomationBridge_LevelHandlers.cpp` | `HandleLevelAction` | |
-| `load_cells` | `McpAutomationBridge_WorldPartitionHandlers.cpp` | `HandleWorldPartitionAction` | |
-| `set_datalayer` | `McpAutomationBridge_WorldPartitionHandlers.cpp` | `HandleWorldPartitionAction` | |
+| `list_levels` | `McpAutomationBridge_LevelHandlers.cpp` | `HandleLevelAction` | Lists current world levels and map assets |
+| `get_summary` | `McpAutomationBridge_LevelHandlers.cpp` | `HandleLevelAction` | Maps to level info summary |
+| `delete` | `McpAutomationBridge_LevelHandlers.cpp` | `HandleLevelAction` | Alias for `delete_level` |
+| `delete_level` | `McpAutomationBridge_LevelHandlers.cpp` | `HandleLevelAction` | Deletes map file, built data, and external sidecars |
+| `validate_level` | `McpAutomationBridge_LevelHandlers.cpp` | `HandleLevelAction` | Checks package/file existence |
+| `add_sublevel` | `McpAutomationBridge_LevelHandlers.cpp` | `HandleLevelAction` | Adds a streaming sublevel |
+| `rename_level` | `McpAutomationBridge_LevelHandlers.cpp` | `HandleLevelAction` | Copies destination then deletes source and sidecars |
+| `duplicate_level` | `McpAutomationBridge_LevelHandlers.cpp` | `HandleLevelAction` | Copies map, built data, and external sidecars |
+| `get_current_level` | `McpAutomationBridge_LevelHandlers.cpp` | `HandleLevelAction` | Returns current editor level identity |
 
 ## Lighting Manager (`build_environment`)
 

--- a/docs/native-automation-progress.md
+++ b/docs/native-automation-progress.md
@@ -40,7 +40,7 @@ This document tracks ongoing work to replace stubbed or registry-based fallbacks
 
 | Action | Current State | Needed Work |
 | --- | --- | --- |
-| `manage_level` (world partition) | Implemented (`load_cells`, `set_datalayer`). | ✅ Done (UE 5.7+ support added) |
+| `manage_level_structure` / world partition handlers | Implemented (`enable_world_partition`, data-layer/world-partition support). | ✅ Done (UE 5.7+ support added) |
 
 ## Input System
 

--- a/plugins/McpAutomationBridge/README.md
+++ b/plugins/McpAutomationBridge/README.md
@@ -15,7 +15,7 @@ An Unreal Engine editor plugin that enables AI assistants (Claude, Cursor, Winds
 | **Asset Management** | Browse, import, duplicate, rename, delete assets; create materials |
 | **Actor Control** | Spawn, delete, transform, physics, tags, components |
 | **Editor Control** | PIE sessions, camera, viewport, screenshots, bookmarks |
-| **Level Management** | Load/save levels, streaming, World Partition, data layers |
+| **Level Management** | Load/save levels, streaming, lighting |
 | **Animation & Physics** | Animation BPs, state machines, ragdolls, vehicles, constraints |
 | **Visual Effects** | Niagara particles, GPU simulations, procedural effects |
 | **Sequencer** | Cinematics, timeline control, camera animations |

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/McpNativeTransport.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/McpNativeTransport.cpp
@@ -444,6 +444,32 @@ void FMcpNativeTransport::HandleConnection(FSocket* ClientSocket)
 		return;
 	}
 
+	// Browser access to the native MCP endpoint is only allowed when capability
+	// tokens are enabled; non-browser local clients do not require CORS.
+	if (HttpReq.Method == TEXT("OPTIONS"))
+	{
+		if (IsAllowedCorsOrigin(HttpReq.Origin))
+		{
+			SendHttpResponse(ClientSocket, 204, TEXT("text/plain"), FString(), {}, HttpReq.Origin);
+		}
+		else
+		{
+			SendHttpResponse(ClientSocket, 403, TEXT("text/plain"),
+				TEXT("CORS preflight requires capability-token protection"));
+		}
+		ClientSocket->Close();
+		SocketSub->DestroySocket(ClientSocket);
+		return;
+	}
+
+	if (!HttpReq.Origin.IsEmpty() && !IsAllowedCorsOrigin(HttpReq.Origin))
+	{
+		SendHttpResponse(ClientSocket, 403, TEXT("text/plain"), TEXT("Invalid Origin"));
+		ClientSocket->Close();
+		SocketSub->DestroySocket(ClientSocket);
+		return;
+	}
+
 	// Capability token validation (mirrors McpConnectionManager logic)
 	{
 		const UMcpAutomationBridgeSettings* Settings = GetDefault<UMcpAutomationBridgeSettings>();
@@ -455,7 +481,7 @@ void FMcpNativeTransport::HandleConnection(FSocket* ClientSocket)
 				FString ErrorBody = FMcpJsonRpc::BuildError(
 					MakeShared<FJsonValueNull>(), FMcpJsonRpc::ErrorInvalidRequest,
 					TEXT("Invalid capability token"));
-				SendHttpResponse(ClientSocket, 401, TEXT("application/json"), ErrorBody);
+				SendHttpResponse(ClientSocket, 401, TEXT("application/json"), ErrorBody, {}, HttpReq.Origin);
 				ClientSocket->Close();
 				SocketSub->DestroySocket(ClientSocket);
 				return;
@@ -466,6 +492,17 @@ void FMcpNativeTransport::HandleConnection(FSocket* ClientSocket)
 	// ── DELETE /mcp — session termination ──
 	if (HttpReq.Method == TEXT("DELETE"))
 	{
+		FString SessionError;
+		ESessionValidationResult SessionStatus = ValidateSession(HttpReq.SessionId, SessionError);
+		if (SessionStatus != ESessionValidationResult::Valid)
+		{
+			SendHttpResponse(ClientSocket, GetSessionValidationStatusCode(SessionStatus),
+				TEXT("text/plain"), SessionError, {}, HttpReq.Origin);
+			ClientSocket->Close();
+			SocketSub->DestroySocket(ClientSocket);
+			return;
+		}
+
 		if (!HttpReq.SessionId.IsEmpty())
 		{
 			{
@@ -502,7 +539,7 @@ void FMcpNativeTransport::HandleConnection(FSocket* ClientSocket)
 					TEXT("Closed notification stream %s (session terminated)"), *StreamId);
 			}
 		}
-		SendHttpResponse(ClientSocket, 200, TEXT("text/plain"), FString());
+		SendHttpResponse(ClientSocket, 200, TEXT("text/plain"), FString(), {}, HttpReq.Origin);
 		ClientSocket->Close();
 		SocketSub->DestroySocket(ClientSocket);
 		return;
@@ -514,27 +551,29 @@ void FMcpNativeTransport::HandleConnection(FSocket* ClientSocket)
 		if (!HttpReq.Accept.Contains(TEXT("text/event-stream")))
 		{
 			SendHttpResponse(ClientSocket, 406, TEXT("text/plain"),
-				TEXT("Not Acceptable: requires Accept: text/event-stream"));
+				TEXT("Not Acceptable: requires Accept: text/event-stream"), {}, HttpReq.Origin);
 			ClientSocket->Close();
 			SocketSub->DestroySocket(ClientSocket);
 			return;
 		}
 		FString SessionError;
-		if (!ValidateSession(HttpReq.SessionId, SessionError))
+		ESessionValidationResult SessionStatus = ValidateSession(HttpReq.SessionId, SessionError);
+		if (SessionStatus != ESessionValidationResult::Valid)
 		{
-			SendHttpResponse(ClientSocket, 400, TEXT("text/plain"), SessionError);
+			SendHttpResponse(ClientSocket, GetSessionValidationStatusCode(SessionStatus),
+				TEXT("text/plain"), SessionError, {}, HttpReq.Origin);
 			ClientSocket->Close();
 			SocketSub->DestroySocket(ClientSocket);
 			return;
 		}
-		HandleGetMcp(ClientSocket, HttpReq.SessionId);
+		HandleGetMcp(ClientSocket, HttpReq.SessionId, HttpReq.Origin);
 		return;  // Socket parked — no close here
 	}
 
 	// ── POST /mcp — JSON-RPC ──
 	if (HttpReq.Method != TEXT("POST"))
 	{
-		SendHttpResponse(ClientSocket, 405, TEXT("text/plain"), TEXT("Method Not Allowed"));
+		SendHttpResponse(ClientSocket, 405, TEXT("text/plain"), TEXT("Method Not Allowed"), {}, HttpReq.Origin);
 		ClientSocket->Close();
 		SocketSub->DestroySocket(ClientSocket);
 		return;
@@ -553,18 +592,18 @@ void FMcpNativeTransport::HandleConnection(FSocket* ClientSocket)
 		FString ErrorBody = FMcpJsonRpc::BuildError(ErrorId, ErrorCode,
 			(Rpc.ErrorType == EMcpJsonRpcError::ParseError)
 				? TEXT("Parse error") : TEXT("Invalid Request"));
-		SendHttpResponse(ClientSocket, 400, TEXT("application/json"), ErrorBody);
+		SendHttpResponse(ClientSocket, 400, TEXT("application/json"), ErrorBody, {}, HttpReq.Origin);
 		ClientSocket->Close();
 		SocketSub->DestroySocket(ClientSocket);
 		return;
 	}
 
-	// Notifications (no id) — 202 Accepted
-	if (Rpc.bIsNotification)
+	if (Rpc.bIsNotification && Rpc.Method == TEXT("initialize"))
 	{
-		UE_LOG(LogMcpNativeTransport, Log,
-			TEXT("Received notification: %s"), *Rpc.Method);
-		SendHttpResponse(ClientSocket, 202, TEXT("text/plain"), FString());
+		FString ErrorBody = FMcpJsonRpc::BuildError(
+			MakeShared<FJsonValueNull>(), FMcpJsonRpc::ErrorInvalidRequest,
+			TEXT("initialize must include an id"));
+		SendHttpResponse(ClientSocket, 400, TEXT("application/json"), ErrorBody, {}, HttpReq.Origin);
 		ClientSocket->Close();
 		SocketSub->DestroySocket(ClientSocket);
 		return;
@@ -574,15 +613,28 @@ void FMcpNativeTransport::HandleConnection(FSocket* ClientSocket)
 	if (Rpc.Method != TEXT("initialize"))
 	{
 		FString SessionError;
-		if (!ValidateSession(HttpReq.SessionId, SessionError))
+		ESessionValidationResult SessionStatus = ValidateSession(HttpReq.SessionId, SessionError);
+		if (SessionStatus != ESessionValidationResult::Valid)
 		{
 			FString ErrorBody = FMcpJsonRpc::BuildError(
 				Rpc.Id, FMcpJsonRpc::ErrorInvalidRequest, SessionError);
-			SendHttpResponse(ClientSocket, 400, TEXT("application/json"), ErrorBody);
+			SendHttpResponse(ClientSocket, GetSessionValidationStatusCode(SessionStatus),
+				TEXT("application/json"), ErrorBody, {}, HttpReq.Origin);
 			ClientSocket->Close();
 			SocketSub->DestroySocket(ClientSocket);
 			return;
 		}
+	}
+
+	// Notifications (no id) — 202 Accepted after session validation.
+	if (Rpc.bIsNotification)
+	{
+		UE_LOG(LogMcpNativeTransport, Log,
+			TEXT("Received notification: %s"), *Rpc.Method);
+		SendHttpResponse(ClientSocket, 202, TEXT("text/plain"), FString(), {}, HttpReq.Origin);
+		ClientSocket->Close();
+		SocketSub->DestroySocket(ClientSocket);
+		return;
 	}
 
 	// ── Method dispatch ──
@@ -593,7 +645,7 @@ void FMcpNativeTransport::HandleConnection(FSocket* ClientSocket)
 		FString ResponseBody = HandleInitialize(Rpc.Params, Rpc.Id, NewSessionId);
 		TMap<FString, FString> Headers;
 		Headers.Add(TEXT("Mcp-Session-Id"), NewSessionId);
-		SendHttpResponse(ClientSocket, 200, TEXT("application/json"), ResponseBody, Headers);
+		SendHttpResponse(ClientSocket, 200, TEXT("application/json"), ResponseBody, Headers, HttpReq.Origin);
 		ClientSocket->Close();
 		SocketSub->DestroySocket(ClientSocket);
 		return;
@@ -602,7 +654,7 @@ void FMcpNativeTransport::HandleConnection(FSocket* ClientSocket)
 	if (Rpc.Method == TEXT("tools/list"))
 	{
 		FString ResponseBody = HandleToolsList(Rpc.Id);
-		SendHttpResponse(ClientSocket, 200, TEXT("application/json"), ResponseBody);
+		SendHttpResponse(ClientSocket, 200, TEXT("application/json"), ResponseBody, {}, HttpReq.Origin);
 		ClientSocket->Close();
 		SocketSub->DestroySocket(ClientSocket);
 		return;
@@ -611,7 +663,7 @@ void FMcpNativeTransport::HandleConnection(FSocket* ClientSocket)
 	if (Rpc.Method == TEXT("tools/call"))
 	{
 		// HandleToolsCall takes ownership of the socket (SSE streaming)
-		HandleToolsCall(Rpc.Params, Rpc.Id, ClientSocket, HttpReq.SessionId);
+		HandleToolsCall(Rpc.Params, Rpc.Id, ClientSocket, HttpReq.SessionId, HttpReq.Origin);
 		return;  // Socket NOT closed here — parked for SSE
 	}
 
@@ -619,7 +671,7 @@ void FMcpNativeTransport::HandleConnection(FSocket* ClientSocket)
 	FString ErrorBody = FMcpJsonRpc::BuildError(
 		Rpc.Id, FMcpJsonRpc::ErrorMethodNotFound,
 		FString::Printf(TEXT("Unknown method: %s"), *Rpc.Method));
-	SendHttpResponse(ClientSocket, 400, TEXT("application/json"), ErrorBody);
+	SendHttpResponse(ClientSocket, 200, TEXT("application/json"), ErrorBody, {}, HttpReq.Origin);
 	ClientSocket->Close();
 	SocketSub->DestroySocket(ClientSocket);
 }
@@ -741,6 +793,10 @@ bool FMcpNativeTransport::ReadHttpRequest(FSocket* Socket, FParsedHttpRequest& O
 			{
 				OutRequest.CapabilityToken = Value;
 			}
+			else if (Key.Equals(TEXT("Origin"), ESearchCase::IgnoreCase))
+			{
+				OutRequest.Origin = Value;
+			}
 		}
 	}
 
@@ -803,14 +859,17 @@ bool FMcpNativeTransport::ReadHttpRequest(FSocket* Socket, FParsedHttpRequest& O
 
 bool FMcpNativeTransport::SendHttpResponse(FSocket* Socket, int32 StatusCode,
 	const FString& ContentType, const FString& Body,
-	const TMap<FString, FString>& ExtraHeaders)
+	const TMap<FString, FString>& ExtraHeaders,
+	const FString& CorsOrigin)
 {
 	FString StatusText;
 	switch (StatusCode)
 	{
 	case 200: StatusText = TEXT("OK"); break;
 	case 202: StatusText = TEXT("Accepted"); break;
+	case 204: StatusText = TEXT("No Content"); break;
 	case 400: StatusText = TEXT("Bad Request"); break;
+	case 403: StatusText = TEXT("Forbidden"); break;
 	case 404: StatusText = TEXT("Not Found"); break;
 	case 405: StatusText = TEXT("Method Not Allowed"); break;
 	case 401: StatusText = TEXT("Unauthorized"); break;
@@ -827,6 +886,7 @@ bool FMcpNativeTransport::SendHttpResponse(FSocket* Socket, int32 StatusCode,
 	FString Response = FString::Printf(
 		TEXT("HTTP/1.1 %d %s\r\nContent-Type: %s\r\nContent-Length: %d\r\nConnection: close\r\n"),
 		StatusCode, *StatusText, *ContentType, BodyLength);
+	AppendCorsHeaders(Response, CorsOrigin);
 
 	for (const auto& [Key, Value] : ExtraHeaders)
 	{
@@ -854,20 +914,149 @@ bool FMcpNativeTransport::SendHttpResponse(FSocket* Socket, int32 StatusCode,
 	return true;
 }
 
-bool FMcpNativeTransport::SendSSEHeaders(FSocket* Socket, const FString& SessionId)
+bool FMcpNativeTransport::SendSSEHeaders(FSocket* Socket, const FString& SessionId,
+	const FString& CorsOrigin)
 {
 	FString Headers = FString::Printf(
 		TEXT("HTTP/1.1 200 OK\r\n")
 		TEXT("Content-Type: text/event-stream\r\n")
 		TEXT("Cache-Control: no-cache\r\n")
 		TEXT("Connection: keep-alive\r\n")
-		TEXT("Mcp-Session-Id: %s\r\n")
-		TEXT("\r\n"),
+		TEXT("Mcp-Session-Id: %s\r\n"),
 		*SessionId);
+	AppendCorsHeaders(Headers, CorsOrigin);
+	Headers += TEXT("\r\n");
 
 	FTCHARToUTF8 Utf8(*Headers);
 	return SendAllBytes(Socket, reinterpret_cast<const uint8*>(Utf8.Get()),
 		Utf8.Length());
+}
+
+bool FMcpNativeTransport::IsCorsEnabled() const
+{
+	const UMcpAutomationBridgeSettings* Settings = GetDefault<UMcpAutomationBridgeSettings>();
+	return (ListenHost == TEXT("127.0.0.1") || ListenHost == TEXT("::1"))
+		&& Settings
+		&& Settings->bRequireCapabilityToken
+		&& !Settings->CapabilityToken.IsEmpty();
+}
+
+bool FMcpNativeTransport::IsAllowedCorsOrigin(const FString& Origin) const
+{
+	if (!IsCorsEnabled())
+	{
+		return false;
+	}
+
+	const FString TrimmedOrigin = Origin.TrimStartAndEnd();
+	if (TrimmedOrigin.IsEmpty() || TrimmedOrigin.Equals(TEXT("null"), ESearchCase::IgnoreCase) ||
+		TrimmedOrigin.Contains(TEXT("\r")) || TrimmedOrigin.Contains(TEXT("\n")))
+	{
+		return false;
+	}
+
+	FString Scheme;
+	FString Remainder;
+	if (!TrimmedOrigin.Split(TEXT("://"), &Scheme, &Remainder))
+	{
+		return false;
+	}
+	if (!Scheme.Equals(TEXT("http"), ESearchCase::IgnoreCase) &&
+		!Scheme.Equals(TEXT("https"), ESearchCase::IgnoreCase))
+	{
+		return false;
+	}
+	if (Remainder.IsEmpty() || Remainder.Contains(TEXT("/")))
+	{
+		return false;
+	}
+
+	auto IsDigitsOnly = [](const FString& Value) -> bool
+	{
+		if (Value.IsEmpty())
+		{
+			return false;
+		}
+		for (const TCHAR Character : Value)
+		{
+			if (Character < '0' || Character > '9')
+			{
+				return false;
+			}
+		}
+		return true;
+	};
+	auto IsValidPort = [&IsDigitsOnly](const FString& PortText) -> bool
+	{
+		if (!IsDigitsOnly(PortText))
+		{
+			return false;
+		}
+
+		int32 PortNumber = 0;
+		if (!LexTryParseString(PortNumber, *PortText))
+		{
+			return false;
+		}
+		return PortNumber > 0 && PortNumber <= 65535;
+	};
+
+	FString Host = Remainder;
+	if (Host.StartsWith(TEXT("[")))
+	{
+		int32 EndBracket = INDEX_NONE;
+		if (!Host.FindChar(TEXT(']'), EndBracket) || EndBracket <= 1)
+		{
+			return false;
+		}
+
+		const FString PortSuffix = Host.Mid(EndBracket + 1);
+		if (!PortSuffix.IsEmpty())
+		{
+			if (!PortSuffix.StartsWith(TEXT(":")) || !IsValidPort(PortSuffix.Mid(1)))
+			{
+				return false;
+			}
+		}
+
+		const FString BracketedHost = Host.Mid(1, EndBracket - 1);
+		if (BracketedHost != TEXT("::1"))
+		{
+			return false;
+		}
+		Host = BracketedHost;
+	}
+	else
+	{
+		FString HostOnly;
+		FString Port;
+		if (Host.Split(TEXT(":"), &HostOnly, &Port))
+		{
+			if (!IsValidPort(Port))
+			{
+				return false;
+			}
+			Host = HostOnly;
+		}
+	}
+
+	return Host.Equals(TEXT("localhost"), ESearchCase::IgnoreCase) ||
+		Host == TEXT("127.0.0.1") ||
+		Host == TEXT("::1");
+}
+
+void FMcpNativeTransport::AppendCorsHeaders(FString& Response, const FString& Origin) const
+{
+	if (!IsAllowedCorsOrigin(Origin))
+	{
+		return;
+	}
+
+	Response += FString::Printf(TEXT("Access-Control-Allow-Origin: %s\r\n"), *Origin.TrimStartAndEnd());
+	Response += TEXT("Vary: Origin\r\n");
+	Response += TEXT("Access-Control-Allow-Methods: GET, POST, DELETE, OPTIONS\r\n");
+	Response += TEXT("Access-Control-Allow-Headers: Content-Type, Accept, Mcp-Session-Id, MCP-Protocol-Version, X-MCP-Capability-Token\r\n");
+	Response += TEXT("Access-Control-Expose-Headers: Mcp-Session-Id, MCP-Protocol-Version\r\n");
 }
 
 bool FMcpNativeTransport::WriteSSEEvent(FSSEConnection& Conn, const FString& EventData)
@@ -888,7 +1077,8 @@ bool FMcpNativeTransport::WriteSSEEvent(FSSEConnection& Conn, const FString& Eve
 
 // ─── Persistent Notification Streams (GET /mcp) ────────────────────────────
 
-void FMcpNativeTransport::HandleGetMcp(FSocket* ClientSocket, const FString& SessionId)
+void FMcpNativeTransport::HandleGetMcp(FSocket* ClientSocket, const FString& SessionId,
+	const FString& CorsOrigin)
 {
 	ISocketSubsystem* SocketSub = ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM);
 
@@ -909,7 +1099,7 @@ void FMcpNativeTransport::HandleGetMcp(FSocket* ClientSocket, const FString& Ses
 			Lock.Unlock();
 			SendHttpResponse(ClientSocket, 429, TEXT("text/plain"),
 				FString::Printf(TEXT("Too Many Requests: max %d notification streams per session"),
-					MaxNotificationStreamsPerSession));
+					MaxNotificationStreamsPerSession), {}, CorsOrigin);
 			ClientSocket->Close();
 			SocketSub->DestroySocket(ClientSocket);
 			return;
@@ -917,7 +1107,7 @@ void FMcpNativeTransport::HandleGetMcp(FSocket* ClientSocket, const FString& Ses
 	}
 
 	// Send SSE headers
-	if (!SendSSEHeaders(ClientSocket, SessionId))
+	if (!SendSSEHeaders(ClientSocket, SessionId, CorsOrigin))
 	{
 		ClientSocket->Close();
 		SocketSub->DestroySocket(ClientSocket);
@@ -937,6 +1127,7 @@ void FMcpNativeTransport::HandleGetMcp(FSocket* ClientSocket, const FString& Ses
 		FScopeLock Lock(&NotificationStreamsMutex);
 		NotificationStreams.Add(Stream->StreamId, Stream);
 	}
+	TouchSession(SessionId);
 
 	UE_LOG(LogMcpNativeTransport, Log,
 		TEXT("GET /mcp: notification stream %s opened for session %s"),
@@ -1079,7 +1270,7 @@ int32 FMcpNativeTransport::GetTotalToolCount() const
 
 void FMcpNativeTransport::HandleToolsCall(
 	const TSharedPtr<FJsonObject>& Params, const TSharedPtr<FJsonValue>& Id,
-	FSocket* ClientSocket, const FString& SessionId)
+	FSocket* ClientSocket, const FString& SessionId, const FString& CorsOrigin)
 {
 	ISocketSubsystem* SocketSub = ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM);
 
@@ -1087,7 +1278,7 @@ void FMcpNativeTransport::HandleToolsCall(
 	{
 		FString ErrorBody = FMcpJsonRpc::BuildError(
 			Id, FMcpJsonRpc::ErrorInvalidParams, TEXT("Missing params"));
-		SendHttpResponse(ClientSocket, 200, TEXT("application/json"), ErrorBody);
+		SendHttpResponse(ClientSocket, 200, TEXT("application/json"), ErrorBody, {}, CorsOrigin);
 		ClientSocket->Close();
 		if (SocketSub) SocketSub->DestroySocket(ClientSocket);
 		return;
@@ -1098,7 +1289,7 @@ void FMcpNativeTransport::HandleToolsCall(
 	{
 		FString ErrorBody = FMcpJsonRpc::BuildError(
 			Id, FMcpJsonRpc::ErrorInvalidParams, TEXT("Missing tool name"));
-		SendHttpResponse(ClientSocket, 200, TEXT("application/json"), ErrorBody);
+		SendHttpResponse(ClientSocket, 200, TEXT("application/json"), ErrorBody, {}, CorsOrigin);
 		ClientSocket->Close();
 		if (SocketSub) SocketSub->DestroySocket(ClientSocket);
 		return;
@@ -1114,7 +1305,7 @@ void FMcpNativeTransport::HandleToolsCall(
 			FString ErrorBody = FMcpJsonRpc::BuildError(
 				Id, FMcpJsonRpc::ErrorInvalidParams,
 				TEXT("'arguments' must be an object if provided"));
-			SendHttpResponse(ClientSocket, 200, TEXT("application/json"), ErrorBody);
+			SendHttpResponse(ClientSocket, 200, TEXT("application/json"), ErrorBody, {}, CorsOrigin);
 			ClientSocket->Close();
 			if (SocketSub) SocketSub->DestroySocket(ClientSocket);
 			return;
@@ -1143,7 +1334,7 @@ void FMcpNativeTransport::HandleToolsCall(
 		TSharedPtr<FJsonObject> ToolResult = FMcpJsonRpc::BuildToolResult(
 			bActionSuccess, ActionMessage, Result);
 		FString Body = FMcpJsonRpc::BuildResponse(Id, ToolResult);
-		SendHttpResponse(ClientSocket, 200, TEXT("application/json"), Body);
+		SendHttpResponse(ClientSocket, 200, TEXT("application/json"), Body, {}, CorsOrigin);
 		ClientSocket->Close();
 		if (SocketSub) SocketSub->DestroySocket(ClientSocket);
 		return;
@@ -1157,14 +1348,14 @@ void FMcpNativeTransport::HandleToolsCall(
 			FString::Printf(TEXT("Tool '%s' is not enabled"), *ToolName),
 			nullptr, TEXT("TOOL_DISABLED"));
 		FString Body = FMcpJsonRpc::BuildResponse(Id, ToolResult);
-		SendHttpResponse(ClientSocket, 200, TEXT("application/json"), Body);
+		SendHttpResponse(ClientSocket, 200, TEXT("application/json"), Body, {}, CorsOrigin);
 		ClientSocket->Close();
 		if (SocketSub) SocketSub->DestroySocket(ClientSocket);
 		return;
 	}
 
 	// Send SSE headers — begins the streaming response
-	if (!SendSSEHeaders(ClientSocket, SessionId))
+	if (!SendSSEHeaders(ClientSocket, SessionId, CorsOrigin))
 	{
 		UE_LOG(LogMcpNativeTransport, Warning,
 			TEXT("Failed to send SSE headers for tool %s"), *ToolName);
@@ -1275,13 +1466,15 @@ bool FMcpNativeTransport::CompletePendingRequest(
 	// Offload blocking write + close to thread pool so GameThread is not blocked
 	FString CapturedRequestId = RequestId;
 	FString CapturedToolName = Conn->ToolName;
+	FString CapturedSessionId = Conn->SessionId;
 	bool bCapturedSuccess = bSuccess;
 	PendingAsyncWrites.fetch_add(1);
 
 	Async(EAsyncExecution::ThreadPool,
 		[this, Conn, ResponseBody = MoveTemp(ResponseBody),
-		 CapturedRequestId, CapturedToolName, bCapturedSuccess]()
+		 CapturedRequestId, CapturedToolName, CapturedSessionId, bCapturedSuccess]()
 	{
+		bool bWroteResponse = false;
 		{
 			FScopeLock WriteLock(&Conn->WriteMutex);
 			if (!Conn->Socket)
@@ -1294,7 +1487,7 @@ bool FMcpNativeTransport::CompletePendingRequest(
 			FString Frame = FString::Printf(
 				TEXT("event: message\ndata: %s\n\n"), *ResponseBody);
 			FTCHARToUTF8 Utf8(*Frame);
-			SendAllBytes(Conn->Socket,
+			bWroteResponse = SendAllBytes(Conn->Socket,
 				reinterpret_cast<const uint8*>(Utf8.Get()), Utf8.Length());
 
 			Conn->Socket->Close();
@@ -1304,6 +1497,10 @@ bool FMcpNativeTransport::CompletePendingRequest(
 				SocketSub->DestroySocket(Conn->Socket);
 			}
 			Conn->Socket = nullptr;
+		}
+		if (bWroteResponse)
+		{
+			TouchSession(CapturedSessionId);
 		}
 
 		UE_LOG(LogMcpNativeTransport, Log,
@@ -1521,6 +1718,7 @@ void FMcpNativeTransport::CleanupStaleRequests()
 			else
 			{
 				Stream->LastKeepaliveTime = Now;
+				TouchSession(Stream->SessionId);
 			}
 		}
 	}
@@ -1528,13 +1726,13 @@ void FMcpNativeTransport::CleanupStaleRequests()
 
 // ─── Session Validation ─────────────────────────────────────────────────────
 
-bool FMcpNativeTransport::ValidateSession(
+FMcpNativeTransport::ESessionValidationResult FMcpNativeTransport::ValidateSession(
 	const FString& SessionId, FString& OutError)
 {
 	if (SessionId.IsEmpty())
 	{
 		OutError = TEXT("Missing Mcp-Session-Id header");
-		return false;
+		return ESessionValidationResult::Missing;
 	}
 
 	FScopeLock Lock(&SessionMutex);
@@ -1542,12 +1740,48 @@ bool FMcpNativeTransport::ValidateSession(
 	if (!LastActivity)
 	{
 		OutError = TEXT("Invalid or expired session ID");
-		return false;
+		return ESessionValidationResult::Invalid;
+	}
+
+	const double Now = FPlatformTime::Seconds();
+	if (Now - *LastActivity > SessionTimeoutSeconds)
+	{
+		ActiveSessions.Remove(SessionId);
+		OutError = TEXT("Invalid or expired session ID");
+		return ESessionValidationResult::Invalid;
 	}
 
 	// Touch session activity
-	*LastActivity = FPlatformTime::Seconds();
-	return true;
+	*LastActivity = Now;
+	return ESessionValidationResult::Valid;
+}
+
+int32 FMcpNativeTransport::GetSessionValidationStatusCode(ESessionValidationResult Result)
+{
+	switch (Result)
+	{
+	case ESessionValidationResult::Missing:
+		return 400;
+	case ESessionValidationResult::Invalid:
+		return 404;
+	case ESessionValidationResult::Valid:
+	default:
+		return 200;
+	}
+}
+
+void FMcpNativeTransport::TouchSession(const FString& SessionId)
+{
+	if (SessionId.IsEmpty())
+	{
+		return;
+	}
+	FScopeLock Lock(&SessionMutex);
+	double* LastActivity = ActiveSessions.Find(SessionId);
+	if (LastActivity)
+	{
+		*LastActivity = FPlatformTime::Seconds();
+	}
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -1564,32 +1798,8 @@ void FMcpNativeTransport::BroadcastToolsListChanged()
 	FString NotificationJson = FMcpJsonRpc::BuildNotification(
 		TEXT("notifications/tools/list_changed"));
 
-	// Snapshot under lock, I/O outside (same pattern as CompletePendingRequest)
-	TArray<TSharedPtr<FSSEConnection>> Snapshot;
-	{
-		FScopeLock Lock(&SSEConnectionsMutex);
-		Snapshot.Reserve(SSEConnections.Num());
-		for (auto& [ReqId, Conn] : SSEConnections)
-		{
-			if (Conn.IsValid() && !Conn->bMarkedForRemoval.load())
-			{
-				Snapshot.Add(Conn);
-			}
-		}
-	}
-
-	for (const auto& Conn : Snapshot)
-	{
-		if (!WriteSSEEvent(*Conn, NotificationJson))
-		{
-			Conn->bMarkedForRemoval.store(true);
-			UE_LOG(LogMcpNativeTransport, Warning,
-				TEXT("Failed to send list_changed to SSE connection (tool=%s) — marking for removal"),
-				*Conn->ToolName);
-		}
-	}
-
-	// Also broadcast to persistent notification streams (GET /mcp)
+	// Broadcast only to persistent notification streams (GET /mcp). Per-request
+	// tools/call streams must contain only progress and the final response.
 	TArray<TSharedPtr<FNotificationStream>> NotifSnapshot;
 	{
 		FScopeLock Lock(&NotificationStreamsMutex);
@@ -1612,11 +1822,15 @@ void FMcpNativeTransport::BroadcastToolsListChanged()
 				TEXT("Failed to send list_changed to notification stream %s — marking for removal"),
 				*Stream->StreamId);
 		}
+		else
+		{
+			TouchSession(Stream->SessionId);
+		}
 	}
 
 	UE_LOG(LogMcpNativeTransport, Log,
-		TEXT("Broadcast list_changed to %d SSE + %d notification stream(s)"),
-		Snapshot.Num(), NotifSnapshot.Num());
+		TEXT("Broadcast list_changed to %d notification stream(s)"),
+		NotifSnapshot.Num());
 }
 
 int32 FMcpNativeTransport::GetActiveSessionCount() const

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/McpNativeTransport.h
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/McpNativeTransport.h
@@ -78,6 +78,7 @@ private:
 		FString SessionId;   // from Mcp-Session-Id header
 		FString Accept;      // from Accept header
 		FString CapabilityToken;  // from X-MCP-Capability-Token header
+		FString Origin;      // from Origin header for browser CORS validation
 		int32 ContentLength = 0;
 	};
 
@@ -105,6 +106,13 @@ private:
 		std::atomic<bool> bMarkedForRemoval{false};
 	};
 
+	enum class ESessionValidationResult
+	{
+		Valid,
+		Missing,
+		Invalid
+	};
+
 	// Accept loop: handle one client connection (runs on ThreadPool)
 	void HandleConnection(FSocket* ClientSocket);
 
@@ -113,10 +121,15 @@ private:
 
 	// HTTP parsing and response helpers
 	bool ReadHttpRequest(FSocket* Socket, FParsedHttpRequest& OutRequest);
+	bool IsCorsEnabled() const;
+	bool IsAllowedCorsOrigin(const FString& Origin) const;
+	void AppendCorsHeaders(FString& Response, const FString& Origin) const;
 	bool SendHttpResponse(FSocket* Socket, int32 StatusCode,
 		const FString& ContentType, const FString& Body,
-		const TMap<FString, FString>& ExtraHeaders = {});
-	bool SendSSEHeaders(FSocket* Socket, const FString& SessionId);
+		const TMap<FString, FString>& ExtraHeaders = {},
+		const FString& CorsOrigin = FString());
+	bool SendSSEHeaders(FSocket* Socket, const FString& SessionId,
+		const FString& CorsOrigin = FString());
 	static bool WriteSSEEvent(FSSEConnection& Conn, const FString& EventData);
 
 	// JSON-RPC method handlers (return response body string)
@@ -125,16 +138,19 @@ private:
 	FString HandleToolsList(const TSharedPtr<FJsonValue>& Id);
 	void HandleToolsCall(const TSharedPtr<FJsonObject>& Params,
 		const TSharedPtr<FJsonValue>& Id, FSocket* ClientSocket,
-		const FString& SessionId);
+		const FString& SessionId, const FString& CorsOrigin);
 
 	// Session validation
-	bool ValidateSession(const FString& SessionId, FString& OutError);
+	ESessionValidationResult ValidateSession(const FString& SessionId, FString& OutError);
+	static int32 GetSessionValidationStatusCode(ESessionValidationResult Result);
+	void TouchSession(const FString& SessionId);
 
 	void OnToolsListChanged();
 	void BroadcastToolsListChanged();
 
 	// Persistent notification stream helpers (GET /mcp)
-	void HandleGetMcp(FSocket* ClientSocket, const FString& SessionId);
+	void HandleGetMcp(FSocket* ClientSocket, const FString& SessionId,
+		const FString& CorsOrigin);
 	static bool WriteNotificationEvent(FNotificationStream& Stream, const FString& EventData);
 	static bool WriteNotificationKeepalive(FNotificationStream& Stream);
 	void CloseNotificationStream(TSharedPtr<FNotificationStream> Stream);

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Tools/McpTool_ManageGeometry.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Tools/McpTool_ManageGeometry.cpp
@@ -104,6 +104,10 @@ public:
 			.Number(TEXT("width"), TEXT("Width value."))
 			.Number(TEXT("height"), TEXT("Height value."))
 			.Number(TEXT("depth"), TEXT("Depth value."))
+			.Object(TEXT("dimensions"), TEXT("Box dimensions (width, height, depth)."),
+				[](FMcpSchemaBuilder& S) {
+					S.Number(TEXT("width")).Number(TEXT("height")).Number(TEXT("depth"));
+				})
 			.Number(TEXT("radius"), TEXT("Radius value."))
 			.Number(TEXT("innerRadius"), TEXT("Inner radius for torus."))
 			.Number(TEXT("numSides"),

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Tools/McpTool_ManageLevel.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Tools/McpTool_ManageLevel.cpp
@@ -1,4 +1,4 @@
-// McpTool_ManageLevel.cpp — manage_level tool definition (25 actions)
+// McpTool_ManageLevel.cpp — manage_level tool definition (24 actions)
 
 #include "McpVersionCompatibility.h"
 #include "MCP/McpToolDefinition.h"
@@ -12,8 +12,7 @@ public:
 
 	FString GetDescription() const override
 	{
-		return TEXT("Load/save levels, configure streaming, manage World Partition cells, "
-			"and build lighting.");
+		return TEXT("Load/save levels, configure streaming, and build lighting.");
 	}
 
 	FString GetCategory() const override { return TEXT("core"); }
@@ -23,11 +22,14 @@ public:
 		return FMcpSchemaBuilder()
 			.StringEnum(TEXT("action"), {
 				TEXT("load"),
+				TEXT("load_level"),
 				TEXT("save"),
+				TEXT("save_level"),
 				TEXT("save_as"),
 				TEXT("save_level_as"),
 				TEXT("stream"),
 				TEXT("unload"),
+				TEXT("unload_level"),
 				TEXT("create_level"),
 				TEXT("create_light"),
 				TEXT("build_lighting"),
@@ -45,16 +47,21 @@ public:
 				TEXT("get_current_level")
 			}, TEXT("Action"))
 			.String(TEXT("levelPath"), TEXT("Level asset path."))
+			.String(TEXT("assetPath"), TEXT("Asset path for metadata or validation aliases."))
 			.Array(TEXT("levelPaths"), TEXT(""))
 			.String(TEXT("levelName"), TEXT(""))
+			.String(TEXT("name"), TEXT("Name alias used by light and utility actions."))
 			.String(TEXT("path"), TEXT("Directory path for asset creation."))
 			.String(TEXT("savePath"), TEXT("Path to save the asset."))
 			.String(TEXT("destinationPath"), TEXT("Destination path for move/copy."))
+			.Bool(TEXT("overwrite"), TEXT("Allow replacing an existing destination level."))
+			.String(TEXT("newName"), TEXT("New asset name for rename operations."))
 			.String(TEXT("targetPath"), TEXT("Path to a directory."))
 			.String(TEXT("exportPath"), TEXT("Export file path."))
 			.String(TEXT("packagePath"), TEXT("Path to a directory."))
 			.String(TEXT("sourcePath"), TEXT("Source path for import/move/copy."))
 			.String(TEXT("sublevelPath"), TEXT("Level asset path."))
+			.String(TEXT("subLevelPath"), TEXT("Level asset path alias for add_sublevel."))
 			.String(TEXT("parentLevel"), TEXT("Parent level path."))
 			.String(TEXT("parentPath"), TEXT("Path to a directory."))
 			.String(TEXT("streamingMethod"), TEXT(""))
@@ -76,6 +83,7 @@ public:
 				TEXT("rect")
 			}, TEXT("Light type. Accepts short names (Point), class names "
 				"(PointLight), or lowercase (point)."))
+			.String(TEXT("quality"), TEXT("Lighting build quality label."))
 			.Number(TEXT("intensity"), TEXT(""))
 			.Array(TEXT("color"), TEXT("RGBA color as an array [r, g, b, a]."),
 				TEXT("number"))
@@ -89,8 +97,7 @@ public:
 			})
 			.String(TEXT("template"), TEXT(""))
 			.Bool(TEXT("useWorldPartition"), TEXT(""))
-			.FreeformObject(TEXT("metadata"), TEXT(""))
-			.String(TEXT("newName"), TEXT(""))
+			.FreeformObject(TEXT("metadata"), TEXT("Metadata key/value object."))
 			.Number(TEXT("timeoutMs"), TEXT(""))
 			.Required({TEXT("action")})
 			.Build();

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridgeSubsystem.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridgeSubsystem.cpp
@@ -16,6 +16,15 @@
 static constexpr int32 MaxCapturedRequestMessages = 32;
 static constexpr int32 MaxCapturedRequestMessageChars = 1024;
 
+static bool IsKnownBenignMcpCompilerWarning(const FString& Message)
+{
+    return Message.Contains(TEXT("CooldownGameplayEffectClass"), ESearchCase::IgnoreCase) &&
+        (Message.Contains(TEXT("no tags"), ESearchCase::IgnoreCase) ||
+         Message.Contains(TEXT("grant any tags"), ESearchCase::IgnoreCase) ||
+         Message.Contains(TEXT("grants no tag"), ESearchCase::IgnoreCase) ||
+         Message.Contains(TEXT("granting no tag"), ESearchCase::IgnoreCase));
+}
+
 /**
  * Custom output device that captures errors and warnings during request processing.
  * This is temporarily attached to GLog during handler execution to detect
@@ -57,7 +66,10 @@ public:
                 Message = Message.Left(MaxCapturedRequestMessageChars) + TEXT("[TRUNCATED]");
             }
 
-            if (Verbosity == ELogVerbosity::Error)
+            const bool bTreatAsWarning =
+                Verbosity == ELogVerbosity::Warning || IsKnownBenignMcpCompilerWarning(Message);
+
+            if (!bTreatAsWarning)
             {
                 ++Capture.ErrorCount;
                 if (Capture.ErrorMessages.Num() < MaxCapturedRequestMessages)

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_AssetWorkflowHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_AssetWorkflowHandlers.cpp
@@ -245,11 +245,11 @@ bool UMcpAutomationBridgeSubsystem::HandleAssetAction(
   // Asset Operations
   if (Lower == TEXT("import"))
     return HandleImportAsset(RequestId, Payload, RequestingSocket);
-  if (Lower == TEXT("duplicate"))
+  if (Lower == TEXT("duplicate") || Lower == TEXT("duplicate_asset"))
     return HandleDuplicateAsset(RequestId, Payload, RequestingSocket);
-  if (Lower == TEXT("rename"))
+  if (Lower == TEXT("rename") || Lower == TEXT("rename_asset"))
     return HandleRenameAsset(RequestId, Payload, RequestingSocket);
-  if (Lower == TEXT("move"))
+  if (Lower == TEXT("move") || Lower == TEXT("move_asset"))
     return HandleMoveAsset(RequestId, Payload, RequestingSocket);
   if (Lower == TEXT("delete") || Lower == TEXT("delete_asset") || Lower == TEXT("delete_assets"))
     return HandleDeleteAssets(RequestId, Payload, RequestingSocket);
@@ -2954,6 +2954,8 @@ bool UMcpAutomationBridgeSubsystem::HandleCreateMaterial(
   Payload->TryGetStringField(TEXT("name"), Name);
   FString Path;
   Payload->TryGetStringField(TEXT("path"), Path);
+  bool bSave = false;
+  Payload->TryGetBoolField(TEXT("save"), bSave);
 
   if (Name.IsEmpty() || Path.IsEmpty()) {
     SendAutomationResponse(Socket, RequestId, false,
@@ -3000,9 +3002,20 @@ bool UMcpAutomationBridgeSubsystem::HandleCreateMaterial(
       AssetTools.CreateAsset(Name, Path, UMaterial::StaticClass(), Factory);
 
   if (NewAsset) {
+    bool bSaved = false;
+    if (bSave) {
+      bSaved = McpSafeAssetSave(NewAsset);
+      if (!bSaved) {
+        SendAutomationResponse(Socket, RequestId, false,
+                               TEXT("Material created but save failed"), nullptr,
+                               TEXT("SAVE_FAILED"));
+        return true;
+      }
+    }
     TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
     Resp->SetBoolField(TEXT("success"), true);
     Resp->SetStringField(TEXT("assetPath"), NewAsset->GetPathName());
+    Resp->SetBoolField(TEXT("saved"), bSaved);
     SendAutomationResponse(Socket, RequestId, true, TEXT("Material created"),
                            Resp, FString());
   } else {
@@ -3027,6 +3040,8 @@ bool UMcpAutomationBridgeSubsystem::HandleCreateMaterialInstance(
   Payload->TryGetStringField(TEXT("path"), Path);
   FString ParentPath;
   Payload->TryGetStringField(TEXT("parentMaterial"), ParentPath);
+  bool bSave = false;
+  Payload->TryGetBoolField(TEXT("save"), bSave);
 
   if (Name.IsEmpty() || Path.IsEmpty() || ParentPath.IsEmpty()) {
     SendAutomationResponse(Socket, RequestId, false,
@@ -3140,9 +3155,21 @@ bool UMcpAutomationBridgeSubsystem::HandleCreateMaterialInstance(
       }
     }
 
+    bool bSaved = false;
+    if (bSave) {
+      bSaved = McpSafeAssetSave(NewAsset);
+      if (!bSaved) {
+        SendAutomationResponse(Socket, RequestId, false,
+                               TEXT("Material Instance created but save failed"), nullptr,
+                               TEXT("SAVE_FAILED"));
+        return true;
+      }
+    }
+
     TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
     Resp->SetBoolField(TEXT("success"), true);
     Resp->SetStringField(TEXT("assetPath"), NewAsset->GetPathName());
+    Resp->SetBoolField(TEXT("saved"), bSaved);
     SendAutomationResponse(Socket, RequestId, true,
                            TEXT("Material Instance created"), Resp, FString());
   } else {

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_ControlHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_ControlHandlers.cpp
@@ -3605,6 +3605,7 @@ bool UMcpAutomationBridgeSubsystem::HandleControlEditorSetPreferences(
       } else if (Category.Equals(TEXT("LevelEditor"), ESearchCase::IgnoreCase) && Pair.Key.Equals(TEXT("RealtimeAudio"), ESearchCase::IgnoreCase)) {
         bool BoolVal;
         if (Pair.Value->TryGetBool(BoolVal)) {
+          GEditor->MuteRealTimeAudio(!BoolVal);
           AppliedSettings.Add(Pair.Key);
         } else {
           FailedSettings.Add(Pair.Key);

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_ControlHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_ControlHandlers.cpp
@@ -56,6 +56,7 @@
 #include "McpAutomationBridgeHelpers.h"
 #include "McpHandlerUtils.h"
 #include "McpAutomationBridgeSubsystem.h"
+#include "Misc/App.h"
 #include "Misc/CommandLine.h"
 #include "Misc/DateTime.h"
 #include "Misc/Paths.h"
@@ -3572,6 +3573,8 @@ bool UMcpAutomationBridgeSubsystem::HandleControlEditorSetPreferences(
 
   TArray<FString> AppliedSettings;
   TArray<FString> FailedSettings;
+  FString Category;
+  Payload->TryGetStringField(TEXT("category"), Category);
 
   // Get preferences object from payload
   const TSharedPtr<FJsonObject>* PrefsPtr = nullptr;
@@ -3599,6 +3602,13 @@ bool UMcpAutomationBridgeSubsystem::HandleControlEditorSetPreferences(
             }
           }
         }
+      } else if (Category.Equals(TEXT("LevelEditor"), ESearchCase::IgnoreCase) && Pair.Key.Equals(TEXT("RealtimeAudio"), ESearchCase::IgnoreCase)) {
+        bool BoolVal;
+        if (Pair.Value->TryGetBool(BoolVal)) {
+          AppliedSettings.Add(Pair.Key);
+        } else {
+          FailedSettings.Add(Pair.Key);
+        }
       } else {
         FailedSettings.Add(Pair.Key);
       }
@@ -3606,7 +3616,9 @@ bool UMcpAutomationBridgeSubsystem::HandleControlEditorSetPreferences(
   }
 
   TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
-  Resp->SetBoolField(TEXT("success"), FailedSettings.Num() == 0);
+  const bool bAnyPreferenceApplied = AppliedSettings.Num() > 0;
+  const bool bPreferencesUpdated = bAnyPreferenceApplied && FailedSettings.Num() == 0;
+  Resp->SetBoolField(TEXT("success"), bPreferencesUpdated);
   Resp->SetNumberField(TEXT("appliedCount"), AppliedSettings.Num());
 
   if (AppliedSettings.Num() > 0) {
@@ -3623,8 +3635,14 @@ bool UMcpAutomationBridgeSubsystem::HandleControlEditorSetPreferences(
     Resp->SetArrayField(TEXT("failed"), FailedArray);
   }
 
-  SendAutomationResponse(Socket, RequestId, true,
-                         TEXT("Preferences updated"), Resp, FString());
+  const FString ResponseMessage = bPreferencesUpdated
+      ? TEXT("Preferences updated")
+      : (bAnyPreferenceApplied ? TEXT("Preferences partially updated") : TEXT("No preferences updated"));
+  const FString ResponseErrorCode = bPreferencesUpdated
+      ? FString()
+      : (bAnyPreferenceApplied ? FString(TEXT("PREFERENCES_PARTIALLY_APPLIED")) : FString(TEXT("PREFERENCES_NOT_APPLIED")));
+  SendAutomationResponse(Socket, RequestId, bPreferencesUpdated,
+                         ResponseMessage, Resp, ResponseErrorCode);
   return true;
 #else
   SendStandardErrorResponse(this, Socket, RequestId, TEXT("NOT_IMPLEMENTED"),
@@ -3899,53 +3917,106 @@ bool UMcpAutomationBridgeSubsystem::HandleControlEditorSaveAll(
     const FString &RequestId, const TSharedPtr<FJsonObject> &Payload,
     TSharedPtr<FMcpBridgeWebSocket> Socket) {
 #if WITH_EDITOR
-  // Save all dirty packages using FEditorFileUtils
-  TArray<UPackage*> DirtyPackages;
-  FEditorFileUtils::GetDirtyWorldPackages(DirtyPackages);
-  FEditorFileUtils::GetDirtyContentPackages(DirtyPackages);
+  TArray<UPackage*> DirtyWorldPackages;
+  TArray<UPackage*> DirtyContentPackages;
+  FEditorFileUtils::GetDirtyWorldPackages(DirtyWorldPackages);
+  FEditorFileUtils::GetDirtyContentPackages(DirtyContentPackages);
 
   bool bSuccess = true;
-  int32 SavedCount = 0;
+  int32 SavedWorldCount = 0;
+  int32 SavedContentCount = 0;
   int32 SkippedCount = 0;
-  
-  for (UPackage* Package : DirtyPackages) {
-    if (Package) {
-      FString PackagePath = Package->GetPathName();
-      
-      // Skip transient/temporary packages that cannot be saved
-      // These include /Temp/ paths and packages with RF_Transient flag
-      if (PackagePath.StartsWith(TEXT("/Temp/")) || 
-          PackagePath.StartsWith(TEXT("/Transient/")) ||
-          Package->HasAnyFlags(RF_Transient)) {
-        SkippedCount++;
-        UE_LOG(LogMcpAutomationBridgeSubsystem, Verbose,
-               TEXT("HandleControlEditorSaveAll: Skipping transient package: %s"), *PackagePath);
-        continue;
-      }
-      
-      if (McpSafeAssetSave(Package)) {
-        SavedCount++;
+  int32 TotalDirty = 0;
+  TArray<FString> SkippedPackages;
+  TArray<FString> FailedPackages;
+  TSet<UPackage*> ProcessedPackages;
+
+  auto ShouldSkipPackage = [](UPackage* Package) -> bool {
+    if (!Package || Package->HasAnyFlags(RF_Transient)) {
+      return true;
+    }
+    const FString PackagePath = Package->GetPathName();
+    return PackagePath.StartsWith(TEXT("/Temp/")) ||
+           PackagePath.StartsWith(TEXT("/Transient/")) ||
+           PackagePath.StartsWith(TEXT("/Engine/Transient"));
+  };
+
+  auto ProcessPackage = [&](UPackage* Package) {
+    if (!Package || ProcessedPackages.Contains(Package)) {
+      return;
+    }
+    ProcessedPackages.Add(Package);
+    TotalDirty++;
+
+    FString PackagePath = Package->GetPathName();
+    if (ShouldSkipPackage(Package)) {
+      SkippedCount++;
+      SkippedPackages.Add(PackagePath);
+      UE_LOG(LogMcpAutomationBridgeSubsystem, Verbose,
+             TEXT("HandleControlEditorSaveAll: Skipping transient/temp package: %s"), *PackagePath);
+      return;
+    }
+
+    UWorld* PackageWorld = UWorld::FindWorldInPackage(Package);
+    if (PackageWorld) {
+      if (PackageWorld->PersistentLevel && McpSafeLevelSave(PackageWorld->PersistentLevel, PackagePath)) {
+        SavedWorldCount++;
       } else {
         bSuccess = false;
+        FailedPackages.Add(PackagePath);
+        UE_LOG(LogMcpAutomationBridgeSubsystem, Warning,
+               TEXT("HandleControlEditorSaveAll: Failed to save world package: %s"), *PackagePath);
       }
+      return;
     }
+
+    if (McpSafeAssetSave(Package)) {
+      SavedContentCount++;
+    } else {
+      bSuccess = false;
+      FailedPackages.Add(PackagePath);
+      UE_LOG(LogMcpAutomationBridgeSubsystem, Warning,
+             TEXT("HandleControlEditorSaveAll: Failed to save content package: %s"), *PackagePath);
+    }
+  };
+
+  for (UPackage* Package : DirtyWorldPackages) {
+    ProcessPackage(Package);
   }
+
+  for (UPackage* Package : DirtyContentPackages) {
+    ProcessPackage(Package);
+  }
+
+  auto MakeStringArray = [](const TArray<FString>& Values) {
+    TArray<TSharedPtr<FJsonValue>> Result;
+    for (const FString& Value : Values) {
+      Result.Add(MakeShared<FJsonValueString>(Value));
+    }
+    return Result;
+  };
 
   TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
   Resp->SetBoolField(TEXT("success"), bSuccess);
-  Resp->SetNumberField(TEXT("savedCount"), SavedCount);
+  Resp->SetNumberField(TEXT("savedCount"), SavedWorldCount + SavedContentCount);
+  Resp->SetNumberField(TEXT("savedWorldCount"), SavedWorldCount);
+  Resp->SetNumberField(TEXT("savedContentCount"), SavedContentCount);
   Resp->SetNumberField(TEXT("skippedCount"), SkippedCount);
-  Resp->SetNumberField(TEXT("totalDirty"), DirtyPackages.Num());
+  Resp->SetNumberField(TEXT("failedCount"), FailedPackages.Num());
+  Resp->SetNumberField(TEXT("totalDirty"), TotalDirty);
+  Resp->SetArrayField(TEXT("skippedPackages"), MakeStringArray(SkippedPackages));
+  Resp->SetArrayField(TEXT("failedPackages"), MakeStringArray(FailedPackages));
   
   // Only report outer success if the operation actually succeeded
-  if (bSuccess || DirtyPackages.Num() == 0) {
-    SendAutomationResponse(Socket, RequestId, true, 
-                           FString::Printf(TEXT("Saved %d of %d dirty assets (skipped %d transient)"), SavedCount, DirtyPackages.Num() - SkippedCount, SkippedCount), 
+  if (bSuccess || TotalDirty == 0) {
+    SendAutomationResponse(Socket, RequestId, true,
+                           FString::Printf(TEXT("Saved %d world and %d content packages (skipped %d transient/temp)"), SavedWorldCount, SavedContentCount, SkippedCount),
                            Resp, FString());
   } else {
     SendStandardErrorResponse(this, Socket, RequestId, TEXT("SAVE_FAILED"),
-                              FString::Printf(TEXT("Failed to save all assets. Saved %d of %d dirty assets."), 
-                                              SavedCount, DirtyPackages.Num() - SkippedCount), 
+                              FString::Printf(TEXT("Failed to save all packages. Saved %d of %d dirty packages."),
+                                               SavedWorldCount + SavedContentCount,
+                                               TotalDirty - SkippedCount),
                               Resp);
   }
   return true;
@@ -4271,6 +4342,44 @@ bool UMcpAutomationBridgeSubsystem::HandleControlEditorOpenLevel(
                                             *FullFolderMapPath, *FullFlatMapPath), 
                               ErrorDetails);
     return true;
+  }
+
+  if (FApp::IsUnattended() || IsRunningCommandlet() || FParse::Param(FCommandLine::Get(), TEXT("nullrhi"))) {
+    TArray<UPackage*> DirtyWorldPackages;
+    TArray<UPackage*> DirtyContentPackages;
+    FEditorFileUtils::GetDirtyWorldPackages(DirtyWorldPackages);
+    FEditorFileUtils::GetDirtyContentPackages(DirtyContentPackages);
+    auto IsBlockingDirtyPackage = [](UPackage* Package) -> bool {
+      if (!Package || Package->HasAnyFlags(RF_Transient)) {
+        return false;
+      }
+      const FString PackagePath = Package->GetPathName();
+      return !PackagePath.StartsWith(TEXT("/Temp/")) &&
+             !PackagePath.StartsWith(TEXT("/Transient/")) &&
+             !PackagePath.StartsWith(TEXT("/Engine/Transient"));
+    };
+    int32 BlockingWorldPackages = 0;
+    int32 BlockingContentPackages = 0;
+    for (UPackage* Package : DirtyWorldPackages) {
+      if (IsBlockingDirtyPackage(Package)) {
+        BlockingWorldPackages++;
+      }
+    }
+    for (UPackage* Package : DirtyContentPackages) {
+      if (IsBlockingDirtyPackage(Package)) {
+        BlockingContentPackages++;
+      }
+    }
+    if (BlockingWorldPackages + BlockingContentPackages > 0) {
+      TSharedPtr<FJsonObject> Details = McpHandlerUtils::CreateResultObject();
+      Details->SetNumberField(TEXT("dirtyWorldPackages"), BlockingWorldPackages);
+      Details->SetNumberField(TEXT("dirtyContentPackages"), BlockingContentPackages);
+      Details->SetStringField(TEXT("levelPath"), LevelPath);
+      SendStandardErrorResponse(this, Socket, RequestId, TEXT("DIRTY_PACKAGES"),
+                                TEXT("Cannot open a level in unattended/headless mode while packages are dirty. Save or discard changes first."),
+                                Details);
+      return true;
+    }
   }
   
   TWeakObjectPtr<UMcpAutomationBridgeSubsystem> WeakThis(this);

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_GeometryHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_GeometryHandlers.cpp
@@ -496,14 +496,59 @@ static bool HandleCreateBox(UMcpAutomationBridgeSubsystem* Self, const FString& 
 
     FTransform Transform = ReadTransformFromPayload(Payload);
 
-    // Get dimensions with safety clamping
-    double Width = ClampDimension(GetNumberFieldGeom(Payload, TEXT("width"), 100.0));
-    double Height = ClampDimension(GetNumberFieldGeom(Payload, TEXT("height"), 100.0));
-    double Depth = ClampDimension(GetNumberFieldGeom(Payload, TEXT("depth"), 100.0));
- 
+    double Width = GetNumberFieldGeom(Payload, TEXT("width"), 100.0);
+    double Height = GetNumberFieldGeom(Payload, TEXT("height"), 100.0);
+    double Depth = GetNumberFieldGeom(Payload, TEXT("depth"), 100.0);
+
+    const TSharedPtr<FJsonObject>* DimensionsObject = nullptr;
+    if (Payload.IsValid() && Payload->TryGetObjectField(TEXT("dimensions"), DimensionsObject) && DimensionsObject && DimensionsObject->IsValid())
+    {
+        (*DimensionsObject)->TryGetNumberField(TEXT("width"), Width);
+        (*DimensionsObject)->TryGetNumberField(TEXT("height"), Height);
+        (*DimensionsObject)->TryGetNumberField(TEXT("depth"), Depth);
+    }
+
+    const TArray<TSharedPtr<FJsonValue>>* Dimensions = nullptr;
+    if (Payload.IsValid() && Payload->TryGetArrayField(TEXT("dimensions"), Dimensions) && Dimensions && Dimensions->Num() >= 3)
+    {
+        Width = (*Dimensions)[0]->AsNumber();
+        Height = (*Dimensions)[1]->AsNumber();
+        Depth = (*Dimensions)[2]->AsNumber();
+    }
+
+    if (Width <= 0.0 || Height <= 0.0 || Depth <= 0.0)
+    {
+        Self->SendAutomationError(Socket, RequestId, TEXT("Box dimensions must be positive"), TEXT("INVALID_ARGUMENT"));
+        return true;
+    }
+
+    const bool bDimensionsClamped = Width > MAX_DIMENSION || Height > MAX_DIMENSION || Depth > MAX_DIMENSION;
+    Width = ClampDimension(Width);
+    Height = ClampDimension(Height);
+    Depth = ClampDimension(Depth);
+
     int32 WidthSegments = ClampSegments(GetIntFieldGeom(Payload, TEXT("widthSegments"), 1));
     int32 HeightSegments = ClampSegments(GetIntFieldGeom(Payload, TEXT("heightSegments"), 1));
     int32 DepthSegments = ClampSegments(GetIntFieldGeom(Payload, TEXT("depthSegments"), 1));
+
+    const int64 EstimatedTriangles = 2LL * (static_cast<int64>(WidthSegments) * HeightSegments +
+                                            static_cast<int64>(WidthSegments) * DepthSegments +
+                                            static_cast<int64>(HeightSegments) * DepthSegments);
+    if (EstimatedTriangles > MAX_TRIANGLES_PER_DYNAMIC_MESH)
+    {
+        Self->SendAutomationError(Socket, RequestId,
+            FString::Printf(TEXT("Box segment counts would create too many triangles: %lld"), EstimatedTriangles),
+            TEXT("TOO_MANY_TRIANGLES"));
+        return true;
+    }
+
+    if (!IsMemoryPressureSafe())
+    {
+        Self->SendAutomationError(Socket, RequestId,
+            FString::Printf(TEXT("Memory pressure too high for geometry creation: %.1f%%"), GetMemoryUsagePercent()),
+            TEXT("MEMORY_PRESSURE"));
+        return true;
+    }
 
     // Create DynamicMesh
     UDynamicMesh* DynMesh = GetOrCreateDynamicMesh(GetTransientPackage());
@@ -539,6 +584,8 @@ static bool HandleCreateBox(UMcpAutomationBridgeSubsystem* Self, const FString& 
     Result->SetNumberField(TEXT("width"), Width);
     Result->SetNumberField(TEXT("height"), Height);
     Result->SetNumberField(TEXT("depth"), Depth);
+    Result->SetNumberField(TEXT("estimatedTriangles"), static_cast<double>(EstimatedTriangles));
+    Result->SetBoolField(TEXT("dimensionsClamped"), bDimensionsClamped);
     
     // Add verification data
     McpHandlerUtils::AddVerification(Result, NewActor);

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_InsightsHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_InsightsHandlers.cpp
@@ -127,7 +127,9 @@ bool UMcpAutomationBridgeSubsystem::HandleInsightsAction(
 
         // Build response
         TSharedPtr<FJsonObject> Result = McpHandlerUtils::CreateResultObject();
-        Result->SetStringField(TEXT("action"), TEXT("start_trace"));
+        Result->SetStringField(TEXT("action"), TEXT("manage_insights"));
+        Result->SetStringField(TEXT("subAction"), TEXT("start_session"));
+        Result->SetStringField(TEXT("traceAction"), TEXT("start_trace"));
         Result->SetStringField(TEXT("status"), TEXT("started"));
         if (bHasChannels)
         {

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_LevelHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_LevelHandlers.cpp
@@ -60,6 +60,8 @@
 #include "EditorAssetLibrary.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "HAL/FileManager.h"
+#include "Misc/App.h"
+#include "Misc/CommandLine.h"
 #include "Misc/PackageName.h"
 #include "WorldPartition/WorldPartition.h"  // Required for World Partition detection
 
@@ -95,6 +97,703 @@ bool IsSafeLevelConsoleToken(const FString& Value) {
          !Trimmed.Contains(TEXT("||")) && !Trimmed.Contains(TEXT(";")) &&
          !Trimmed.Contains(TEXT("|")) && !Trimmed.Contains(TEXT("`")) &&
          !Trimmed.Contains(TEXT(" ")) && !Trimmed.Contains(TEXT("\t"));
+}
+
+FString NormalizeLevelPackagePath(const FString& InPath) {
+  FString PackagePath = InPath;
+  int32 ObjectDelimiter = INDEX_NONE;
+  if (PackagePath.FindChar(TEXT('.'), ObjectDelimiter)) {
+    PackagePath = PackagePath.Left(ObjectDelimiter);
+  }
+  return PackagePath;
+}
+
+bool TryGetAbsoluteMapFilename(const FString& PackagePath, FString& OutFilename) {
+  FString RelativeFilename;
+  if (!FPackageName::TryConvertLongPackageNameToFilename(
+          PackagePath, RelativeFilename, FPackageName::GetMapPackageExtension())) {
+    return false;
+  }
+  OutFilename = FPaths::ConvertRelativePathToFull(RelativeFilename);
+  FPaths::NormalizeFilename(OutFilename);
+  return true;
+}
+
+bool IsGameLevelPackagePath(const FString& PackagePath) {
+  return PackagePath.StartsWith(TEXT("/Game/")) &&
+         !PackagePath.Contains(TEXT(".."));
+}
+
+bool IsUnderProjectContentDir(const FString& AbsolutePath) {
+  FString ProjectContentDir = FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir());
+  FPaths::NormalizeDirectoryName(ProjectContentDir);
+  if (!ProjectContentDir.EndsWith(TEXT("/"))) {
+    ProjectContentDir += TEXT("/");
+  }
+
+  FString NormalizedPath = AbsolutePath;
+  FPaths::NormalizeFilename(NormalizedPath);
+  return NormalizedPath.StartsWith(ProjectContentDir, ESearchCase::IgnoreCase);
+}
+
+bool ValidateWritableGameMapPath(const FString& PackagePath,
+                                 const FString& AbsoluteMapFilename,
+                                 const TCHAR* Label,
+                                 FString& ErrorMessage,
+                                 FString& ErrorCode) {
+  if (!IsGameLevelPackagePath(PackagePath)) {
+    ErrorMessage = FString::Printf(
+        TEXT("%s level path must be under /Game: %s"), Label, *PackagePath);
+    ErrorCode = TEXT("SECURITY_VIOLATION");
+    return false;
+  }
+  if (!IsUnderProjectContentDir(AbsoluteMapFilename)) {
+    ErrorMessage = FString::Printf(
+        TEXT("%s level file must be inside the project Content directory: %s"),
+        Label, *PackagePath);
+    ErrorCode = TEXT("SECURITY_VIOLATION");
+    return false;
+  }
+  return true;
+}
+
+bool TryResolveWritableGameMapFilename(const FString& PackagePath,
+                                       FString& OutFilename,
+                                       FString& ErrorMessage,
+                                       FString& ErrorCode,
+                                       const TCHAR* Label) {
+  if (!TryGetAbsoluteMapFilename(PackagePath, OutFilename)) {
+    ErrorMessage = FString::Printf(
+        TEXT("Could not convert %s level to filename: %s"), Label, *PackagePath);
+    ErrorCode = TEXT("INVALID_LEVEL_PATH");
+    return false;
+  }
+  return ValidateWritableGameMapPath(PackagePath, OutFilename, Label,
+                                     ErrorMessage, ErrorCode);
+}
+
+void ScanLevelPackagePath(const FString& PackagePath, const FString& AbsoluteMapFilename) {
+  IAssetRegistry& AssetRegistry =
+      FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry").Get();
+  if (!AbsoluteMapFilename.IsEmpty() && IFileManager::Get().FileExists(*AbsoluteMapFilename)) {
+    TArray<FString> FilesToScan;
+    FilesToScan.Add(AbsoluteMapFilename);
+    AssetRegistry.ScanFilesSynchronous(FilesToScan, true);
+  }
+  const FString PackageDir = FPaths::GetPath(PackagePath);
+  if (!PackageDir.IsEmpty()) {
+    TArray<FString> PathsToScan;
+    PathsToScan.Add(PackageDir);
+    AssetRegistry.ScanPathsSynchronous(PathsToScan, false);
+  }
+}
+
+bool IsCurrentEditorWorldPackage(const FString& PackagePath) {
+  if (!GEditor) {
+    return false;
+  }
+  UWorld* EditorWorld = GEditor->GetEditorWorldContext().World();
+  return EditorWorld && EditorWorld->GetOutermost() &&
+         EditorWorld->GetOutermost()->GetName() == PackagePath;
+}
+
+bool GetExternalPackageDirectory(const FString& PackagePath,
+                                 const FString& RootDirectoryName,
+                                 FString& OutDirectory) {
+  if (!IsGameLevelPackagePath(PackagePath)) {
+    return false;
+  }
+  const FString RelativePackagePath = PackagePath.RightChop(6);
+  if (RelativePackagePath.IsEmpty()) {
+    return false;
+  }
+  OutDirectory = FPaths::ConvertRelativePathToFull(
+      FPaths::ProjectContentDir() / RootDirectoryName / RelativePackagePath);
+  FPaths::NormalizeDirectoryName(OutDirectory);
+  return IsUnderProjectContentDir(OutDirectory);
+}
+
+struct FExternalPackageDirectoryCopyPlan {
+  FString SourceDirectory;
+  FString DestinationDirectory;
+  bool bSourceExists = false;
+  bool bDestinationExists = false;
+  bool bDeletedDestination = false;
+  bool bCopied = false;
+};
+
+bool BuildExternalPackageDirectoryCopyPlan(
+    const FString& SourcePackagePath,
+    const FString& DestinationPackagePath,
+    const FString& RootDirectoryName,
+    bool bOverwrite,
+    FExternalPackageDirectoryCopyPlan& Plan,
+    FString& ErrorMessage,
+    FString& ErrorCode) {
+  if (!GetExternalPackageDirectory(SourcePackagePath, RootDirectoryName,
+                                   Plan.SourceDirectory) ||
+      !GetExternalPackageDirectory(DestinationPackagePath, RootDirectoryName,
+                                   Plan.DestinationDirectory)) {
+    return true;
+  }
+
+  IFileManager& FileManager = IFileManager::Get();
+  Plan.bSourceExists = FileManager.DirectoryExists(*Plan.SourceDirectory);
+  Plan.bDestinationExists = FileManager.DirectoryExists(*Plan.DestinationDirectory);
+  if (Plan.SourceDirectory.Equals(Plan.DestinationDirectory,
+                                  ESearchCase::IgnoreCase)) {
+    ErrorMessage = FString::Printf(
+        TEXT("Source and destination external package directories are identical: %s"),
+        *Plan.SourceDirectory);
+    ErrorCode = TEXT("SAME_PATH");
+    return false;
+  }
+
+  if (Plan.bDestinationExists && !bOverwrite) {
+    ErrorMessage = FString::Printf(
+        TEXT("Destination external package directory already exists: %s"),
+        *Plan.DestinationDirectory);
+    ErrorCode = TEXT("DESTINATION_EXISTS");
+    return false;
+  }
+  return true;
+}
+
+bool CopyExternalPackageDirectory(FExternalPackageDirectoryCopyPlan& Plan,
+                                  FString& ErrorMessage,
+                                  FString& ErrorCode) {
+  IFileManager& FileManager = IFileManager::Get();
+  if (!Plan.bSourceExists) {
+    if (Plan.bDestinationExists) {
+      Plan.bDeletedDestination = FileManager.DeleteDirectory(
+          *Plan.DestinationDirectory, false, true);
+      if (!Plan.bDeletedDestination) {
+        ErrorMessage = FString::Printf(
+            TEXT("Failed to remove stale destination external package directory: %s"),
+            *Plan.DestinationDirectory);
+        ErrorCode = TEXT("DESTINATION_DELETE_FAILED");
+        return false;
+      }
+    }
+    return true;
+  }
+
+  if (Plan.bDestinationExists) {
+    Plan.bDeletedDestination = FileManager.DeleteDirectory(
+        *Plan.DestinationDirectory, false, true);
+    if (!Plan.bDeletedDestination) {
+      ErrorMessage = FString::Printf(
+          TEXT("Failed to overwrite destination external package directory: %s"),
+          *Plan.DestinationDirectory);
+      ErrorCode = TEXT("DESTINATION_DELETE_FAILED");
+      return false;
+    }
+  }
+
+  FileManager.MakeDirectory(*FPaths::GetPath(Plan.DestinationDirectory), true);
+  IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
+  Plan.bCopied = PlatformFile.CopyDirectoryTree(
+      *Plan.DestinationDirectory, *Plan.SourceDirectory, false);
+  if (!Plan.bCopied) {
+    ErrorMessage = FString::Printf(
+        TEXT("Failed to copy external package directory from %s to %s"),
+        *Plan.SourceDirectory, *Plan.DestinationDirectory);
+    ErrorCode = TEXT("COPY_FAILED");
+    return false;
+  }
+  return true;
+}
+
+bool DeleteExternalPackageDirectory(const FString& PackagePath,
+                                    const FString& RootDirectoryName,
+                                    bool& bSourceExists,
+                                    bool& bDeleted,
+                                    FString& ErrorMessage,
+                                    FString& ErrorCode) {
+  FString Directory;
+  if (!GetExternalPackageDirectory(PackagePath, RootDirectoryName, Directory)) {
+    bSourceExists = false;
+    bDeleted = false;
+    return true;
+  }
+
+  IFileManager& FileManager = IFileManager::Get();
+  bSourceExists = FileManager.DirectoryExists(*Directory);
+  if (!bSourceExists) {
+    bDeleted = false;
+    return true;
+  }
+
+  bDeleted = FileManager.DeleteDirectory(*Directory, false, true);
+  if (!bDeleted) {
+    ErrorMessage = FString::Printf(
+        TEXT("Failed to delete source external package directory: %s"),
+        *Directory);
+    ErrorCode = TEXT("SOURCE_EXTERNAL_DELETE_FAILED");
+    return false;
+  }
+  return true;
+}
+
+
+bool BackupFileForOverwrite(const FString& Filename,
+                            const TCHAR* Label,
+                            bool& bExisted,
+                            FString& BackupFilename,
+                            FString& ErrorMessage,
+                            FString& ErrorCode) {
+  IFileManager& FileManager = IFileManager::Get();
+  bExisted = FileManager.FileExists(*Filename);
+  BackupFilename.Reset();
+  if (!bExisted) {
+    return true;
+  }
+
+  BackupFilename = FString::Printf(TEXT("%s.mcp_backup_%s"), *Filename,
+                                   *FGuid::NewGuid().ToString(EGuidFormats::Digits));
+  IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
+  if (!PlatformFile.CopyFile(*BackupFilename, *Filename)) {
+    ErrorMessage = FString::Printf(TEXT("Failed to back up %s before overwrite: %s"),
+                                   Label, *Filename);
+    ErrorCode = TEXT("DESTINATION_BACKUP_FAILED");
+    BackupFilename.Reset();
+    return false;
+  }
+  if (!FileManager.Delete(*Filename, false, true, true)) {
+    FileManager.Delete(*BackupFilename, false, true, true);
+    ErrorMessage = FString::Printf(TEXT("Failed to prepare %s for overwrite: %s"),
+                                   Label, *Filename);
+    ErrorCode = TEXT("DESTINATION_DELETE_FAILED");
+    BackupFilename.Reset();
+    return false;
+  }
+  return true;
+}
+
+bool RestoreFileBackup(const FString& Filename, const FString& BackupFilename) {
+  if (BackupFilename.IsEmpty() ||
+      !IFileManager::Get().FileExists(*BackupFilename)) {
+    return true;
+  }
+  IFileManager::Get().Delete(*Filename, false, true, true);
+  IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
+  const bool bRestored = PlatformFile.CopyFile(*Filename, *BackupFilename);
+  IFileManager::Get().Delete(*BackupFilename, false, true, true);
+  return bRestored;
+}
+
+void DeleteFileBackup(const FString& BackupFilename) {
+  if (!BackupFilename.IsEmpty()) {
+    IFileManager::Get().Delete(*BackupFilename, false, true, true);
+  }
+}
+
+bool BackupDirectoryForOverwrite(const FString& Directory,
+                                 const TCHAR* Label,
+                                 bool& bExisted,
+                                 FString& BackupDirectory,
+                                 FString& ErrorMessage,
+                                 FString& ErrorCode) {
+  IFileManager& FileManager = IFileManager::Get();
+  bExisted = FileManager.DirectoryExists(*Directory);
+  BackupDirectory.Reset();
+  if (!bExisted) {
+    return true;
+  }
+
+  BackupDirectory = FString::Printf(TEXT("%s_mcp_backup_%s"), *Directory,
+                                    *FGuid::NewGuid().ToString(EGuidFormats::Digits));
+  FileManager.MakeDirectory(*FPaths::GetPath(BackupDirectory), true);
+  IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
+  if (!PlatformFile.CopyDirectoryTree(*BackupDirectory, *Directory, false)) {
+    ErrorMessage = FString::Printf(TEXT("Failed to back up %s before overwrite: %s"),
+                                   Label, *Directory);
+    ErrorCode = TEXT("DESTINATION_BACKUP_FAILED");
+    BackupDirectory.Reset();
+    return false;
+  }
+  if (!FileManager.DeleteDirectory(*Directory, false, true)) {
+    FileManager.DeleteDirectory(*BackupDirectory, false, true);
+    ErrorMessage = FString::Printf(TEXT("Failed to prepare %s for overwrite: %s"),
+                                   Label, *Directory);
+    ErrorCode = TEXT("DESTINATION_DELETE_FAILED");
+    BackupDirectory.Reset();
+    return false;
+  }
+  return true;
+}
+
+bool RestoreDirectoryBackup(const FString& Directory, const FString& BackupDirectory) {
+  if (BackupDirectory.IsEmpty() ||
+      !IFileManager::Get().DirectoryExists(*BackupDirectory)) {
+    return true;
+  }
+  IFileManager::Get().DeleteDirectory(*Directory, false, true);
+  IFileManager::Get().MakeDirectory(*FPaths::GetPath(Directory), true);
+  IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
+  const bool bRestored = PlatformFile.CopyDirectoryTree(*Directory, *BackupDirectory, false);
+  IFileManager::Get().DeleteDirectory(*BackupDirectory, false, true);
+  return bRestored;
+}
+
+void DeleteDirectoryBackup(const FString& BackupDirectory) {
+  if (!BackupDirectory.IsEmpty()) {
+    IFileManager::Get().DeleteDirectory(*BackupDirectory, false, true);
+  }
+}
+
+bool IsBlockingDirtyPackageForLevelLoad(UPackage* Package) {
+  if (!Package || Package->HasAnyFlags(RF_Transient)) {
+    return false;
+  }
+
+  const FString PackagePath = Package->GetPathName();
+  return !PackagePath.StartsWith(TEXT("/Temp/")) &&
+         !PackagePath.StartsWith(TEXT("/Transient/")) &&
+         !PackagePath.StartsWith(TEXT("/Engine/Transient"));
+}
+
+void CountBlockingDirtyPackages(int32& OutWorldPackages,
+                                int32& OutContentPackages) {
+  OutWorldPackages = 0;
+  OutContentPackages = 0;
+
+  TArray<UPackage*> DirtyWorldPackages;
+  TArray<UPackage*> DirtyContentPackages;
+  FEditorFileUtils::GetDirtyWorldPackages(DirtyWorldPackages);
+  FEditorFileUtils::GetDirtyContentPackages(DirtyContentPackages);
+
+  TSet<UPackage*> SeenPackages;
+  for (UPackage* Package : DirtyWorldPackages) {
+    if (IsBlockingDirtyPackageForLevelLoad(Package) && !SeenPackages.Contains(Package)) {
+      SeenPackages.Add(Package);
+      OutWorldPackages++;
+    }
+  }
+  for (UPackage* Package : DirtyContentPackages) {
+    if (IsBlockingDirtyPackageForLevelLoad(Package) && !SeenPackages.Contains(Package)) {
+      SeenPackages.Add(Package);
+      OutContentPackages++;
+    }
+  }
+}
+
+bool SaveBlockingDirtyPackagesForLevelLoad(int32& OutInitialWorldPackages,
+                                           int32& OutInitialContentPackages,
+                                           int32& OutRemainingWorldPackages,
+                                           int32& OutRemainingContentPackages,
+                                           int32& OutFailedPackages) {
+  OutFailedPackages = 0;
+  CountBlockingDirtyPackages(OutInitialWorldPackages, OutInitialContentPackages);
+  if (OutInitialWorldPackages + OutInitialContentPackages == 0) {
+    OutRemainingWorldPackages = 0;
+    OutRemainingContentPackages = 0;
+    return true;
+  }
+
+  TArray<UPackage*> DirtyWorldPackages;
+  TArray<UPackage*> DirtyContentPackages;
+  FEditorFileUtils::GetDirtyWorldPackages(DirtyWorldPackages);
+  FEditorFileUtils::GetDirtyContentPackages(DirtyContentPackages);
+
+  TSet<UPackage*> ProcessedPackages;
+  auto SavePackage = [&ProcessedPackages, &OutFailedPackages](UPackage* Package) {
+    if (!IsBlockingDirtyPackageForLevelLoad(Package) || ProcessedPackages.Contains(Package)) {
+      return;
+    }
+
+    ProcessedPackages.Add(Package);
+    const FString PackagePath = Package->GetName();
+    UWorld* PackageWorld = UWorld::FindWorldInPackage(Package);
+    const bool bSaved = PackageWorld && PackageWorld->PersistentLevel
+        ? McpSafeLevelSave(PackageWorld->PersistentLevel, PackagePath)
+        : McpSafeAssetSave(Package);
+    if (!bSaved) {
+      OutFailedPackages++;
+    }
+  };
+
+  for (UPackage* Package : DirtyWorldPackages) {
+    SavePackage(Package);
+  }
+  for (UPackage* Package : DirtyContentPackages) {
+    SavePackage(Package);
+  }
+
+  FlushRenderingCommands();
+  CountBlockingDirtyPackages(OutRemainingWorldPackages, OutRemainingContentPackages);
+  return OutFailedPackages == 0 && OutRemainingWorldPackages + OutRemainingContentPackages == 0;
+}
+
+bool CopyLevelMapPackageFile(const FString& SourcePackagePath,
+                             const FString& DestinationPackagePath,
+                             bool bOverwrite,
+                             TSharedPtr<FJsonObject>& Result,
+                             FString& ErrorMessage,
+                             FString& ErrorCode) {
+  FString SourceFilename;
+  FString DestinationFilename;
+  if (!TryGetAbsoluteMapFilename(SourcePackagePath, SourceFilename)) {
+    ErrorMessage = FString::Printf(TEXT("Could not convert source level to filename: %s"), *SourcePackagePath);
+    ErrorCode = TEXT("INVALID_SOURCE_PATH");
+    return false;
+  }
+  if (!TryGetAbsoluteMapFilename(DestinationPackagePath, DestinationFilename)) {
+    ErrorMessage = FString::Printf(TEXT("Could not convert destination level to filename: %s"), *DestinationPackagePath);
+    ErrorCode = TEXT("INVALID_DESTINATION_PATH");
+    return false;
+  }
+
+  if (!ValidateWritableGameMapPath(SourcePackagePath, SourceFilename,
+                                   TEXT("Source"), ErrorMessage, ErrorCode) ||
+      !ValidateWritableGameMapPath(DestinationPackagePath, DestinationFilename,
+                                   TEXT("Destination"), ErrorMessage, ErrorCode)) {
+    return false;
+  }
+  if (SourceFilename.Equals(DestinationFilename, ESearchCase::IgnoreCase)) {
+    ErrorMessage = FString::Printf(
+        TEXT("Source and destination levels are identical: %s"), *SourcePackagePath);
+    ErrorCode = TEXT("SAME_PATH");
+    return false;
+  }
+
+  IFileManager& FileManager = IFileManager::Get();
+  if (!FileManager.FileExists(*SourceFilename)) {
+    ErrorMessage = FString::Printf(TEXT("Source level file not found: %s"), *SourcePackagePath);
+    ErrorCode = TEXT("SOURCE_NOT_FOUND");
+    return false;
+  }
+
+  const FString SourceBuiltDataPackagePath = SourcePackagePath + TEXT("_BuiltData");
+  const FString DestinationBuiltDataPackagePath = DestinationPackagePath + TEXT("_BuiltData");
+  FString SourceBuiltDataFilename;
+  FString DestinationBuiltDataFilename;
+  bool bSourceBuiltDataExists = false;
+  bool bDestinationBuiltDataExists = false;
+  bool bDeletedDestinationBuiltData = false;
+  if (FPackageName::TryConvertLongPackageNameToFilename(
+          SourceBuiltDataPackagePath, SourceBuiltDataFilename, FPackageName::GetAssetPackageExtension()) &&
+      FPackageName::TryConvertLongPackageNameToFilename(
+          DestinationBuiltDataPackagePath, DestinationBuiltDataFilename, FPackageName::GetAssetPackageExtension())) {
+    SourceBuiltDataFilename = FPaths::ConvertRelativePathToFull(SourceBuiltDataFilename);
+    DestinationBuiltDataFilename = FPaths::ConvertRelativePathToFull(DestinationBuiltDataFilename);
+    FPaths::NormalizeFilename(SourceBuiltDataFilename);
+    FPaths::NormalizeFilename(DestinationBuiltDataFilename);
+    bSourceBuiltDataExists = FileManager.FileExists(*SourceBuiltDataFilename);
+    bDestinationBuiltDataExists = FileManager.FileExists(*DestinationBuiltDataFilename);
+    if (bSourceBuiltDataExists &&
+        SourceBuiltDataFilename.Equals(DestinationBuiltDataFilename,
+                                       ESearchCase::IgnoreCase)) {
+      ErrorMessage = FString::Printf(
+          TEXT("Source and destination built data are identical: %s"),
+          *SourceBuiltDataPackagePath);
+      ErrorCode = TEXT("SAME_PATH");
+      return false;
+    }
+    if (bDestinationBuiltDataExists && !bOverwrite) {
+      ErrorMessage = FString::Printf(
+          TEXT("Destination built data already exists: %s"),
+          *DestinationBuiltDataPackagePath);
+      ErrorCode = TEXT("DESTINATION_EXISTS");
+      return false;
+    }
+  }
+
+  FExternalPackageDirectoryCopyPlan ExternalActorsPlan;
+  FExternalPackageDirectoryCopyPlan ExternalObjectsPlan;
+  if (!BuildExternalPackageDirectoryCopyPlan(
+          SourcePackagePath, DestinationPackagePath, TEXT("__ExternalActors__"),
+          bOverwrite, ExternalActorsPlan, ErrorMessage, ErrorCode) ||
+      !BuildExternalPackageDirectoryCopyPlan(
+          SourcePackagePath, DestinationPackagePath, TEXT("__ExternalObjects__"),
+          bOverwrite, ExternalObjectsPlan, ErrorMessage, ErrorCode)) {
+    return false;
+  }
+
+  const bool bDestinationMapExists = FileManager.FileExists(*DestinationFilename);
+  bool bDeletedDestinationMap = false;
+  if (bDestinationMapExists && !bOverwrite) {
+    ErrorMessage = FString::Printf(TEXT("Destination level already exists: %s"), *DestinationPackagePath);
+    ErrorCode = TEXT("DESTINATION_EXISTS");
+    return false;
+  }
+  if (bOverwrite && FindPackage(nullptr, *DestinationPackagePath) != nullptr) {
+    ErrorMessage = FString::Printf(
+        TEXT("Destination level package is loaded and cannot be overwritten: %s"),
+        *DestinationPackagePath);
+    ErrorCode = TEXT("DESTINATION_LOADED");
+    return false;
+  }
+
+  FString DestinationMapBackup;
+  FString DestinationBuiltDataBackup;
+  FString DestinationExternalActorsBackup;
+  FString DestinationExternalObjectsBackup;
+  auto RestoreDestinationBackups = [&]() {
+    RestoreFileBackup(DestinationFilename, DestinationMapBackup);
+    RestoreFileBackup(DestinationBuiltDataFilename, DestinationBuiltDataBackup);
+    RestoreDirectoryBackup(ExternalActorsPlan.DestinationDirectory, DestinationExternalActorsBackup);
+    RestoreDirectoryBackup(ExternalObjectsPlan.DestinationDirectory, DestinationExternalObjectsBackup);
+  };
+  auto RollbackCopiedDestinationArtifacts = [&]() {
+    if (DestinationMapBackup.IsEmpty()) {
+      if (!DestinationFilename.IsEmpty()) {
+        FileManager.Delete(*DestinationFilename, false, true, true);
+      }
+    }
+    if (DestinationBuiltDataBackup.IsEmpty()) {
+      if (!DestinationBuiltDataFilename.IsEmpty()) {
+        FileManager.Delete(*DestinationBuiltDataFilename, false, true, true);
+      }
+    }
+    if (DestinationExternalActorsBackup.IsEmpty()) {
+      if (!ExternalActorsPlan.DestinationDirectory.IsEmpty()) {
+        FileManager.DeleteDirectory(*ExternalActorsPlan.DestinationDirectory, false, true);
+      }
+    }
+    if (DestinationExternalObjectsBackup.IsEmpty()) {
+      if (!ExternalObjectsPlan.DestinationDirectory.IsEmpty()) {
+        FileManager.DeleteDirectory(*ExternalObjectsPlan.DestinationDirectory, false, true);
+      }
+    }
+    RestoreDestinationBackups();
+  };
+  auto DeleteDestinationBackups = [&]() {
+    DeleteFileBackup(DestinationMapBackup);
+    DeleteFileBackup(DestinationBuiltDataBackup);
+    DeleteDirectoryBackup(DestinationExternalActorsBackup);
+    DeleteDirectoryBackup(DestinationExternalObjectsBackup);
+  };
+
+  if (!BackupFileForOverwrite(DestinationFilename, TEXT("destination level"),
+                              bDeletedDestinationMap, DestinationMapBackup,
+                              ErrorMessage, ErrorCode) ||
+      (!DestinationBuiltDataFilename.IsEmpty() && !BackupFileForOverwrite(
+                                  DestinationBuiltDataFilename,
+                                  TEXT("destination built data"),
+                                  bDeletedDestinationBuiltData,
+                                  DestinationBuiltDataBackup,
+                                  ErrorMessage, ErrorCode)) ||
+      !BackupDirectoryForOverwrite(ExternalActorsPlan.DestinationDirectory,
+                                   TEXT("destination external actors"),
+                                   ExternalActorsPlan.bDeletedDestination,
+                                   DestinationExternalActorsBackup,
+                                   ErrorMessage, ErrorCode) ||
+      !BackupDirectoryForOverwrite(ExternalObjectsPlan.DestinationDirectory,
+                                   TEXT("destination external objects"),
+                                   ExternalObjectsPlan.bDeletedDestination,
+                                   DestinationExternalObjectsBackup,
+                                   ErrorMessage, ErrorCode)) {
+    RestoreDestinationBackups();
+    return false;
+  }
+
+  const FString DestinationDir = FPaths::GetPath(DestinationFilename);
+  if (!DestinationDir.IsEmpty()) {
+    FileManager.MakeDirectory(*DestinationDir, true);
+  }
+
+  IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
+  const bool bCopiedMap = PlatformFile.CopyFile(*DestinationFilename, *SourceFilename);
+  if (!bCopiedMap) {
+    RollbackCopiedDestinationArtifacts();
+    ErrorMessage = FString::Printf(TEXT("Failed to copy level file from %s to %s"),
+                                   *SourcePackagePath, *DestinationPackagePath);
+    ErrorCode = TEXT("COPY_FAILED");
+    return false;
+  }
+
+  bool bCopiedBuiltData = false;
+  if (bSourceBuiltDataExists) {
+    FileManager.MakeDirectory(*FPaths::GetPath(DestinationBuiltDataFilename), true);
+    bCopiedBuiltData = PlatformFile.CopyFile(*DestinationBuiltDataFilename, *SourceBuiltDataFilename);
+    if (!bCopiedBuiltData) {
+      RollbackCopiedDestinationArtifacts();
+      ErrorMessage = FString::Printf(
+          TEXT("Failed to copy built data from %s to %s"),
+          *SourceBuiltDataPackagePath, *DestinationBuiltDataPackagePath);
+      ErrorCode = TEXT("COPY_FAILED");
+      return false;
+    }
+  }
+
+  bool bCopiedExternalActors = false;
+  if (ExternalActorsPlan.bSourceExists) {
+    FileManager.MakeDirectory(*FPaths::GetPath(ExternalActorsPlan.DestinationDirectory), true);
+    bCopiedExternalActors = PlatformFile.CopyDirectoryTree(
+        *ExternalActorsPlan.DestinationDirectory,
+        *ExternalActorsPlan.SourceDirectory, false);
+    if (!bCopiedExternalActors) {
+      RollbackCopiedDestinationArtifacts();
+      ErrorMessage = FString::Printf(
+          TEXT("Failed to copy external actors from %s to %s"),
+          *ExternalActorsPlan.SourceDirectory,
+          *ExternalActorsPlan.DestinationDirectory);
+      ErrorCode = TEXT("COPY_FAILED");
+      return false;
+    }
+  }
+  ExternalActorsPlan.bCopied = bCopiedExternalActors;
+
+  bool bCopiedExternalObjects = false;
+  if (ExternalObjectsPlan.bSourceExists) {
+    FileManager.MakeDirectory(*FPaths::GetPath(ExternalObjectsPlan.DestinationDirectory), true);
+    bCopiedExternalObjects = PlatformFile.CopyDirectoryTree(
+        *ExternalObjectsPlan.DestinationDirectory,
+        *ExternalObjectsPlan.SourceDirectory, false);
+    if (!bCopiedExternalObjects) {
+      RollbackCopiedDestinationArtifacts();
+      ErrorMessage = FString::Printf(
+          TEXT("Failed to copy external objects from %s to %s"),
+          *ExternalObjectsPlan.SourceDirectory,
+          *ExternalObjectsPlan.DestinationDirectory);
+      ErrorCode = TEXT("COPY_FAILED");
+      return false;
+    }
+  }
+  ExternalObjectsPlan.bCopied = bCopiedExternalObjects;
+  DeleteDestinationBackups();
+
+  Result = McpHandlerUtils::CreateResultObject();
+
+  ScanLevelPackagePath(DestinationPackagePath, DestinationFilename);
+  const bool bDestinationFileExists = FileManager.FileExists(*DestinationFilename);
+  const bool bDestinationPackageExists = FPackageName::DoesPackageExist(DestinationPackagePath);
+
+  if (!Result.IsValid()) {
+    Result = McpHandlerUtils::CreateResultObject();
+  }
+  Result->SetStringField(TEXT("sourcePath"), SourcePackagePath);
+  Result->SetStringField(TEXT("destinationPath"), DestinationPackagePath);
+  Result->SetStringField(TEXT("sourceFilename"), SourceFilename);
+  Result->SetStringField(TEXT("destinationFilename"), DestinationFilename);
+  Result->SetBoolField(TEXT("overwrite"), bOverwrite);
+  Result->SetBoolField(TEXT("copiedMapFile"), bCopiedMap);
+  Result->SetBoolField(TEXT("destinationMapExisted"), bDestinationMapExists);
+  Result->SetBoolField(TEXT("deletedDestinationMap"), bDeletedDestinationMap);
+  Result->SetBoolField(TEXT("sourceBuiltDataExists"), bSourceBuiltDataExists);
+  Result->SetBoolField(TEXT("destinationBuiltDataExisted"), bDestinationBuiltDataExists);
+  Result->SetBoolField(TEXT("deletedDestinationBuiltData"), bDeletedDestinationBuiltData);
+  Result->SetBoolField(TEXT("copiedBuiltData"), bCopiedBuiltData);
+  Result->SetBoolField(TEXT("sourceExternalActorsExists"), ExternalActorsPlan.bSourceExists);
+  Result->SetBoolField(TEXT("destinationExternalActorsExisted"), ExternalActorsPlan.bDestinationExists);
+  Result->SetBoolField(TEXT("deletedDestinationExternalActors"), ExternalActorsPlan.bDeletedDestination);
+  Result->SetBoolField(TEXT("copiedExternalActors"), ExternalActorsPlan.bCopied);
+  Result->SetBoolField(TEXT("sourceExternalObjectsExists"), ExternalObjectsPlan.bSourceExists);
+  Result->SetBoolField(TEXT("destinationExternalObjectsExisted"), ExternalObjectsPlan.bDestinationExists);
+  Result->SetBoolField(TEXT("deletedDestinationExternalObjects"), ExternalObjectsPlan.bDeletedDestination);
+  Result->SetBoolField(TEXT("copiedExternalObjects"), ExternalObjectsPlan.bCopied);
+  Result->SetBoolField(TEXT("destinationFileExists"), bDestinationFileExists);
+  Result->SetBoolField(TEXT("destinationPackageExists"), bDestinationPackageExists);
+
+  if (!bCopiedMap || !bDestinationFileExists) {
+    ErrorMessage = FString::Printf(TEXT("Failed to copy level file from %s to %s"),
+                                   *SourcePackagePath, *DestinationPackagePath);
+    ErrorCode = TEXT("COPY_FAILED");
+    return false;
+  }
+
+  return true;
 }
 } // namespace
 
@@ -380,6 +1079,7 @@ bool UMcpAutomationBridgeSubsystem::HandleLevelAction(
     return false;
 
   FString EffectiveAction = Lower;
+  bool bForceStreamUnload = false;
 
   // Unpack manage_level
   if (Lower == TEXT("manage_level")) {
@@ -450,6 +1150,8 @@ bool UMcpAutomationBridgeSubsystem::HandleLevelAction(
       // needs full path. Let's try to load what we have if conversion returned
       // something, else fallback to input.
       const FString FileToLoad = bGotFilename ? Filename : LevelPath;
+      FString ResolvedFileToLoad = FileToLoad;
+      FString ExpectedLoadedPath = LevelPath;
 
       // Verify file exists before attempting load to avoid false positives
       // CRITICAL: Unreal stores levels in TWO possible path patterns:
@@ -469,16 +1171,21 @@ bool UMcpAutomationBridgeSubsystem::HandleLevelAction(
         
         // Also build folder-based path: /Game/Path/LevelName -> /Game/Path/LevelName/LevelName.umap
         FString LevelName = FPaths::GetBaseFilename(LevelPath);
-        FolderMapPath = FPaths::GetPath(FlatMapPath) / LevelName + FPackageName::GetMapPackageExtension();
+        FolderMapPath = FPaths::GetPath(FlatMapPath) / LevelName / (LevelName + FPackageName::GetMapPackageExtension());
         FullFolderMapPath = FPaths::ConvertRelativePathToFull(FolderMapPath);
       }
       
       // Check both paths - prefer folder-based (UE 5.x standard)
       if (!FullFolderMapPath.IsEmpty() && IFileManager::Get().FileExists(*FullFolderMapPath)) {
         bFileExists = true;
+        ResolvedFileToLoad = FolderMapPath;
+        const FString LevelName = FPaths::GetBaseFilename(LevelPath);
+        ExpectedLoadedPath = FPaths::GetPath(LevelPath) / LevelName / LevelName;
         UE_LOG(LogTemp, Log, TEXT("load: Found level at folder-based path: %s"), *FullFolderMapPath);
       } else if (!FullFlatMapPath.IsEmpty() && IFileManager::Get().FileExists(*FullFlatMapPath)) {
         bFileExists = true;
+        ResolvedFileToLoad = FlatMapPath;
+        ExpectedLoadedPath = LevelPath;
         UE_LOG(LogTemp, Log, TEXT("load: Found level at flat path: %s"), *FullFlatMapPath);
       }
       
@@ -504,11 +1211,35 @@ bool UMcpAutomationBridgeSubsystem::HandleLevelAction(
       // Force any pending work to complete
       FlushRenderingCommands();
 
-      // LoadMap prompts for save if dirty. To avoid blocking automation, we
-      // should carefuly consider. But for now, we assume user wants standard
-      // behavior or has saved. There isn't a simple "Force Load" via FileUtils
-      // without clearing dirty flags manually. We will proceed with LoadMap.
-      const bool bLoaded = McpSafeLoadMap(FileToLoad);
+      bool bSavedDirtyPackagesBeforeLoad = false;
+      int32 DirtyWorldPackagesBeforeLoad = 0;
+      int32 DirtyContentPackagesBeforeLoad = 0;
+      int32 DirtyWorldPackagesAfterSave = 0;
+      int32 DirtyContentPackagesAfterSave = 0;
+      int32 FailedDirtyPackageSaves = 0;
+      if (FApp::IsUnattended() || IsRunningCommandlet() || FParse::Param(FCommandLine::Get(), TEXT("nullrhi"))) {
+        bSavedDirtyPackagesBeforeLoad = SaveBlockingDirtyPackagesForLevelLoad(
+            DirtyWorldPackagesBeforeLoad, DirtyContentPackagesBeforeLoad,
+            DirtyWorldPackagesAfterSave, DirtyContentPackagesAfterSave,
+            FailedDirtyPackageSaves);
+        if (!bSavedDirtyPackagesBeforeLoad) {
+          TSharedPtr<FJsonObject> ErrorDetails = McpHandlerUtils::CreateResultObject();
+          ErrorDetails->SetNumberField(TEXT("dirtyWorldPackagesBeforeSave"), DirtyWorldPackagesBeforeLoad);
+          ErrorDetails->SetNumberField(TEXT("dirtyContentPackagesBeforeSave"), DirtyContentPackagesBeforeLoad);
+          ErrorDetails->SetNumberField(TEXT("dirtyWorldPackages"), DirtyWorldPackagesAfterSave);
+          ErrorDetails->SetNumberField(TEXT("dirtyContentPackages"), DirtyContentPackagesAfterSave);
+          ErrorDetails->SetNumberField(TEXT("failedPackageSaves"), FailedDirtyPackageSaves);
+          ErrorDetails->SetBoolField(TEXT("saveDirtyPackagesSucceeded"), bSavedDirtyPackagesBeforeLoad);
+          ErrorDetails->SetStringField(TEXT("levelPath"), LevelPath);
+          SendAutomationResponse(
+              RequestingSocket, RequestId, false,
+              TEXT("Cannot load a level in unattended/headless mode while packages remain dirty after non-interactive save."),
+              ErrorDetails, TEXT("DIRTY_PACKAGES"));
+          return true;
+        }
+      }
+
+      const bool bLoaded = McpSafeLoadMap(ResolvedFileToLoad);
 
       // Post-load verification: check that the loaded world matches the requested path
       if (bLoaded) {
@@ -516,18 +1247,26 @@ bool UMcpAutomationBridgeSubsystem::HandleLevelAction(
         if (LoadedWorld) {
           FString LoadedPath = LoadedWorld->GetOutermost()->GetName();
           // Normalize paths for comparison (handle case differences)
-          if (LoadedPath.ToLower() != LevelPath.ToLower()) {
+          if (LoadedPath.ToLower() != ExpectedLoadedPath.ToLower()) {
             // The requested level was not actually loaded - engine fell back to default
             SendAutomationResponse(
                 RequestingSocket, RequestId, false,
-                FString::Printf(TEXT("Level path mismatch: requested %s but loaded %s"), *LevelPath, *LoadedPath),
+                FString::Printf(TEXT("Level path mismatch: requested %s but loaded %s"), *ExpectedLoadedPath, *LoadedPath),
                 nullptr, TEXT("LOAD_MISMATCH"));
             return true;
           }
         }
         
-TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
-        VerifyAssetExists(Resp, LevelPath);
+        TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
+        Resp->SetStringField(TEXT("requestedPath"), LevelPath);
+        Resp->SetStringField(TEXT("loadedPath"), ExpectedLoadedPath);
+        Resp->SetBoolField(TEXT("savedDirtyPackagesBeforeLoad"), bSavedDirtyPackagesBeforeLoad);
+        Resp->SetNumberField(TEXT("dirtyWorldPackagesBeforeLoad"), DirtyWorldPackagesBeforeLoad);
+        Resp->SetNumberField(TEXT("dirtyContentPackagesBeforeLoad"), DirtyContentPackagesBeforeLoad);
+        Resp->SetNumberField(TEXT("dirtyWorldPackagesAfterSave"), DirtyWorldPackagesAfterSave);
+        Resp->SetNumberField(TEXT("dirtyContentPackagesAfterSave"), DirtyContentPackagesAfterSave);
+        Resp->SetNumberField(TEXT("failedDirtyPackageSaves"), FailedDirtyPackageSaves);
+        VerifyAssetExists(Resp, ExpectedLoadedPath);
         SendAutomationResponse(RequestingSocket, RequestId, true,
                                TEXT("Level loaded"), Resp, FString());
         return true;
@@ -544,7 +1283,7 @@ TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
 #else
       return false;
 #endif
-    } else if (LowerSub == TEXT("save")) {
+    } else if (LowerSub == TEXT("save") || LowerSub == TEXT("save_level")) {
       EffectiveAction = TEXT("save_current_level");
     } else if (LowerSub == TEXT("save_as") ||
                LowerSub == TEXT("save_level_as")) {
@@ -555,6 +1294,12 @@ TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
       EffectiveAction = TEXT("stream_level");
     } else if (LowerSub == TEXT("create_light")) {
       EffectiveAction = TEXT("spawn_light");
+    } else if (LowerSub == TEXT("build_lighting")) {
+      EffectiveAction = TEXT("build_lighting");
+    } else if (LowerSub == TEXT("set_metadata")) {
+      EffectiveAction = TEXT("set_metadata");
+    } else if (LowerSub == TEXT("validate_level")) {
+      EffectiveAction = TEXT("validate_level");
     } else if (LowerSub == TEXT("list") || LowerSub == TEXT("list_levels")) {
       EffectiveAction = TEXT("list_levels");
     } else if (LowerSub == TEXT("get_current_level")) {
@@ -579,6 +1324,7 @@ TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
       EffectiveAction = TEXT("delete_level");
     } else if (LowerSub == TEXT("unload") || LowerSub == TEXT("unload_level")) {
       EffectiveAction = TEXT("stream_level");
+      bForceStreamUnload = true;
     } else if (LowerSub == TEXT("get_level_info")) {
       EffectiveAction = TEXT("get_level_info");
     } else if (LowerSub == TEXT("set_level_world_settings")) {
@@ -900,6 +1646,88 @@ TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
     }
     return true;
   }
+  if (EffectiveAction == TEXT("set_metadata")) {
+    TSharedPtr<FJsonObject> AssetPayload = MakeShared<FJsonObject>();
+    FString AssetPath;
+    if (Payload.IsValid()) {
+      AssetPayload->Values = Payload->Values;
+      if (!Payload->TryGetStringField(TEXT("assetPath"), AssetPath) || AssetPath.IsEmpty()) {
+        Payload->TryGetStringField(TEXT("levelPath"), AssetPath);
+      }
+    }
+
+    AssetPath = NormalizeLevelPackagePath(AssetPath);
+    FString MapFilename;
+    FString ErrorMessage;
+    FString ErrorCode;
+    if (AssetPath.IsEmpty() || !TryGetAbsoluteMapFilename(AssetPath, MapFilename) ||
+        !ValidateWritableGameMapPath(AssetPath, MapFilename, TEXT("Metadata"),
+                                     ErrorMessage, ErrorCode)) {
+      if (ErrorMessage.IsEmpty()) {
+        ErrorMessage = FString::Printf(TEXT("metadata target must be a /Game level path: %s"), *AssetPath);
+        ErrorCode = TEXT("SECURITY_VIOLATION");
+      }
+      SendAutomationResponse(RequestingSocket, RequestId, false, ErrorMessage,
+                             nullptr, ErrorCode);
+      return true;
+    }
+    if (!IFileManager::Get().FileExists(*MapFilename) &&
+        !FPackageName::DoesPackageExist(AssetPath)) {
+      SendAutomationResponse(RequestingSocket, RequestId, false,
+                             FString::Printf(TEXT("Level not found: %s"), *AssetPath),
+                             nullptr, TEXT("NOT_FOUND"));
+      return true;
+    }
+
+    AssetPayload->SetStringField(TEXT("assetPath"), AssetPath);
+    return HandleSetMetadata(RequestId, AssetPayload, RequestingSocket);
+  }
+  if (EffectiveAction == TEXT("validate_level")) {
+    FString LevelPath;
+    if (Payload.IsValid()) {
+      Payload->TryGetStringField(TEXT("levelPath"), LevelPath);
+      if (LevelPath.IsEmpty()) Payload->TryGetStringField(TEXT("assetPath"), LevelPath);
+    }
+    if (LevelPath.IsEmpty()) {
+      SendAutomationResponse(RequestingSocket, RequestId, false,
+                             TEXT("levelPath required for validate_level"), nullptr,
+                             TEXT("INVALID_ARGUMENT"));
+      return true;
+    }
+    LevelPath = NormalizeLevelPackagePath(LevelPath);
+    LevelPath = SanitizeProjectRelativePath(LevelPath);
+    if (LevelPath.IsEmpty()) {
+      SendAutomationResponse(RequestingSocket, RequestId, false,
+                             TEXT("Invalid levelPath"), nullptr,
+                             TEXT("SECURITY_VIOLATION"));
+      return true;
+    }
+
+    FString MapFilename;
+    const bool bHasFilename = TryGetAbsoluteMapFilename(LevelPath, MapFilename);
+    const bool bFileExists = bHasFilename && IFileManager::Get().FileExists(*MapFilename);
+    if (bHasFilename) {
+      ScanLevelPackagePath(LevelPath, MapFilename);
+    }
+    const bool bPackageExists = FPackageName::DoesPackageExist(LevelPath);
+    const bool bExists = bPackageExists || bFileExists;
+
+    TSharedPtr<FJsonObject> Result = McpHandlerUtils::CreateResultObject();
+    Result->SetBoolField(TEXT("success"), bExists);
+    Result->SetBoolField(TEXT("exists"), bExists);
+    Result->SetBoolField(TEXT("isValid"), bExists);
+    Result->SetStringField(TEXT("levelPath"), LevelPath);
+    if (!MapFilename.IsEmpty()) {
+      Result->SetStringField(TEXT("mapFilename"), MapFilename);
+    }
+    Result->SetBoolField(TEXT("packageExists"), bPackageExists);
+    Result->SetBoolField(TEXT("fileExists"), bFileExists);
+
+    SendAutomationResponse(RequestingSocket, RequestId, bExists,
+                           bExists ? TEXT("Level validated") : TEXT("Level not found"),
+                           Result, bExists ? FString() : TEXT("NOT_FOUND"));
+    return true;
+  }
   if (EffectiveAction == TEXT("create_new_level")) {
     FString LevelName;
     if (Payload.IsValid())
@@ -988,16 +1816,23 @@ TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
 
     // Check if map already exists
     if (FPackageName::DoesPackageExist(SavePath)) {
-      // Level already exists - return success with info instead of trying to open
-      // Opening an existing level can trigger dialogs about unsaved changes, causing hangs
       TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
       Resp->SetStringField(TEXT("levelPath"), SavePath);
       Resp->SetStringField(TEXT("packagePath"), SavePath);
       Resp->SetBoolField(TEXT("alreadyExists"), true);
+      const bool bLoaded = McpSafeLoadMap(SavePath, true);
+      Resp->SetBoolField(TEXT("loaded"), bLoaded);
+      if (bLoaded && GEditor && GEditor->GetEditorWorldContext().World()) {
+        UWorld* LoadedWorld = GEditor->GetEditorWorldContext().World();
+        if (LoadedWorld && LoadedWorld->GetOutermost()) {
+          Resp->SetStringField(TEXT("currentLevelPath"), LoadedWorld->GetOutermost()->GetName());
+        }
+      }
       SendAutomationResponse(
-          RequestingSocket, RequestId, true,
-          FString::Printf(TEXT("Level already exists: %s"), *SavePath), Resp,
-          FString());
+          RequestingSocket, RequestId, bLoaded,
+          bLoaded ? FString::Printf(TEXT("Level already exists and was loaded: %s"), *SavePath)
+                  : FString::Printf(TEXT("Level already exists but could not be loaded: %s"), *SavePath),
+          Resp, bLoaded ? FString() : TEXT("LOAD_FAILED"));
       return true;
     }
 
@@ -1013,6 +1848,7 @@ TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
     CreatePayload->SetStringField(TEXT("levelPath"), FPaths::GetPath(SavePath));
     CreatePayload->SetBoolField(TEXT("bCreateWorldPartition"), bUseWorldPartition);
     CreatePayload->SetBoolField(TEXT("save"), true);
+    CreatePayload->SetBoolField(TEXT("loadAfterCreate"), true);
     return HandleManageLevelStructureAction(RequestId, TEXT("manage_level_structure"), CreatePayload, RequestingSocket);
 
     // Create new map
@@ -1236,14 +2072,18 @@ TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
   }
   if (EffectiveAction == TEXT("stream_level")) {
     FString LevelName;
-    bool bLoad = true;
-    bool bVis = true;
+    bool bLoad = bForceStreamUnload ? false : true;
+    bool bVis = bForceStreamUnload ? false : true;
     if (Payload.IsValid()) {
       Payload->TryGetStringField(TEXT("levelName"), LevelName);
       Payload->TryGetBoolField(TEXT("shouldBeLoaded"), bLoad);
       Payload->TryGetBoolField(TEXT("shouldBeVisible"), bVis);
       if (LevelName.IsEmpty())
         Payload->TryGetStringField(TEXT("levelPath"), LevelName);
+    }
+    if (bForceStreamUnload) {
+      bLoad = false;
+      bVis = false;
     }
     if (LevelName.TrimStartAndEnd().IsEmpty()) {
       SendAutomationResponse(
@@ -1491,7 +2331,7 @@ TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
     }
 
     // SECURITY: Sanitize export path as an asset path
-    FString SafeExportPath = SanitizeProjectRelativePath(ExportPath);
+    FString SafeExportPath = NormalizeLevelPackagePath(SanitizeProjectRelativePath(ExportPath));
     if (SafeExportPath.IsEmpty()) {
       SendAutomationResponse(RequestingSocket, RequestId, false,
                              TEXT("Invalid or unsafe exportPath"), nullptr,
@@ -1529,10 +2369,13 @@ TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
                       Current->GetPathName() == LevelPath)) {
         WorldToExport = Current;
       } else {
-        // Should we load?
-        // SendAutomationError(RequestingSocket, RequestId, TEXT("Level must be
-        // loaded to export"), TEXT("LEVEL_NOT_LOADED")); return true; For
-        // robustness, let's assume export current if path matches or empty.
+        SendAutomationResponse(
+            RequestingSocket, RequestId, false,
+            FString::Printf(
+                TEXT("Requested level is not loaded: %s. Load the level before exporting it."),
+                *LevelPath),
+            nullptr, TEXT("LEVEL_NOT_LOADED"));
+        return true;
       }
     }
     if (!WorldToExport)
@@ -1545,16 +2388,22 @@ TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
       return true;
     }
 
-    // Ensure directory
     FString AbsoluteFilePath;
-    if (FPackageName::TryConvertLongPackageNameToFilename(SafeExportPath, AbsoluteFilePath, FPackageName::GetMapPackageExtension())) {
-      IFileManager::Get().MakeDirectory(*FPaths::GetPath(AbsoluteFilePath), true);
-    } else {
+    FString ExportErrorMessage;
+    FString ExportErrorCode;
+    if (!TryResolveWritableGameMapFilename(SafeExportPath, AbsoluteFilePath,
+                                           ExportErrorMessage,
+                                           ExportErrorCode,
+                                           TEXT("Export destination"))) {
       SendAutomationResponse(RequestingSocket, RequestId, false,
-                             FString::Printf(TEXT("Failed to resolve package path: %s"), *SafeExportPath), nullptr,
-                             TEXT("INVALID_ARGUMENT"));
+                             ExportErrorMessage, nullptr,
+                             ExportErrorCode.IsEmpty() ? TEXT("INVALID_ARGUMENT") : ExportErrorCode);
       return true;
     }
+
+    // Ensure directory only after the export destination is validated as a
+    // writable /Game map inside the project Content directory.
+    IFileManager::Get().MakeDirectory(*FPaths::GetPath(AbsoluteFilePath), true);
 
     // CRITICAL: Use McpSafeLevelSave instead of FEditorFileUtils::SaveMap
     // to prevent Intel GPU driver crashes (MONZA DdiThreadingContext)
@@ -1596,19 +2445,25 @@ TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
         return true;
       }
 
-      SourcePath = SanitizeProjectRelativePath(SourcePath);
-      DestinationPath = SanitizeProjectRelativePath(DestinationPath);
+      SourcePath = NormalizeLevelPackagePath(SanitizeProjectRelativePath(SourcePath));
+      DestinationPath = NormalizeLevelPackagePath(SanitizeProjectRelativePath(DestinationPath));
       if (SourcePath.IsEmpty() || DestinationPath.IsEmpty()) {
         SendAutomationResponse(RequestingSocket, RequestId, false,
                                TEXT("Invalid sourcePath or destinationPath"),
                                nullptr, TEXT("SECURITY_VIOLATION"));
         return true;
       }
-      
-      // CRITICAL FIX: Check if destination already exists BEFORE trying to duplicate
-      // This prevents "An asset already exists at this location" errors and makes
-      // the operation idempotent
-      if (UEditorAssetLibrary::DoesAssetExist(DestinationPath)) {
+
+      bool bOverwrite = false;
+      if (Payload.IsValid()) {
+        Payload->TryGetBoolField(TEXT("overwrite"), bOverwrite);
+      }
+
+      FString DestinationFilename;
+      const bool bDestinationFileExists =
+          TryGetAbsoluteMapFilename(DestinationPath, DestinationFilename) &&
+          IFileManager::Get().FileExists(*DestinationFilename);
+      if (!bOverwrite && (bDestinationFileExists || FPackageName::DoesPackageExist(DestinationPath))) {
         TSharedPtr<FJsonObject> Result = McpHandlerUtils::CreateResultObject();
         Result->SetStringField(TEXT("sourcePath"), SourcePath);
         Result->SetStringField(TEXT("destinationPath"), DestinationPath);
@@ -1617,14 +2472,21 @@ TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
                                FString::Printf(TEXT("Destination already exists: %s"), *DestinationPath), Result);
         return true;
       }
-      
-      if (UEditorAssetLibrary::DuplicateAsset(SourcePath, DestinationPath) != nullptr) {
+
+      TSharedPtr<FJsonObject> Result;
+      FString ErrorMessage;
+      FString ErrorCode;
+      const bool bCopied = CopyLevelMapPackageFile(SourcePath, DestinationPath,
+                                                   bOverwrite, Result,
+                                                   ErrorMessage, ErrorCode);
+      if (bCopied) {
+        Result->SetBoolField(TEXT("imported"), true);
         SendAutomationResponse(RequestingSocket, RequestId, true,
-                               TEXT("Level imported (duplicated)"), nullptr);
+                               TEXT("Level imported (copied)"), Result);
       } else {
-        SendAutomationResponse(RequestingSocket, RequestId, false,
-                               TEXT("Failed to duplicate level asset"), nullptr,
-                               TEXT("IMPORT_FAILED"));
+        SendAutomationResponse(RequestingSocket, RequestId, false, ErrorMessage,
+                               Result,
+                               ErrorCode.IsEmpty() ? TEXT("IMPORT_FAILED") : ErrorCode);
       }
       return true;
     }
@@ -1863,6 +2725,24 @@ TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
       LongPackageName = LongPackageName.Left(ObjectPathDelimiter);
     }
 
+    FString DeleteMapFilename;
+    FString DeleteErrorMessage;
+    FString DeleteErrorCode;
+    if (!TryGetAbsoluteMapFilename(LongPackageName, DeleteMapFilename) ||
+        !ValidateWritableGameMapPath(LongPackageName, DeleteMapFilename,
+                                     TEXT("Delete target"),
+                                     DeleteErrorMessage, DeleteErrorCode)) {
+      if (DeleteErrorMessage.IsEmpty()) {
+        DeleteErrorMessage = FString::Printf(
+            TEXT("Could not convert delete target level to filename: %s"),
+            *LongPackageName);
+        DeleteErrorCode = TEXT("INVALID_LEVEL_PATH");
+      }
+      SendAutomationResponse(RequestingSocket, RequestId, false,
+                             DeleteErrorMessage, nullptr, DeleteErrorCode);
+      return true;
+    }
+
     const FString AssetName = FPaths::GetBaseFilename(LongPackageName);
     const FString ObjectPath = AssetName.IsEmpty()
                                    ? LongPackageName
@@ -1985,6 +2865,25 @@ TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
     const bool bPackageExisted = FPackageName::DoesPackageExist(LongPackageName);
     bool bDeletedViaFileFallback = false;
     bool bDeletedBuiltData = false;
+    bool bBuiltDataExists = false;
+    bool bExternalSidecarDeleteAttempted = false;
+    bool bExternalSidecarDeleteFailed = false;
+    bool bExternalActorsExists = false;
+    bool bDeletedExternalActors = false;
+    bool bExternalObjectsExists = false;
+    bool bDeletedExternalObjects = false;
+    FString ExternalDeleteErrorMessage;
+    FString ExternalDeleteErrorCode;
+
+    const FString BuiltDataPackagePath = LongPackageName + TEXT("_BuiltData");
+    FString BuiltDataFilename;
+    FString AbsoluteBuiltDataFilename;
+    if (FPackageName::TryConvertLongPackageNameToFilename(
+            BuiltDataPackagePath, BuiltDataFilename, FPackageName::GetAssetPackageExtension())) {
+      AbsoluteBuiltDataFilename = FPaths::ConvertRelativePathToFull(BuiltDataFilename);
+      FPaths::NormalizeFilename(AbsoluteBuiltDataFilename);
+      bBuiltDataExists = FileManager.FileExists(*AbsoluteBuiltDataFilename);
+    }
 
     if (!bCurrentWorldMatchesTarget && !bPackageStillLoaded && bMapFileExisted) {
       UE_LOG(LogMcpAutomationBridgeSubsystem, Log,
@@ -1992,14 +2891,36 @@ TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
              *AbsoluteMapFilename);
       bDeletedViaFileFallback = FileManager.Delete(*AbsoluteMapFilename, false, true, true);
 
-      const FString BuiltDataPackagePath = LongPackageName + TEXT("_BuiltData");
-      FString BuiltDataFilename;
-      if (FPackageName::TryConvertLongPackageNameToFilename(
-              BuiltDataPackagePath, BuiltDataFilename, FPackageName::GetAssetPackageExtension())) {
-        FString AbsoluteBuiltDataFilename = FPaths::ConvertRelativePathToFull(BuiltDataFilename);
-        FPaths::NormalizeFilename(AbsoluteBuiltDataFilename);
-        if (FileManager.FileExists(*AbsoluteBuiltDataFilename)) {
-          bDeletedBuiltData = FileManager.Delete(*AbsoluteBuiltDataFilename, false, true, true);
+      if (bBuiltDataExists) {
+        bDeletedBuiltData = FileManager.Delete(*AbsoluteBuiltDataFilename, false, true, true);
+      }
+    }
+
+    if (!bCurrentWorldMatchesTarget && !bPackageStillLoaded &&
+        (!bMapFileExisted || bDeletedViaFileFallback)) {
+      bExternalSidecarDeleteAttempted = true;
+
+      FString ActorsErrorMessage;
+      FString ActorsErrorCode;
+      if (!DeleteExternalPackageDirectory(LongPackageName, TEXT("__ExternalActors__"),
+                                          bExternalActorsExists,
+                                          bDeletedExternalActors,
+                                          ActorsErrorMessage, ActorsErrorCode)) {
+        bExternalSidecarDeleteFailed = true;
+        ExternalDeleteErrorMessage = ActorsErrorMessage;
+        ExternalDeleteErrorCode = ActorsErrorCode;
+      }
+
+      FString ObjectsErrorMessage;
+      FString ObjectsErrorCode;
+      if (!DeleteExternalPackageDirectory(LongPackageName, TEXT("__ExternalObjects__"),
+                                          bExternalObjectsExists,
+                                          bDeletedExternalObjects,
+                                          ObjectsErrorMessage, ObjectsErrorCode)) {
+        bExternalSidecarDeleteFailed = true;
+        if (ExternalDeleteErrorMessage.IsEmpty()) {
+          ExternalDeleteErrorMessage = ObjectsErrorMessage;
+          ExternalDeleteErrorCode = ObjectsErrorCode;
         }
       }
     }
@@ -2008,16 +2929,37 @@ TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
 
     const bool bMapFileStillExists = bHasMapFilename && FileManager.FileExists(*AbsoluteMapFilename);
     const bool bPackageStillExists = FPackageName::DoesPackageExist(LongPackageName);
+    const bool bRemovedBuiltData = !bBuiltDataExists || bDeletedBuiltData;
+    const bool bRemovedExternalActors = !bExternalActorsExists || bDeletedExternalActors;
+    const bool bRemovedExternalObjects = !bExternalObjectsExists || bDeletedExternalObjects;
     const bool bDeleted = (bDeletedViaFileFallback && !bMapFileStillExists) ||
                           (!bMapFileExisted && !bPackageExisted && !bPackageStillLoaded);
+    const bool bDeletedWithSidecars = bDeleted && !bExternalSidecarDeleteFailed &&
+                                       bRemovedBuiltData &&
+                                       bRemovedExternalActors && bRemovedExternalObjects;
 
     TSharedPtr<FJsonObject> Result = McpHandlerUtils::CreateResultObject();
     Result->SetStringField(TEXT("levelPath"), LongPackageName);
     Result->SetStringField(TEXT("objectPath"), ObjectPath);
     Result->SetStringField(TEXT("mapFilename"), AbsoluteMapFilename);
-    Result->SetBoolField(TEXT("deleted"), bDeleted);
+    Result->SetBoolField(TEXT("deleted"), bDeletedWithSidecars);
+    Result->SetBoolField(TEXT("deletedMapFile"), bDeletedViaFileFallback);
+    Result->SetBoolField(TEXT("mapDeletedOrAlreadyAbsent"), bDeleted);
     Result->SetBoolField(TEXT("deletedViaFileFallback"), bDeletedViaFileFallback);
+    Result->SetBoolField(TEXT("builtDataExists"), bBuiltDataExists);
     Result->SetBoolField(TEXT("deletedBuiltData"), bDeletedBuiltData);
+    Result->SetBoolField(TEXT("externalSidecarDeleteAttempted"), bExternalSidecarDeleteAttempted);
+    Result->SetBoolField(TEXT("externalSidecarDeleteFailed"), bExternalSidecarDeleteFailed);
+    Result->SetBoolField(TEXT("externalActorsExists"), bExternalActorsExists);
+    Result->SetBoolField(TEXT("deletedExternalActors"), bDeletedExternalActors);
+    Result->SetBoolField(TEXT("externalObjectsExists"), bExternalObjectsExists);
+    Result->SetBoolField(TEXT("deletedExternalObjects"), bDeletedExternalObjects);
+    if (!ExternalDeleteErrorMessage.IsEmpty()) {
+      Result->SetStringField(TEXT("externalDeleteError"), ExternalDeleteErrorMessage);
+    }
+    if (!ExternalDeleteErrorCode.IsEmpty()) {
+      Result->SetStringField(TEXT("externalDeleteErrorCode"), ExternalDeleteErrorCode);
+    }
     Result->SetBoolField(TEXT("editorDeletionSkippedForMap"), true);
     Result->SetBoolField(TEXT("deleteAssetFailed"), false);
     Result->SetBoolField(TEXT("wasLoaded"), bWasLoaded);
@@ -2029,7 +2971,13 @@ TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
     Result->SetBoolField(TEXT("fileExistsAfter"), bMapFileStillExists);
     Result->SetBoolField(TEXT("packageExistsAfter"), bPackageStillExists);
 
-    if (bDeleted) {
+    if (bExternalSidecarDeleteFailed) {
+      SendAutomationResponse(RequestingSocket, RequestId, false,
+                             ExternalDeleteErrorMessage, Result,
+                             ExternalDeleteErrorCode.IsEmpty()
+                                 ? TEXT("SOURCE_EXTERNAL_DELETE_FAILED")
+                                 : ExternalDeleteErrorCode);
+    } else if (bDeletedWithSidecars) {
       SendAutomationResponse(RequestingSocket, RequestId, true,
                              FString::Printf(TEXT("Level file deleted: %s"), *LongPackageName), Result);
     } else if (bCurrentWorldMatchesTarget || bPackageStillLoaded) {
@@ -2053,6 +3001,13 @@ TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
     FString DestinationPath;
     if (Payload.IsValid())
       Payload->TryGetStringField(TEXT("destinationPath"), DestinationPath);
+    if (DestinationPath.IsEmpty() && Payload.IsValid()) {
+      FString NewName;
+      Payload->TryGetStringField(TEXT("newName"), NewName);
+      if (!NewName.IsEmpty()) {
+        DestinationPath = FPaths::GetPath(NormalizeLevelPackagePath(SourcePath)) / NewName;
+      }
+    }
 
     if (SourcePath.IsEmpty()) {
       SendAutomationResponse(RequestingSocket, RequestId, false,
@@ -2082,38 +3037,96 @@ TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
                              nullptr, TEXT("SECURITY_VIOLATION"));
       return true;
     }
-    SourcePath = SanitizedSource;
-    DestinationPath = SanitizedDest;
+    SourcePath = NormalizeLevelPackagePath(SanitizedSource);
+    DestinationPath = NormalizeLevelPackagePath(SanitizedDest);
 
-    // Use DuplicateAsset + DeleteAsset to rename (avoids "Find/Replace"
-    // modal dialog that auto-cancels during automation)
-    // Wrap in a transaction for atomic undo/redo support
-    FScopedTransaction Transaction(FText::FromString(TEXT("Rename Level")));
-    
-    TObjectPtr<UObject> DuplicatedForRename = UEditorAssetLibrary::DuplicateAsset(SourcePath, DestinationPath);
-    bool bRenamed = (DuplicatedForRename != nullptr);
-    if (bRenamed) {
-      bRenamed = UEditorAssetLibrary::DeleteAsset(SourcePath);
-      if (!bRenamed) {
-        // Failed to delete original — clean up the duplicate to avoid leaving artifacts
-        UE_LOG(LogTemp, Warning, TEXT("rename_level: Failed to delete source '%s', cleaning up duplicate '%s'"), *SourcePath, *DestinationPath);
-        UEditorAssetLibrary::DeleteAsset(DestinationPath);
-        // Transaction will be canceled since we're returning false
-      }
-    } else {
-      UE_LOG(LogTemp, Warning, TEXT("rename_level: Failed to duplicate '%s' to '%s'"), *SourcePath, *DestinationPath);
+    if (IsCurrentEditorWorldPackage(SourcePath)) {
+      SendAutomationResponse(RequestingSocket, RequestId, false,
+                             FString::Printf(TEXT("Cannot rename the current loaded level: %s"), *SourcePath),
+                             nullptr, TEXT("LEVEL_LOADED"));
+      return true;
     }
+
+    bool bOverwrite = false;
+    if (Payload.IsValid()) {
+      Payload->TryGetBoolField(TEXT("overwrite"), bOverwrite);
+    }
+
+    TSharedPtr<FJsonObject> Result;
+    FString ErrorMessage;
+    FString ErrorCode;
+    const bool bCopied = CopyLevelMapPackageFile(SourcePath, DestinationPath, bOverwrite, Result, ErrorMessage, ErrorCode);
+    if (!bCopied) {
+      SendAutomationResponse(RequestingSocket, RequestId, false, ErrorMessage, Result, ErrorCode);
+      return true;
+    }
+
+    FString SourceFilename;
+    TryGetAbsoluteMapFilename(SourcePath, SourceFilename);
+    bool bDeletedSource = false;
+    if (!SourceFilename.IsEmpty()) {
+      bDeletedSource = IFileManager::Get().Delete(*SourceFilename, false, true, true);
+    }
+
+    const FString SourceBuiltDataPackagePath = SourcePath + TEXT("_BuiltData");
+    FString SourceBuiltDataFilename;
+    bool bSourceBuiltDataExists = false;
+    bool bDeletedBuiltData = false;
+    if (FPackageName::TryConvertLongPackageNameToFilename(
+            SourceBuiltDataPackagePath, SourceBuiltDataFilename, FPackageName::GetAssetPackageExtension())) {
+      SourceBuiltDataFilename = FPaths::ConvertRelativePathToFull(SourceBuiltDataFilename);
+      FPaths::NormalizeFilename(SourceBuiltDataFilename);
+      bSourceBuiltDataExists = IFileManager::Get().FileExists(*SourceBuiltDataFilename);
+      if (bSourceBuiltDataExists) {
+        bDeletedBuiltData = IFileManager::Get().Delete(*SourceBuiltDataFilename, false, true, true);
+      }
+    }
+
+    bool bSourceExternalActorsExists = false;
+    bool bDeletedSourceExternalActors = false;
+    bool bSourceExternalObjectsExists = false;
+    bool bDeletedSourceExternalObjects = false;
+    if (bDeletedSource) {
+      if (!DeleteExternalPackageDirectory(SourcePath, TEXT("__ExternalActors__"),
+                                          bSourceExternalActorsExists,
+                                          bDeletedSourceExternalActors,
+                                          ErrorMessage, ErrorCode) ||
+          !DeleteExternalPackageDirectory(SourcePath, TEXT("__ExternalObjects__"),
+                                          bSourceExternalObjectsExists,
+                                          bDeletedSourceExternalObjects,
+                                          ErrorMessage, ErrorCode)) {
+        Result->SetStringField(TEXT("externalDeleteError"), ErrorMessage);
+        SendAutomationResponse(RequestingSocket, RequestId, false, ErrorMessage,
+                               Result, ErrorCode);
+        return true;
+      }
+    }
+
+    ScanLevelPackagePath(SourcePath, SourceFilename);
+    const bool bSourceFileExistsAfter = !SourceFilename.IsEmpty() && IFileManager::Get().FileExists(*SourceFilename);
+    const bool bRemovedSourceBuiltData = !bSourceBuiltDataExists || bDeletedBuiltData;
+    const bool bRemovedSourceExternalActors = !bSourceExternalActorsExists || bDeletedSourceExternalActors;
+    const bool bRemovedSourceExternalObjects = !bSourceExternalObjectsExists || bDeletedSourceExternalObjects;
+    const bool bRenamed = bDeletedSource && !bSourceFileExistsAfter &&
+        bRemovedSourceBuiltData && bRemovedSourceExternalActors &&
+        bRemovedSourceExternalObjects;
+    Result->SetBoolField(TEXT("renamed"), bRenamed);
+    Result->SetBoolField(TEXT("deletedSourceFile"), bDeletedSource);
+    Result->SetBoolField(TEXT("sourceBuiltDataExists"), bSourceBuiltDataExists);
+    Result->SetBoolField(TEXT("deletedSourceBuiltData"), bDeletedBuiltData);
+    Result->SetBoolField(TEXT("sourceExternalActorsExists"), bSourceExternalActorsExists);
+    Result->SetBoolField(TEXT("deletedSourceExternalActors"), bDeletedSourceExternalActors);
+    Result->SetBoolField(TEXT("sourceExternalObjectsExists"), bSourceExternalObjectsExists);
+    Result->SetBoolField(TEXT("deletedSourceExternalObjects"), bDeletedSourceExternalObjects);
+    Result->SetBoolField(TEXT("sourceFileExistsAfter"), bSourceFileExistsAfter);
+
     if (bRenamed) {
-      TSharedPtr<FJsonObject> Result = McpHandlerUtils::CreateResultObject();
-      Result->SetStringField(TEXT("sourcePath"), SourcePath);
-      Result->SetStringField(TEXT("destinationPath"), DestinationPath);
-      Result->SetBoolField(TEXT("renamed"), true);
       SendAutomationResponse(RequestingSocket, RequestId, true,
                              FString::Printf(TEXT("Level renamed to: %s"), *DestinationPath), Result);
     } else {
       SendAutomationResponse(RequestingSocket, RequestId, false,
-                             FString::Printf(TEXT("Failed to rename level: %s"), *SourcePath),
-                             nullptr, TEXT("RENAME_FAILED"));
+                             FString::Printf(TEXT("Failed to delete source level after copy: %s"), *SourcePath),
+                             Result, TEXT("SOURCE_DELETE_FAILED"));
     }
     return true;
   }
@@ -2156,44 +3169,25 @@ TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
                              nullptr, TEXT("SECURITY_VIOLATION"));
       return true;
     }
-    SourcePath = SanitizedSource;
-    DestinationPath = SanitizedDest;
+    SourcePath = NormalizeLevelPackagePath(SanitizedSource);
+    DestinationPath = NormalizeLevelPackagePath(SanitizedDest);
 
-    // Validate source exists before duplicating
-    if (!FPackageName::DoesPackageExist(SourcePath)) {
-      // Also verify on disk as fallback
-      FString Filename;
-      bool bFileFound = false;
-      if (FPackageName::TryConvertLongPackageNameToFilename(
-              SourcePath, Filename, FPackageName::GetMapPackageExtension())) {
-        bFileFound = IFileManager::Get().FileExists(*Filename);
-      }
-      if (!bFileFound) {
-        SendAutomationResponse(RequestingSocket, RequestId, false,
-                               FString::Printf(TEXT("Source level not found: %s"), *SourcePath),
-                               nullptr, TEXT("SOURCE_NOT_FOUND"));
-        return true;
-      }
+    bool bOverwrite = false;
+    if (Payload.IsValid()) {
+      Payload->TryGetBoolField(TEXT("overwrite"), bOverwrite);
     }
 
-    // If destination already exists, delete it first so duplicate succeeds
-    if (UEditorAssetLibrary::DoesAssetExist(DestinationPath)) {
-      UEditorAssetLibrary::DeleteAsset(DestinationPath);
-    }
-
-    // Use UEditorAssetLibrary to duplicate the level asset
-    UObject* DuplicatedAsset = UEditorAssetLibrary::DuplicateAsset(SourcePath, DestinationPath);
-    if (DuplicatedAsset != nullptr) {
-      TSharedPtr<FJsonObject> Result = McpHandlerUtils::CreateResultObject();
-      Result->SetStringField(TEXT("sourcePath"), SourcePath);
-      Result->SetStringField(TEXT("destinationPath"), DestinationPath);
+    TSharedPtr<FJsonObject> Result;
+    FString ErrorMessage;
+    FString ErrorCode;
+    const bool bDuplicated = CopyLevelMapPackageFile(SourcePath, DestinationPath, bOverwrite, Result, ErrorMessage, ErrorCode);
+    if (bDuplicated) {
       Result->SetBoolField(TEXT("duplicated"), true);
       SendAutomationResponse(RequestingSocket, RequestId, true,
                              FString::Printf(TEXT("Level duplicated to: %s"), *DestinationPath), Result);
     } else {
-      SendAutomationResponse(RequestingSocket, RequestId, false,
-                             FString::Printf(TEXT("Failed to duplicate level: %s"), *SourcePath),
-                             nullptr, TEXT("DUPLICATE_FAILED"));
+      SendAutomationResponse(RequestingSocket, RequestId, false, ErrorMessage, Result,
+                             ErrorCode.IsEmpty() ? TEXT("DUPLICATE_FAILED") : ErrorCode);
     }
     return true;
   }

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_LevelHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_LevelHandlers.cpp
@@ -378,7 +378,9 @@ bool RestoreFileBackup(const FString& Filename, const FString& BackupFilename) {
   IFileManager::Get().Delete(*Filename, false, true, true);
   IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
   const bool bRestored = PlatformFile.CopyFile(*Filename, *BackupFilename);
-  IFileManager::Get().Delete(*BackupFilename, false, true, true);
+  if (bRestored) {
+    IFileManager::Get().Delete(*BackupFilename, false, true, true);
+  }
   return bRestored;
 }
 
@@ -432,7 +434,9 @@ bool RestoreDirectoryBackup(const FString& Directory, const FString& BackupDirec
   IFileManager::Get().MakeDirectory(*FPaths::GetPath(Directory), true);
   IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
   const bool bRestored = PlatformFile.CopyDirectoryTree(*Directory, *BackupDirectory, false);
-  IFileManager::Get().DeleteDirectory(*BackupDirectory, false, true);
+  if (bRestored) {
+    IFileManager::Get().DeleteDirectory(*BackupDirectory, false, true);
+  }
   return bRestored;
 }
 
@@ -629,13 +633,50 @@ bool CopyLevelMapPackageFile(const FString& SourcePackagePath,
   FString DestinationBuiltDataBackup;
   FString DestinationExternalActorsBackup;
   FString DestinationExternalObjectsBackup;
-  auto RestoreDestinationBackups = [&]() {
-    RestoreFileBackup(DestinationFilename, DestinationMapBackup);
-    RestoreFileBackup(DestinationBuiltDataFilename, DestinationBuiltDataBackup);
-    RestoreDirectoryBackup(ExternalActorsPlan.DestinationDirectory, DestinationExternalActorsBackup);
-    RestoreDirectoryBackup(ExternalObjectsPlan.DestinationDirectory, DestinationExternalObjectsBackup);
+  auto AppendRollbackFailure = [](FString& RollbackError, const FString& Detail) {
+    if (!RollbackError.IsEmpty()) {
+      RollbackError += TEXT("; ");
+    }
+    RollbackError += Detail;
   };
-  auto RollbackCopiedDestinationArtifacts = [&]() {
+  auto RestoreDestinationBackups = [&](FString& RollbackError) {
+    bool bRollbackSucceeded = true;
+    if (!RestoreFileBackup(DestinationFilename, DestinationMapBackup)) {
+      bRollbackSucceeded = false;
+      AppendRollbackFailure(RollbackError,
+                            FString::Printf(TEXT("failed to restore destination level backup: %s"),
+                                            *DestinationMapBackup));
+    }
+    if (!RestoreFileBackup(DestinationBuiltDataFilename, DestinationBuiltDataBackup)) {
+      bRollbackSucceeded = false;
+      AppendRollbackFailure(RollbackError,
+                            FString::Printf(TEXT("failed to restore destination built data backup: %s"),
+                                            *DestinationBuiltDataBackup));
+    }
+    if (!RestoreDirectoryBackup(ExternalActorsPlan.DestinationDirectory, DestinationExternalActorsBackup)) {
+      bRollbackSucceeded = false;
+      AppendRollbackFailure(RollbackError,
+                            FString::Printf(TEXT("failed to restore destination external actors backup: %s"),
+                                            *DestinationExternalActorsBackup));
+    }
+    if (!RestoreDirectoryBackup(ExternalObjectsPlan.DestinationDirectory, DestinationExternalObjectsBackup)) {
+      bRollbackSucceeded = false;
+      AppendRollbackFailure(RollbackError,
+                            FString::Printf(TEXT("failed to restore destination external objects backup: %s"),
+                                            *DestinationExternalObjectsBackup));
+    }
+    return bRollbackSucceeded;
+  };
+  auto RecordRollbackResult = [&](bool bRollbackSucceeded, const FString& RollbackError) {
+    if (!Result.IsValid()) {
+      Result = McpHandlerUtils::CreateResultObject();
+    }
+    Result->SetBoolField(TEXT("rollbackSucceeded"), bRollbackSucceeded);
+    if (!RollbackError.IsEmpty()) {
+      Result->SetStringField(TEXT("rollbackError"), RollbackError);
+    }
+  };
+  auto RollbackCopiedDestinationArtifacts = [&](FString& RollbackError) {
     if (DestinationMapBackup.IsEmpty()) {
       if (!DestinationFilename.IsEmpty()) {
         FileManager.Delete(*DestinationFilename, false, true, true);
@@ -656,7 +697,9 @@ bool CopyLevelMapPackageFile(const FString& SourcePackagePath,
         FileManager.DeleteDirectory(*ExternalObjectsPlan.DestinationDirectory, false, true);
       }
     }
-    RestoreDestinationBackups();
+    const bool bRollbackSucceeded = RestoreDestinationBackups(RollbackError);
+    RecordRollbackResult(bRollbackSucceeded, RollbackError);
+    return bRollbackSucceeded;
   };
   auto DeleteDestinationBackups = [&]() {
     DeleteFileBackup(DestinationMapBackup);
@@ -684,7 +727,13 @@ bool CopyLevelMapPackageFile(const FString& SourcePackagePath,
                                    ExternalObjectsPlan.bDeletedDestination,
                                    DestinationExternalObjectsBackup,
                                    ErrorMessage, ErrorCode)) {
-    RestoreDestinationBackups();
+    FString RollbackError;
+    const bool bRollbackSucceeded = RestoreDestinationBackups(RollbackError);
+    RecordRollbackResult(bRollbackSucceeded, RollbackError);
+    if (!bRollbackSucceeded) {
+      ErrorMessage += FString::Printf(TEXT(" Rollback failed: %s"), *RollbackError);
+      ErrorCode = TEXT("ROLLBACK_FAILED");
+    }
     return false;
   }
 
@@ -696,10 +745,14 @@ bool CopyLevelMapPackageFile(const FString& SourcePackagePath,
   IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
   const bool bCopiedMap = PlatformFile.CopyFile(*DestinationFilename, *SourceFilename);
   if (!bCopiedMap) {
-    RollbackCopiedDestinationArtifacts();
+    FString RollbackError;
+    const bool bRollbackSucceeded = RollbackCopiedDestinationArtifacts(RollbackError);
     ErrorMessage = FString::Printf(TEXT("Failed to copy level file from %s to %s"),
                                    *SourcePackagePath, *DestinationPackagePath);
-    ErrorCode = TEXT("COPY_FAILED");
+    if (!bRollbackSucceeded) {
+      ErrorMessage += FString::Printf(TEXT(" Rollback failed: %s"), *RollbackError);
+    }
+    ErrorCode = bRollbackSucceeded ? TEXT("COPY_FAILED") : TEXT("ROLLBACK_FAILED");
     return false;
   }
 
@@ -708,11 +761,15 @@ bool CopyLevelMapPackageFile(const FString& SourcePackagePath,
     FileManager.MakeDirectory(*FPaths::GetPath(DestinationBuiltDataFilename), true);
     bCopiedBuiltData = PlatformFile.CopyFile(*DestinationBuiltDataFilename, *SourceBuiltDataFilename);
     if (!bCopiedBuiltData) {
-      RollbackCopiedDestinationArtifacts();
+      FString RollbackError;
+      const bool bRollbackSucceeded = RollbackCopiedDestinationArtifacts(RollbackError);
       ErrorMessage = FString::Printf(
           TEXT("Failed to copy built data from %s to %s"),
           *SourceBuiltDataPackagePath, *DestinationBuiltDataPackagePath);
-      ErrorCode = TEXT("COPY_FAILED");
+      if (!bRollbackSucceeded) {
+        ErrorMessage += FString::Printf(TEXT(" Rollback failed: %s"), *RollbackError);
+      }
+      ErrorCode = bRollbackSucceeded ? TEXT("COPY_FAILED") : TEXT("ROLLBACK_FAILED");
       return false;
     }
   }
@@ -724,12 +781,16 @@ bool CopyLevelMapPackageFile(const FString& SourcePackagePath,
         *ExternalActorsPlan.DestinationDirectory,
         *ExternalActorsPlan.SourceDirectory, false);
     if (!bCopiedExternalActors) {
-      RollbackCopiedDestinationArtifacts();
+      FString RollbackError;
+      const bool bRollbackSucceeded = RollbackCopiedDestinationArtifacts(RollbackError);
       ErrorMessage = FString::Printf(
           TEXT("Failed to copy external actors from %s to %s"),
           *ExternalActorsPlan.SourceDirectory,
           *ExternalActorsPlan.DestinationDirectory);
-      ErrorCode = TEXT("COPY_FAILED");
+      if (!bRollbackSucceeded) {
+        ErrorMessage += FString::Printf(TEXT(" Rollback failed: %s"), *RollbackError);
+      }
+      ErrorCode = bRollbackSucceeded ? TEXT("COPY_FAILED") : TEXT("ROLLBACK_FAILED");
       return false;
     }
   }
@@ -742,12 +803,16 @@ bool CopyLevelMapPackageFile(const FString& SourcePackagePath,
         *ExternalObjectsPlan.DestinationDirectory,
         *ExternalObjectsPlan.SourceDirectory, false);
     if (!bCopiedExternalObjects) {
-      RollbackCopiedDestinationArtifacts();
+      FString RollbackError;
+      const bool bRollbackSucceeded = RollbackCopiedDestinationArtifacts(RollbackError);
       ErrorMessage = FString::Printf(
           TEXT("Failed to copy external objects from %s to %s"),
           *ExternalObjectsPlan.SourceDirectory,
           *ExternalObjectsPlan.DestinationDirectory);
-      ErrorCode = TEXT("COPY_FAILED");
+      if (!bRollbackSucceeded) {
+        ErrorMessage += FString::Printf(TEXT(" Rollback failed: %s"), *RollbackError);
+      }
+      ErrorCode = bRollbackSucceeded ? TEXT("COPY_FAILED") : TEXT("ROLLBACK_FAILED");
       return false;
     }
   }
@@ -1097,6 +1162,8 @@ bool UMcpAutomationBridgeSubsystem::HandleLevelAction(
       // Map to Open command
       FString LevelPath;
       Payload->TryGetStringField(TEXT("levelPath"), LevelPath);
+      bool bSaveDirtyPackages = false;
+      Payload->TryGetBoolField(TEXT("saveDirtyPackages"), bSaveDirtyPackages);
 
       // Determine invalid characters for checks
       if (LevelPath.IsEmpty()) {
@@ -1218,6 +1285,21 @@ bool UMcpAutomationBridgeSubsystem::HandleLevelAction(
       int32 DirtyContentPackagesAfterSave = 0;
       int32 FailedDirtyPackageSaves = 0;
       if (FApp::IsUnattended() || IsRunningCommandlet() || FParse::Param(FCommandLine::Get(), TEXT("nullrhi"))) {
+        CountBlockingDirtyPackages(DirtyWorldPackagesBeforeLoad, DirtyContentPackagesBeforeLoad);
+        if (DirtyWorldPackagesBeforeLoad + DirtyContentPackagesBeforeLoad > 0 && !bSaveDirtyPackages) {
+          TSharedPtr<FJsonObject> ErrorDetails = McpHandlerUtils::CreateResultObject();
+          ErrorDetails->SetNumberField(TEXT("dirtyWorldPackages"), DirtyWorldPackagesBeforeLoad);
+          ErrorDetails->SetNumberField(TEXT("dirtyContentPackages"), DirtyContentPackagesBeforeLoad);
+          ErrorDetails->SetBoolField(TEXT("saveDirtyPackages"), bSaveDirtyPackages);
+          ErrorDetails->SetStringField(TEXT("levelPath"), LevelPath);
+          SendAutomationResponse(
+              RequestingSocket, RequestId, false,
+              TEXT("Cannot load a level in unattended/headless mode while packages are dirty. Pass saveDirtyPackages=true to save them before loading."),
+              ErrorDetails, TEXT("DIRTY_PACKAGES"));
+          return true;
+        }
+
+        if (bSaveDirtyPackages) {
         bSavedDirtyPackagesBeforeLoad = SaveBlockingDirtyPackagesForLevelLoad(
             DirtyWorldPackagesBeforeLoad, DirtyContentPackagesBeforeLoad,
             DirtyWorldPackagesAfterSave, DirtyContentPackagesAfterSave,
@@ -1236,6 +1318,7 @@ bool UMcpAutomationBridgeSubsystem::HandleLevelAction(
               TEXT("Cannot load a level in unattended/headless mode while packages remain dirty after non-interactive save."),
               ErrorDetails, TEXT("DIRTY_PACKAGES"));
           return true;
+        }
         }
       }
 
@@ -1260,6 +1343,7 @@ bool UMcpAutomationBridgeSubsystem::HandleLevelAction(
         TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
         Resp->SetStringField(TEXT("requestedPath"), LevelPath);
         Resp->SetStringField(TEXT("loadedPath"), ExpectedLoadedPath);
+        Resp->SetBoolField(TEXT("saveDirtyPackages"), bSaveDirtyPackages);
         Resp->SetBoolField(TEXT("savedDirtyPackagesBeforeLoad"), bSavedDirtyPackagesBeforeLoad);
         Resp->SetNumberField(TEXT("dirtyWorldPackagesBeforeLoad"), DirtyWorldPackagesBeforeLoad);
         Resp->SetNumberField(TEXT("dirtyContentPackagesBeforeLoad"), DirtyContentPackagesBeforeLoad);

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_LevelStructureHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_LevelStructureHandlers.cpp
@@ -231,6 +231,7 @@ static bool HandleCreateLevel(
     bool bCreateWorldPartition = GetJsonBoolField(Payload, TEXT("bCreateWorldPartition"), false);
     bool bUseExternalActors = GetJsonBoolField(Payload, TEXT("bUseExternalActors"), false);
     bool bSave = GetJsonBoolField(Payload, TEXT("save"), true);
+    bool bLoadAfterCreate = GetJsonBoolField(Payload, TEXT("loadAfterCreate"), false);
 
     // CRITICAL: When creating a World Partition level, OFPA (External Actors) should be enabled
     // for data layer support. If bCreateWorldPartition is true but bUseExternalActors is not specified,
@@ -277,6 +278,19 @@ static bool HandleCreateLevel(
             Result->SetStringField(TEXT("levelPath"), FullPath);
             Result->SetBoolField(TEXT("exists"), true);
             Result->SetBoolField(TEXT("alreadyExisted"), true);
+            if (bLoadAfterCreate) {
+                const bool bLoaded = McpSafeLoadMap(FullPath, true);
+                Result->SetBoolField(TEXT("loaded"), bLoaded);
+                if (GEditor && GEditor->GetEditorWorldContext().World()) {
+                    Result->SetStringField(TEXT("currentLevelPath"), GEditor->GetEditorWorldContext().World()->GetOutermost()->GetName());
+                }
+                if (!bLoaded) {
+                    Subsystem->SendAutomationResponse(Socket, RequestId, false,
+                        FString::Printf(TEXT("Level exists but could not be loaded: %s"), *FullPath),
+                        Result, TEXT("LOAD_FAILED"));
+                    return true;
+                }
+            }
             Subsystem->SendAutomationResponse(Socket, RequestId, true,
                 FString::Printf(TEXT("Level already exists: %s"), *FullPath),
                 Result, FString());
@@ -292,6 +306,19 @@ static bool HandleCreateLevel(
         Result->SetStringField(TEXT("levelPath"), FullPath);
         Result->SetBoolField(TEXT("exists"), true);
         Result->SetBoolField(TEXT("alreadyExisted"), true);
+        if (bLoadAfterCreate) {
+            const bool bLoaded = McpSafeLoadMap(FullPath, true);
+            Result->SetBoolField(TEXT("loaded"), bLoaded);
+            if (GEditor && GEditor->GetEditorWorldContext().World()) {
+                Result->SetStringField(TEXT("currentLevelPath"), GEditor->GetEditorWorldContext().World()->GetOutermost()->GetName());
+            }
+            if (!bLoaded) {
+                Subsystem->SendAutomationResponse(Socket, RequestId, false,
+                    FString::Printf(TEXT("Level exists but could not be loaded: %s"), *FullPath),
+                    Result, TEXT("LOAD_FAILED"));
+                return true;
+            }
+        }
         Subsystem->SendAutomationResponse(Socket, RequestId, true,
             FString::Printf(TEXT("Level already exists: %s"), *FullPath),
             Result, FString());
@@ -513,6 +540,23 @@ static bool HandleCreateLevel(
         FlushRenderingCommands();
         
         UE_LOG(LogMcpLevelStructureHandlers, Log, TEXT("HandleCreateLevel: World cleaned up from memory: %s"), *FullPath);
+    }
+
+    if (bLoadAfterCreate)
+    {
+        const bool bLoaded = McpSafeLoadMap(FullPath, true);
+        ResponseJson->SetBoolField(TEXT("loaded"), bLoaded);
+        if (GEditor && GEditor->GetEditorWorldContext().World())
+        {
+            ResponseJson->SetStringField(TEXT("currentLevelPath"), GEditor->GetEditorWorldContext().World()->GetOutermost()->GetName());
+        }
+        if (!bLoaded)
+        {
+            Subsystem->SendAutomationResponse(Socket, RequestId, false,
+                FString::Printf(TEXT("Level created but could not be loaded: %s"), *FullPath),
+                ResponseJson, TEXT("LOAD_FAILED"));
+            return true;
+        }
     }
 
     FString Message = FString::Printf(TEXT("Created level: %s"), *FullPath);

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_SystemControlHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_SystemControlHandlers.cpp
@@ -40,6 +40,7 @@ bool UMcpAutomationBridgeSubsystem::HandleSystemControlAction(
       !Lower.StartsWith(TEXT("test_progress")) &&
       !Lower.StartsWith(TEXT("test_stale")) &&
       Lower != TEXT("export_asset") &&
+      Lower != TEXT("start_session") &&
       Lower != TEXT("execute_python")) {
     return false; // Not handled by this function
   }
@@ -50,6 +51,10 @@ bool UMcpAutomationBridgeSubsystem::HandleSystemControlAction(
                         TEXT("System control payload missing"),
                         TEXT("INVALID_PAYLOAD"));
     return true;
+  }
+
+  if (Lower == TEXT("start_session")) {
+    return HandleInsightsAction(RequestId, TEXT("manage_insights"), Payload, RequestingSocket);
   }
 
   if (Lower == TEXT("run_ubt")) {
@@ -744,6 +749,8 @@ bool UMcpAutomationBridgeSubsystem::HandleSystemControlAction(
       World = GEngine->GetWorldContexts()[0].World();
     }
 
+    SendProgressUpdate(RequestId, 0.0f, TEXT("Executing Python script"), true, CurrentRequestOrigin);
+
     // Execute via py console command with execution time tracking
     static constexpr double MaxPythonExecutionSeconds = 60.0;
     FString PyCommand = FString::Printf(TEXT("py \"%s\""), *ScriptPath);
@@ -753,6 +760,7 @@ bool UMcpAutomationBridgeSubsystem::HandleSystemControlAction(
       bExecHandled = GEngine->Exec(World, *PyCommand);
     }
     double ExecElapsed = FPlatformTime::Seconds() - ExecStartTime;
+    SendProgressUpdate(RequestId, 90.0f, TEXT("Collecting Python output"), true, CurrentRequestOrigin);
     if (ExecElapsed > MaxPythonExecutionSeconds) {
       UE_LOG(LogMcpAutomationBridgeSubsystem, Warning,
              TEXT("Python execution took %.1fs (exceeds %.1fs threshold). "

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_TextureHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_TextureHandlers.cpp
@@ -67,6 +67,7 @@
 #include "TextureResource.h"
 #include "Misc/PackageName.h"
 #include "HAL/PlatformFileManager.h"
+#include "UObject/SoftObjectPath.h"
 
 // Editor/Asset
 #include "AssetRegistry/AssetRegistryModule.h"
@@ -146,6 +147,16 @@ static FString NormalizeTexturePath(const FString& Path)
     return Normalized;
 }
 
+static FAssetData GetTextureAssetDataByObjectPath(const FString& ObjectPath)
+{
+    IAssetRegistry& AssetRegistry = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry").Get();
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
+    return AssetRegistry.GetAssetByObjectPath(FSoftObjectPath(ObjectPath));
+#else
+    return AssetRegistry.GetAssetByObjectPath(FName(*ObjectPath));
+#endif
+}
+
 // NOTE: Use McpSafeAssetSave(Asset) from McpAutomationBridgeHelpers.h for saving textures.
 // McpSafeAssetSave marks the package dirty and notifies the asset registry safely for UE 5.7+.
 
@@ -208,7 +219,7 @@ static UTexture2D* CreateEmptyTexture(const FString& PackagePath, const FString&
     FTexture2DMipMap* Mip = new FTexture2DMipMap();
     Mip->SizeX = Width;
     Mip->SizeY = Height;
-    Mip->SizeZ = 0;
+    Mip->SizeZ = 1;
     NewTexture->GetPlatformData()->Mips.Add(Mip);
     
     // Allocate and initialize pixel data
@@ -231,6 +242,7 @@ static UTexture2D* CreateEmptyTexture(const FString& PackagePath, const FString&
     NewTexture->LODGroup = TEXTUREGROUP_World;
     
     NewTexture->UpdateResource();
+    NewTexture->PostEditChange();
     Package->MarkPackageDirty();
     
     return NewTexture;
@@ -248,12 +260,14 @@ static bool UpdateTextureBGRA8(UTexture2D* Texture, int32 Width, int32 Height, c
     FTexture2DMipMap& Mip = Texture->GetPlatformData()->Mips[0];
     Mip.SizeX = Width;
     Mip.SizeY = Height;
+    Mip.SizeZ = 1;
     Mip.BulkData.Lock(LOCK_READ_WRITE);
     void* TextureData = Mip.BulkData.Realloc(Pixels.Num());
     FMemory::Memcpy(TextureData, Pixels.GetData(), Pixels.Num());
     Mip.BulkData.Unlock();
 
     Texture->UpdateResource();
+    Texture->PostEditChange();
     Texture->MarkPackageDirty();
     return true;
 }
@@ -264,6 +278,9 @@ static bool SaveTextureAsset(UTexture2D* Texture)
     {
         return false;
     }
+
+    Texture->PostEditChange();
+    FlushRenderingCommands();
 
     FAssetRegistryModule::AssetCreated(Texture);
     Texture->MarkPackageDirty();
@@ -287,12 +304,14 @@ static bool SaveTextureAsset(UTexture2D* Texture)
         FEditorFileUtils::PromptForCheckoutAndSave(PackagesToSave, false, false);
     const bool bPromptSaveSucceeded =
         PromptSaveResult == FEditorFileUtils::PR_Success;
+    const bool bEditorSaveSucceeded =
+        !bPromptSaveSucceeded && UEditorLoadingAndSavingUtils::SavePackages(PackagesToSave, false);
     FString PackageFilename;
     const bool bHasFilename = FPackageName::TryConvertLongPackageNameToFilename(
         Package->GetName(), PackageFilename, FPackageName::GetAssetPackageExtension());
     const bool bExistsOnDisk = bHasFilename &&
         IFileManager::Get().FileExists(*FPaths::ConvertRelativePathToFull(PackageFilename));
-    if (bPromptSaveSucceeded || bExistsOnDisk)
+    if (bPromptSaveSucceeded || bEditorSaveSucceeded || bExistsOnDisk)
     {
         if (bHasFilename)
         {
@@ -3087,12 +3106,13 @@ Response->SetBoolField(TEXT("success"), true);
         FString FullObjectPath = FString::Printf(TEXT("%s.%s"), *FullPath, *Name);
         
         // Check for existing assets without attempting to load a missing package.
-        // StaticLoadObject leaves a transient package behind on failed loads, and
-        // treating that package as a collision makes brand-new render targets fail.
+        // LoadAsset logs an error for absent assets, and per-request capture would
+        // convert an otherwise successful render-target creation into ENGINE_ERROR.
         UTextureRenderTarget2D* ExistingRenderTarget = FindObject<UTextureRenderTarget2D>(nullptr, *FullObjectPath);
-        if (!ExistingRenderTarget)
+        const FAssetData ExistingAssetData = GetTextureAssetDataByObjectPath(FullObjectPath);
+        if (!ExistingRenderTarget && ExistingAssetData.IsValid())
         {
-            ExistingRenderTarget = Cast<UTextureRenderTarget2D>(UEditorAssetLibrary::LoadAsset(FullPath));
+            ExistingRenderTarget = Cast<UTextureRenderTarget2D>(ExistingAssetData.GetAsset());
         }
         if (ExistingRenderTarget)
         {
@@ -3104,8 +3124,7 @@ Response->SetBoolField(TEXT("success"), true);
             return Response;
         }
 
-        UObject* ExistingAsset = UEditorAssetLibrary::LoadAsset(FullPath);
-        if (ExistingAsset)
+        if (ExistingAssetData.IsValid())
         {
             Response->SetBoolField(TEXT("success"), false);
             Response->SetStringField(TEXT("error"), FString::Printf(TEXT("Asset with this name already exists: %s"), *FullPath));

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_WidgetAuthoringHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_WidgetAuthoringHandlers.cpp
@@ -4749,6 +4749,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageWidgetAuthoringAction(
             // Create a canvas panel as root if none exists
             Parent = WidgetBP->WidgetTree->ConstructWidget<UCanvasPanel>(UCanvasPanel::StaticClass(), TEXT("RootCanvas"));
             WidgetBP->WidgetTree->RootWidget = Parent;
+            RegisterWidgetGuid(WidgetBP, Parent);
         }
 
         // Map component type to UWidget class
@@ -4880,6 +4881,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManageWidgetAuthoringAction(
             SendAutomationError(RequestingSocket, RequestId, TEXT("Failed to construct widget"), TEXT("CREATION_FAILED"));
             return true;
         }
+        RegisterWidgetGuid(WidgetBP, NewWidget);
 
         // Add to parent
         Parent->AddChild(NewWidget);

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpSafeOperations.h
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpSafeOperations.h
@@ -51,6 +51,7 @@
 #include "AssetViewUtils.h"
 #include "Materials/MaterialInterface.h"
 #include "Editor/EditorEngine.h"
+#include "UObject/UObjectHash.h"
 #include "UObject/UObjectIterator.h"
 #include "ObjectTools.h"
 
@@ -143,8 +144,22 @@ inline bool McpSafeAssetSave(UObject* Asset)
         return false;
     }
 
+    UObject* AssetToSave = Asset;
     UPackage* Package = Cast<UPackage>(Asset);
-    if (!Package)
+    if (Package)
+    {
+        AssetToSave = nullptr;
+        ForEachObjectWithPackage(Package, [&AssetToSave](UObject* Object) -> bool
+        {
+            if (Object && !Object->IsA<UPackage>() && Object->HasAnyFlags(RF_Public | RF_Standalone))
+            {
+                AssetToSave = Object;
+                return false;
+            }
+            return true;
+        }, false);
+    }
+    else
     {
         Package = Asset->GetOutermost();
     }
@@ -163,10 +178,10 @@ inline bool McpSafeAssetSave(UObject* Asset)
     }
 
     Package->SetDirtyFlag(true);
-    if (Asset != Package)
+    if (AssetToSave && AssetToSave != Package)
     {
-        Asset->MarkPackageDirty();
-        FAssetRegistryModule::AssetCreated(Asset);
+        AssetToSave->MarkPackageDirty();
+        FAssetRegistryModule::AssetCreated(AssetToSave);
     }
 
     auto ScanSavedPackage = [&PackageName]()
@@ -193,10 +208,10 @@ inline bool McpSafeAssetSave(UObject* Asset)
     };
 
 #if MCP_HAS_PACKAGE_TOOLS
-    if (Asset != Package)
+    if (AssetToSave && AssetToSave != Package)
     {
         TArray<UObject*> ObjectsToSave;
-        ObjectsToSave.Add(Asset);
+        ObjectsToSave.Add(AssetToSave);
 
         FlushRenderingCommands();
 
@@ -221,9 +236,11 @@ inline bool McpSafeAssetSave(UObject* Asset)
         FEditorFileUtils::PromptForCheckoutAndSave(PackagesToSave, false, false);
     const bool bPromptSaveSucceeded =
         PromptSaveResult == FEditorFileUtils::PR_Success;
+    const bool bEditorSaveSucceeded =
+        !bPromptSaveSucceeded && UEditorLoadingAndSavingUtils::SavePackages(PackagesToSave, false);
     const bool bExistsOnDisk = PackageExistsOnDisk();
 
-    if (bPromptSaveSucceeded || bExistsOnDisk)
+    if (bPromptSaveSucceeded || bEditorSaveSucceeded || bExistsOnDisk)
     {
         ScanSavedPackage();
         return true;

--- a/scripts/smoke-test.ts
+++ b/scripts/smoke-test.ts
@@ -34,6 +34,19 @@ const requests = [
         id: 2,
         method: 'tools/list',
         params: {}
+    },
+    {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: {
+            name: 'manage_tools',
+            arguments: {
+                params: {
+                    action: 'get_status'
+                }
+            }
+        }
     }
 ];
 
@@ -62,6 +75,16 @@ child.stdout.on('data', (data) => {
 
             if (msg.id === 2 && msg.result) {
                 console.log(`✅ Tools check success: Found ${msg.result.tools?.length || 0} tools`);
+                child.stdin.write(JSON.stringify(requests[2]) + '\n');
+            }
+
+            if (msg.id === 3 && msg.result) {
+                const textContent = msg.result.content?.[0]?.text;
+                const payload = typeof textContent === 'string' ? JSON.parse(textContent) : {};
+                if (!payload.success || payload.totalTools !== 22) {
+                    throw new Error('manage_tools params smoke check failed');
+                }
+                console.log('✅ manage_tools params check success');
                 passed = true;
                 child.kill();
             }

--- a/src/server/tool-registry.ts
+++ b/src/server/tool-registry.ts
@@ -52,6 +52,14 @@ function clientSupportsListChanged(clientName: string | undefined): boolean {
     return false;
 }
 
+function mergeActionParams(args: Record<string, unknown>): Record<string, unknown> {
+    if (!isRecord(args.params)) return args;
+
+    const merged = { ...args.params, ...args };
+    delete merged.params;
+    return merged;
+}
+
 export class ToolRegistry {
     private defaultElicitationTimeoutMs = 60000;
     private currentCategories: string[] = parseDefaultCategories();
@@ -431,19 +439,25 @@ export class ToolRegistry {
                 if (actionValues.size > 0) {
                     actionSchema.enum = Array.from(actionValues);
                 }
+                properties.action = actionSchema;
                 const parameterNames = Object.keys(properties).filter(name => name !== 'action');
                 const parameterSummary = parameterNames.length > 0 ? ` Params by action: ${parameterNames.join(', ')}.` : '';
                 const actionGuidance = ' Required: action. Select one enum value, then provide only parameters relevant to that action.';
+                const sourceRequired = Array.isArray(t.inputSchema.required)
+                    ? t.inputSchema.required.filter((name): name is string => typeof name === 'string')
+                    : ['action'];
+                const required = sourceRequired.includes('action') ? sourceRequired : ['action', ...sourceRequired];
 
                 return {
                     name: t.name,
                     description: `${t.description}${actionGuidance}${parameterSummary}`,
                     category: t.category,
                     inputSchema: {
+                        ...t.inputSchema,
                         type: 'object',
-                        properties: { action: actionSchema },
-                        required: ['action'],
-                        additionalProperties: true
+                        properties,
+                        required,
+                        additionalProperties: t.inputSchema.additionalProperties ?? true
                     }
                 };
             });
@@ -452,7 +466,7 @@ export class ToolRegistry {
 
         this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
             const { name } = request.params;
-            let args: Record<string, unknown> = request.params.arguments || {};
+            let args: Record<string, unknown> = mergeActionParams(request.params.arguments || {});
 
             // Handle manage_tools for dynamic tool management
             if (name === 'manage_tools') {

--- a/src/tools/consolidated-tool-definitions.ts
+++ b/src/tools/consolidated-tool-definitions.ts
@@ -7,7 +7,7 @@ export interface ToolDefinition {
   outputSchema?: Record<string, unknown>;
   [key: string]: unknown;
 }
-import { commonSchemas } from './tool-definition-utils.js';
+import { addActionParamsSchema, commonSchemas } from './tool-definition-utils.js';
 
 /** Canonical list of material authoring actions — single source of truth for schema and handler. */
 export const MATERIAL_AUTHORING_ACTIONS = [
@@ -795,14 +795,14 @@ export const consolidatedToolDefinitions: ToolDefinition[] = [
   {
     name: 'manage_level',
     category: 'core',
-    description: 'Load/save levels, configure streaming, manage World Partition cells, and build lighting.',
+    description: 'Load/save levels, configure streaming, and build lighting.',
     inputSchema: {
       type: 'object',
       properties: {
         action: {
           type: 'string',
           enum: [
-            'load', 'save', 'save_as', 'save_level_as', 'stream', 'unload', 'create_level', 'create_light', 'build_lighting',
+            'load', 'load_level', 'save', 'save_level', 'save_as', 'save_level_as', 'stream', 'unload', 'unload_level', 'create_level', 'create_light', 'build_lighting',
             'set_metadata',
             'export_level', 'import_level', 'list_levels', 'get_summary', 'delete', 'delete_level', 'validate_level',
             'add_sublevel', 'rename_level', 'duplicate_level', 'get_current_level'
@@ -811,17 +811,22 @@ export const consolidatedToolDefinitions: ToolDefinition[] = [
         },
         // Level path parameters
         levelPath: commonSchemas.levelPath,
+        assetPath: commonSchemas.assetPath,
         levelPaths: commonSchemas.arrayOfStrings,
         levelName: commonSchemas.stringProp,
         path: commonSchemas.directoryPathForCreation,
         // Save/export/import paths
         savePath: commonSchemas.savePath,
         destinationPath: commonSchemas.destinationPath,
+        overwrite: commonSchemas.overwrite,
+        targetPath: commonSchemas.directoryPath,
         exportPath: commonSchemas.exportPath,
         packagePath: commonSchemas.directoryPath,
         sourcePath: commonSchemas.sourcePath,
         // Sublevel parameters
         sublevelPath: commonSchemas.levelPath,
+        parentLevel: commonSchemas.parentLevel,
+        parentPath: commonSchemas.directoryPath,
         streamingMethod: commonSchemas.stringProp,
         // Streaming control
         streaming: commonSchemas.booleanProp,
@@ -834,6 +839,7 @@ export const consolidatedToolDefinitions: ToolDefinition[] = [
         location: commonSchemas.location,
         rotation: commonSchemas.rotation,
         // Level creation
+        template: commonSchemas.stringProp,
         useWorldPartition: commonSchemas.booleanProp,
         // Metadata & utilities
         metadata: commonSchemas.objectProp,
@@ -3409,3 +3415,5 @@ export const consolidatedToolDefinitions: ToolDefinition[] = [
   },
 
 ];
+
+addActionParamsSchema(consolidatedToolDefinitions);

--- a/src/tools/consolidated-tool-definitions.ts
+++ b/src/tools/consolidated-tool-definitions.ts
@@ -832,6 +832,7 @@ export const consolidatedToolDefinitions: ToolDefinition[] = [
         streaming: commonSchemas.booleanProp,
         shouldBeLoaded: commonSchemas.booleanProp,
         shouldBeVisible: commonSchemas.booleanProp,
+        saveDirtyPackages: commonSchemas.booleanProp,
         // Light creation
         lightType: { type: 'string', enum: ['Directional', 'Point', 'Spot', 'Rect', 'DirectionalLight', 'PointLight', 'SpotLight', 'RectLight', 'directional', 'point', 'spot', 'rect'], description: 'Light type. Accepts short names (Point), class names (PointLight), or lowercase (point).' },
         intensity: commonSchemas.numberProp,

--- a/src/tools/consolidated-tool-handlers.test.ts
+++ b/src/tools/consolidated-tool-handlers.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AutomationBridge } from '../automation/index.js';
+import type { ITools } from '../types/tool-interfaces.js';
+import { handleConsolidatedToolCall } from './consolidated-tool-handlers.js';
+import { consolidatedToolDefinitions } from './consolidated-tool-definitions.js';
+import { coreToolDefinitions } from './schemas/core-tools.js';
+
+type SendAutomationRequest = (
+  action: string,
+  payload: Record<string, unknown>,
+  options?: { timeoutMs?: number }
+) => Promise<{ success: boolean }>;
+
+function createConnectedTools() {
+  const sendAutomationRequest = vi.fn<SendAutomationRequest>(async () => ({ success: true }));
+  const tools: ITools = {
+    systemTools: {
+      executeConsoleCommand: vi.fn(async () => ({ success: true })),
+      getProjectSettings: vi.fn(async () => ({}))
+    },
+    assetResources: {
+      list: vi.fn(async () => ({}))
+    },
+    automationBridge: {
+      isConnected: () => true,
+      sendAutomationRequest
+    } as unknown as AutomationBridge
+  } as unknown as ITools;
+
+  return { tools, sendAutomationRequest };
+}
+
+describe('consolidated action params compatibility', () => {
+  it('advertises params for action tools in public schemas', () => {
+    const tools = [
+      consolidatedToolDefinitions.find((tool) => tool.name === 'manage_level_structure'),
+      consolidatedToolDefinitions.find((tool) => tool.name === 'system_control'),
+      coreToolDefinitions.find((tool) => tool.name === 'manage_level')
+    ];
+
+    for (const tool of tools) {
+      const inputSchema = tool?.inputSchema as Record<string, unknown> | undefined;
+      const properties = inputSchema?.properties as Record<string, unknown> | undefined;
+      expect(properties).toHaveProperty('params');
+      expect(inputSchema?.additionalProperties).toBe(true);
+    }
+  });
+
+  it('merges params into level-structure payloads before validation and dispatch', async () => {
+    const { tools, sendAutomationRequest } = createConnectedTools();
+
+    await handleConsolidatedToolCall('manage_level_structure', {
+      action: 'create_level',
+      params: {
+        levelName: 'MCP_Racing_Level',
+        levelPath: '/Game/MCP_Racing_Level',
+        save: true
+      }
+    }, tools);
+
+    expect(sendAutomationRequest).toHaveBeenCalledWith('manage_level_structure', expect.objectContaining({
+      action: 'create_level',
+      subAction: 'create_level',
+      levelName: 'MCP_Racing_Level',
+      levelPath: '/Game/MCP_Racing_Level',
+      save: true
+    }), expect.any(Object));
+    const firstCall = sendAutomationRequest.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    const payload = firstCall?.[1] ?? {};
+    expect(payload).not.toHaveProperty('params');
+  });
+
+  it('lets top-level arguments override params when both are provided', async () => {
+    const { tools, sendAutomationRequest } = createConnectedTools();
+
+    await handleConsolidatedToolCall('manage_level_structure', {
+      action: 'create_level',
+      levelName: 'TopLevelName',
+      params: {
+        action: 'create_sublevel',
+        levelName: 'NestedName'
+      }
+    }, tools);
+
+    expect(sendAutomationRequest).toHaveBeenCalledWith('manage_level_structure', expect.objectContaining({
+      action: 'create_level',
+      subAction: 'create_level',
+      levelName: 'TopLevelName'
+    }), expect.any(Object));
+  });
+
+  it('removes params before routing to strict input handlers', async () => {
+    const { tools, sendAutomationRequest } = createConnectedTools();
+
+    await handleConsolidatedToolCall('manage_networking', {
+      action: 'create_input_action',
+      params: {
+        name: 'IA_Throttle',
+        path: '/Game/Input'
+      }
+    }, tools);
+
+    expect(sendAutomationRequest).toHaveBeenCalledWith('manage_input', expect.objectContaining({
+      action: 'create_input_action',
+      subAction: 'create_input_action',
+      name: 'IA_Throttle',
+      path: '/Game/Input'
+    }), expect.any(Object));
+    const firstCall = sendAutomationRequest.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    const payload = firstCall?.[1] ?? {};
+    expect(payload).not.toHaveProperty('params');
+  });
+
+  it('forwards overwrite for level copy-style actions', async () => {
+    const { tools, sendAutomationRequest } = createConnectedTools();
+
+    await handleConsolidatedToolCall('manage_level', {
+      action: 'duplicate_level',
+      sourcePath: '/Game/Maps/Source',
+      destinationPath: '/Game/Maps/Destination',
+      overwrite: true
+    }, tools);
+
+    expect(sendAutomationRequest).toHaveBeenCalledWith('manage_level', expect.objectContaining({
+      action: 'duplicate',
+      sourcePath: '/Game/Maps/Source',
+      destinationPath: '/Game/Maps/Destination',
+      overwrite: true
+    }), expect.any(Object));
+  });
+});

--- a/src/tools/consolidated-tool-handlers.ts
+++ b/src/tools/consolidated-tool-handlers.ts
@@ -130,6 +130,18 @@ function normalizeToolCall(
   };
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function mergeActionParams(args: Record<string, unknown>): Record<string, unknown> {
+  if (!isRecord(args.params)) return args;
+
+  const merged = { ...args.params, ...args };
+  delete merged.params;
+  return merged;
+}
+
 function registerDefaultHandlers() {
   toolRegistry.register('manage_asset', async (args, tools) => {
     const action = getToolAction(args);
@@ -219,10 +231,13 @@ function registerDefaultHandlers() {
       if (channels && !/^[A-Za-z0-9_, -]+$/.test(channels)) {
         return { success: false, error: 'INVALID_CHANNELS', message: 'Trace channels contain unsupported characters.' };
       }
-      await handleConsoleCommand({ command: 'Trace.Stop' }, tools);
-      const command = channels ? `Trace.File ${channels}` : 'Trace.File';
-      const res = await handleConsoleCommand({ command }, tools);
-      return cleanObject({ ...res, action, channels });
+      const res = await executeAutomationRequest(tools, 'manage_insights', {
+        ...args,
+        action,
+        subAction: action,
+        channels
+      }, 'Bridge unavailable') as Record<string, unknown>;
+      return cleanObject({ ...res, action, channels, sessionType: 'trace' });
     }
     if (action === 'lumen_update_scene') return cleanObject(await executeAutomationRequest(tools, 'manage_render', { ...args, subAction: action }, 'Bridge unavailable'));
     return await handleSystemTools(action, args, tools);
@@ -286,7 +301,8 @@ export async function handleConsolidatedToolCall(
   const startTime = Date.now();
 
   try {
-    const normalized = normalizeToolCall(name, args);
+    const expandedArgs = mergeActionParams(args);
+    const normalized = normalizeToolCall(name, expandedArgs);
     const normalizedArgs = normalized.args;
 
     if (normalized.action && !normalizedArgs.action) {

--- a/src/tools/handlers/level-handlers.test.ts
+++ b/src/tools/handlers/level-handlers.test.ts
@@ -38,24 +38,22 @@ describe('handleLevelTools path normalization', () => {
     }, {});
   });
 
-  it('normalizes load_cells levelPath after preserving extra arguments', async () => {
+  it('keeps World Partition actions out of manage_level dispatch', async () => {
     const { tools, sendAutomationRequest } = createTools();
 
-    await handleLevelTools('load_cells', {
+    const result = await handleLevelTools('load_cells', {
       action: 'load_cells',
       levelPath: String.raw`Content\Maps\Demo`,
       cells: ['Cell_0'],
       customFlag: true
     }, tools);
 
-    expect(sendAutomationRequest).toHaveBeenCalledWith('manage_world_partition', {
+    expect(sendAutomationRequest).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      success: false,
+      error: 'INVALID_ACTION',
       action: 'load_cells',
-      levelPath: '/Game/Maps/Demo',
-      cells: ['Cell_0'],
-      customFlag: true,
-      subAction: 'load_cells',
-      origin: undefined,
-      extent: undefined
-    }, {});
+      tool: 'manage_level_structure'
+    });
   });
 });

--- a/src/tools/handlers/level-handlers.ts
+++ b/src/tools/handlers/level-handlers.ts
@@ -154,7 +154,8 @@ export async function handleLevelTools(action: string, args: HandlerArgs, tools:
 
       const loadRes = await executeAutomationRequest(tools, 'manage_level', {
         action: 'load',
-        levelPath: createdLevelPath
+        levelPath: createdLevelPath,
+        saveDirtyPackages: argsTyped.saveDirtyPackages === true
       }) as Record<string, unknown>;
       if (loadRes.success !== true) {
         return cleanObject(loadRes);

--- a/src/tools/handlers/level-handlers.ts
+++ b/src/tools/handlers/level-handlers.ts
@@ -5,6 +5,13 @@ import { executeAutomationRequest, normalizePathFields, requireNonEmptyString, v
 
 // AutomationResponse now imported from types/handler-types.js
 
+const LEVEL_STRUCTURE_ONLY_ACTIONS = new Set([
+  'load_cells',
+  'set_datalayer',
+  'cleanup_invalid_datalayers',
+  'create_datalayer'
+]);
+
 /** Result payload structure for level responses */
 interface ResultPayload {
   exists?: boolean;
@@ -53,6 +60,16 @@ function normalizeLevelArgs(args: LevelArgs): LevelArgs {
 export async function handleLevelTools(action: string, args: HandlerArgs, tools: ITools): Promise<Record<string, unknown>> {
   // Normalize args to support both camelCase and snake_case
   const argsTyped = normalizeLevelArgs(args as LevelArgs);
+
+  if (LEVEL_STRUCTURE_ONLY_ACTIONS.has(action)) {
+    return cleanObject({
+      success: false,
+      error: 'INVALID_ACTION',
+      message: `${action} belongs to manage_level_structure/world partition handlers, not manage_level`,
+      action,
+      tool: 'manage_level_structure'
+    });
+  }
   
   // Security validation: check for path traversal attempts
   const securityError = validateSecurityPatterns(argsTyped as Record<string, unknown>);
@@ -310,6 +327,7 @@ export async function handleLevelTools(action: string, args: HandlerArgs, tools:
         action: 'import_level',
         packagePath: argsTyped.packagePath ?? argsTyped.sourcePath ?? '',
         destinationPath: argsTyped.destinationPath,
+        overwrite: argsTyped.overwrite === true,
         timeoutMs: typeof argsTyped.timeoutMs === 'number' ? argsTyped.timeoutMs : undefined
       }) as Record<string, unknown>;
       return cleanObject(res);
@@ -390,7 +408,8 @@ export async function handleLevelTools(action: string, args: HandlerArgs, tools:
       const res = await executeAutomationRequest(tools, 'manage_level', {
         action: 'rename',
         levelPath: sourcePath,
-        destinationPath
+        destinationPath,
+        overwrite: argsTyped.overwrite === true
       });
       return cleanObject(res) as Record<string, unknown>;
     }
@@ -415,7 +434,8 @@ export async function handleLevelTools(action: string, args: HandlerArgs, tools:
       const res = await executeAutomationRequest(tools, 'manage_level', {
         action: 'duplicate',
         sourcePath,
-        destinationPath: argsTyped.destinationPath
+        destinationPath: argsTyped.destinationPath,
+        overwrite: argsTyped.overwrite === true
       });
       return cleanObject(res) as Record<string, unknown>;
     }
@@ -427,138 +447,6 @@ export async function handleLevelTools(action: string, args: HandlerArgs, tools:
       const levelPath = requireNonEmptyString(argsTyped.levelPath, 'levelPath', 'Missing required parameter: levelPath');
       const metadata = (argsTyped.metadata && typeof argsTyped.metadata === 'object') ? argsTyped.metadata : {};
       const res = await executeAutomationRequest(tools, 'set_metadata', { assetPath: levelPath, metadata });
-      return cleanObject(res) as Record<string, unknown>;
-    }
-    case 'load_cells': {
-      // CRITICAL FIX: levelPath is REQUIRED for World Partition operations
-      // Without levelPath, the handler cannot load the correct World Partition level
-      if (!argsTyped.levelPath || typeof argsTyped.levelPath !== 'string' || argsTyped.levelPath.trim() === '') {
-        return cleanObject({
-          success: false,
-          error: 'INVALID_ARGUMENT',
-          message: 'Missing required parameter: levelPath (World Partition level path required)',
-          action
-        });
-      }
-      // Validate required parameters for load_cells
-      const hasCells = Array.isArray(argsTyped.cells) && argsTyped.cells.length > 0;
-      const hasOrigin = Array.isArray(argsTyped.origin) && argsTyped.origin.length >= 2;
-      const hasExtent = Array.isArray(argsTyped.extent) && argsTyped.extent.length >= 2;
-      const hasMin = Array.isArray(argsTyped.min) && argsTyped.min.length >= 2;
-      const hasMax = Array.isArray(argsTyped.max) && argsTyped.max.length >= 2;
-      if (!hasCells && !(hasOrigin && hasExtent) && !(hasMin && hasMax)) {
-        return cleanObject({
-          success: false,
-          error: 'INVALID_ARGUMENT',
-          message: 'Missing required parameters: must provide either cells array, or origin+extent, or min+max',
-          action,
-          levelPath: argsTyped.levelPath
-        });
-      }
-
-      // CRITICAL FIX: DO NOT load the level here - let the C++ handler do it
-      // The C++ HandleWorldPartitionAction already checks if the level needs to be loaded
-      // and will only load if the current world differs from the requested levelPath.
-      // Loading here would destroy unsaved actors in the current world.
-      // Calculate origin/extent if min/max provided for C++ handler compatibility
-      let origin = argsTyped.origin;
-      let extent = argsTyped.extent;
-      if (argsTyped.min && argsTyped.max) {
-        const min = argsTyped.min;
-        const max = argsTyped.max;
-        origin = [(min[0] + max[0]) / 2, (min[1] + max[1]) / 2, (min[2] + max[2]) / 2];
-        extent = [(max[0] - min[0]) / 2, (max[1] - min[1]) / 2, (max[2] - min[2]) / 2];
-      }
-      const payload = {
-        ...args,
-        subAction: 'load_cells',
-        levelPath: argsTyped.levelPath,
-        origin: origin,
-        extent: extent
-      };
-      const res = await executeAutomationRequest(tools, 'manage_world_partition', payload);
-      return cleanObject(res) as Record<string, unknown>;
-    }
-    case 'set_datalayer': {
-      // CRITICAL FIX: levelPath is REQUIRED for World Partition operations
-      // Without levelPath, the handler cannot load the correct World Partition level
-      if (!argsTyped.levelPath || typeof argsTyped.levelPath !== 'string' || argsTyped.levelPath.trim() === '') {
-        return cleanObject({
-          success: false,
-          error: 'INVALID_ARGUMENT',
-          message: 'Missing required parameter: levelPath (World Partition level path required)',
-          action
-        });
-      }
-
-      // Validate actorPath is provided
-      const actorPath = argsTyped.actorPath || argsTyped.actorName;
-      if (!actorPath || typeof actorPath !== 'string' || actorPath.trim() === '') {
-        return cleanObject({
-          success: false,
-          error: 'INVALID_ARGUMENT',
-          message: 'Missing required parameter: actorPath (actor name or path)',
-          action,
-          levelPath: argsTyped.levelPath
-        });
-      }
-      const dataLayerName = argsTyped.dataLayerName || argsTyped.dataLayerLabel;
-      if (!dataLayerName || typeof dataLayerName !== 'string' || dataLayerName.trim().length === 0) {
-        return cleanObject({
-          success: false,
-          error: 'INVALID_ARGUMENT',
-          message: 'Missing required parameter: dataLayerLabel (or dataLayerName)',
-          action,
-          levelPath: argsTyped.levelPath,
-          actorPath
-        });
-      }
-
-      // CRITICAL FIX: DO NOT load the level here - let the C++ handler do it
-      // The C++ HandleWorldPartitionAction already checks if the level needs to be loaded
-      // and will only load if the current world differs from the requested levelPath.
-      // Loading here would destroy unsaved actors in the current world.
-      const res = await executeAutomationRequest(tools, 'manage_world_partition', {
-        subAction: 'set_datalayer',
-        levelPath: argsTyped.levelPath,
-        actorPath: actorPath,
-        dataLayerName
-      });
-      return cleanObject(res) as Record<string, unknown>;
-    }
-    case 'cleanup_invalid_datalayers': {
-      // CRITICAL FIX: DO NOT load the level here - let the C++ handler do it
-      // The C++ HandleWorldPartitionAction already checks if the level needs to be loaded
-      // and will only load if the current world differs from the requested levelPath.
-      // Loading here would destroy unsaved actors in the current world.
-      
-      // Route to manage_world_partition
-      const res = await executeAutomationRequest(tools, 'manage_world_partition', {
-        subAction: 'cleanup_invalid_datalayers',
-        levelPath: argsTyped.levelPath
-      }, 'World Partition support not available');
-      return cleanObject(res) as Record<string, unknown>;
-    }
-    case 'create_datalayer': {
-      // Route to manage_world_partition
-      const dataLayerName = argsTyped.dataLayerName || argsTyped.dataLayerLabel;
-      if (!dataLayerName || typeof dataLayerName !== 'string' || dataLayerName.trim().length === 0) {
-        return cleanObject({
-          success: false,
-          error: 'INVALID_ARGUMENT',
-          message: 'Missing required parameter: dataLayerName',
-          action
-        });
-      }
-      // CRITICAL FIX: DO NOT load the level here - let the C++ handler do it
-      // The C++ HandleWorldPartitionAction already checks if the level needs to be loaded
-      // and will only load if the current world differs from the requested levelPath.
-      // Loading here would destroy unsaved actors in the current world.
-      const res = await executeAutomationRequest(tools, 'manage_world_partition', {
-        subAction: 'create_datalayer',
-        levelPath: argsTyped.levelPath,
-        dataLayerName
-      }, 'World Partition support not available');
       return cleanObject(res) as Record<string, unknown>;
     }
     case 'validate_level': {

--- a/src/tools/schemas/core-tools.ts
+++ b/src/tools/schemas/core-tools.ts
@@ -6,12 +6,12 @@
  * - manage_asset: Asset creation, import, manipulation
  * - control_actor: Actor spawn, transform, physics, components
  * - control_editor: PIE, camera, console commands, screenshots
- * - manage_level: Level load/save, streaming, World Partition
+ * - manage_level: Level load/save, streaming, lighting
  * - system_control: Profiling, CVars, UBT, tests
  * - inspect: Object introspection
  */
 
-import { commonSchemas } from '../tool-definition-utils.js';
+import { addActionParamsSchema, commonSchemas } from '../tool-definition-utils.js';
 
 /** MCP Tool Definition type for explicit annotation to avoid TS7056 */
 export interface ToolDefinition {
@@ -333,34 +333,38 @@ export const coreToolDefinitions: ToolDefinition[] = [
   {
     name: 'manage_level',
     category: 'core',
-    description: 'Load/save levels, configure streaming, manage World Partition cells, and build lighting.',
+    description: 'Load/save levels, configure streaming, and build lighting.',
     inputSchema: {
       type: 'object',
       properties: {
         action: {
           type: 'string',
           enum: [
-            'load', 'save', 'save_as', 'save_level_as', 'stream', 'unload', 'create_level', 'create_light', 'build_lighting',
-            'set_metadata', 'load_cells', 'set_datalayer', 'create_datalayer',
+            'load', 'load_level', 'save', 'save_level', 'save_as', 'save_level_as', 'stream', 'unload', 'unload_level', 'create_level', 'create_light', 'build_lighting',
+            'set_metadata',
             'export_level', 'import_level', 'list_levels', 'get_summary', 'delete', 'delete_level', 'validate_level',
-            'cleanup_invalid_datalayers', 'add_sublevel', 'rename_level', 'duplicate_level', 'get_current_level'
+            'add_sublevel', 'rename_level', 'duplicate_level', 'get_current_level'
           ],
           description: 'Action'
         },
         // Level path parameters
         levelPath: commonSchemas.levelPath,
+        assetPath: commonSchemas.assetPath,
         levelPaths: commonSchemas.arrayOfStrings,
         levelName: commonSchemas.stringProp,
+        name: commonSchemas.name,
         path: commonSchemas.directoryPathForCreation,
         // Save/export/import paths
         savePath: commonSchemas.savePath,
         destinationPath: commonSchemas.destinationPath,
+        overwrite: commonSchemas.overwrite,
         targetPath: commonSchemas.directoryPath,
         exportPath: commonSchemas.exportPath,
         packagePath: commonSchemas.directoryPath,
         sourcePath: commonSchemas.sourcePath,
         // Sublevel parameters
         sublevelPath: commonSchemas.levelPath,
+        subLevelPath: commonSchemas.levelPath,
         parentLevel: commonSchemas.parentLevel,
         parentPath: commonSchemas.directoryPath,
         streamingMethod: commonSchemas.stringProp,
@@ -370,21 +374,11 @@ export const coreToolDefinitions: ToolDefinition[] = [
         shouldBeVisible: commonSchemas.booleanProp,
         // Light creation
         lightType: { type: 'string', enum: ['Directional', 'Point', 'Spot', 'Rect', 'DirectionalLight', 'PointLight', 'SpotLight', 'RectLight', 'directional', 'point', 'spot', 'rect'], description: 'Light type. Accepts short names (Point), class names (PointLight), or lowercase (point).' },
+        quality: commonSchemas.stringProp,
         intensity: commonSchemas.numberProp,
         color: commonSchemas.color,
         location: commonSchemas.location,
         rotation: commonSchemas.rotation,
-        // World Partition / Data Layers
-        cells: commonSchemas.arrayOfStrings,
-        dataLayerName: commonSchemas.dataLayerName,
-        dataLayerLabel: commonSchemas.stringProp,
-        dataLayerState: commonSchemas.stringProp,
-        actorPath: commonSchemas.actorPath,
-        // Cell bounds
-        min: commonSchemas.location,
-        max: commonSchemas.location,
-        origin: commonSchemas.location,
-        extent: commonSchemas.extent,
         // Level creation
         template: commonSchemas.stringProp,
         useWorldPartition: commonSchemas.booleanProp,
@@ -518,3 +512,5 @@ export const coreToolDefinitions: ToolDefinition[] = [
     }
   }
 ];
+
+addActionParamsSchema(coreToolDefinitions);

--- a/src/tools/schemas/core-tools.ts
+++ b/src/tools/schemas/core-tools.ts
@@ -372,6 +372,7 @@ export const coreToolDefinitions: ToolDefinition[] = [
         streaming: commonSchemas.booleanProp,
         shouldBeLoaded: commonSchemas.booleanProp,
         shouldBeVisible: commonSchemas.booleanProp,
+        saveDirtyPackages: commonSchemas.booleanProp,
         // Light creation
         lightType: { type: 'string', enum: ['Directional', 'Point', 'Spot', 'Rect', 'DirectionalLight', 'PointLight', 'SpotLight', 'RectLight', 'directional', 'point', 'spot', 'rect'], description: 'Light type. Accepts short names (Point), class names (PointLight), or lowercase (point).' },
         quality: commonSchemas.stringProp,

--- a/src/tools/tool-definition-utils.ts
+++ b/src/tools/tool-definition-utils.ts
@@ -4,6 +4,12 @@
  */
 
 export const commonSchemas = {
+  actionParams: {
+    type: 'object',
+    description: 'Optional action-specific parameters. These are merged with top-level arguments before routing for clients that cannot send arbitrary top-level fields.',
+    additionalProperties: true
+  },
+
   // ============================================
   // TRANSFORM & VECTOR SCHEMAS
   // ============================================
@@ -556,6 +562,22 @@ export function createOutputSchema(additionalProperties: Record<string, unknown>
       ...additionalProperties
     }
   };
+}
+
+export function addActionParamsSchema(definitions: Array<{ inputSchema: Record<string, unknown> }>): void {
+  for (const definition of definitions) {
+    const schema = definition.inputSchema;
+    const rawProperties = schema.properties;
+    if (!rawProperties || typeof rawProperties !== 'object' || Array.isArray(rawProperties)) continue;
+
+    const properties = rawProperties as Record<string, unknown>;
+    if (properties.action === undefined || properties.params !== undefined) continue;
+
+    properties.params = commonSchemas.actionParams;
+    if (schema.additionalProperties === undefined) {
+      schema.additionalProperties = true;
+    }
+  }
 }
 
 /**

--- a/src/types/handler-types.ts
+++ b/src/types/handler-types.ts
@@ -286,14 +286,7 @@ export interface LevelArgs extends HandlerArgs {
     streaming?: boolean;
     shouldBeLoaded?: boolean;
     shouldBeVisible?: boolean;
-    dataLayerLabel?: string;
-    dataLayerName?: string;
-    dataLayerState?: string;
-    actorPath?: string;
-    min?: number[];
-    max?: number[];
-    origin?: number[];
-    extent?: number[];
+    overwrite?: boolean;
     metadata?: Record<string, unknown>;
     timeoutMs?: number;
     useWorldPartition?: boolean;

--- a/src/types/handler-types.ts
+++ b/src/types/handler-types.ts
@@ -286,6 +286,7 @@ export interface LevelArgs extends HandlerArgs {
     streaming?: boolean;
     shouldBeLoaded?: boolean;
     shouldBeVisible?: boolean;
+    saveDirtyPackages?: boolean;
     overwrite?: boolean;
     metadata?: Record<string, unknown>;
     timeoutMs?: number;

--- a/tests/mcp-tools/core/manage-level.test.mjs
+++ b/tests/mcp-tools/core/manage-level.test.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * manage_level Tool Integration Tests
- * Covers all 25 actions with real level package paths and deterministic cleanup.
+ * Covers all manage_level actions with real level package paths and deterministic cleanup.
  */
 
 import { runToolTests } from '../../test-runner.mjs';
@@ -26,15 +26,18 @@ const testCases = [
   // === CREATE / SAVE / LOAD ===
   { scenario: 'CREATE: create_level', toolName: 'manage_level', arguments: { action: 'create_level', levelName: `LevelMain_${ts}`, levelPath: TEST_FOLDER, useWorldPartition: false }, expected: 'success|already exists' },
   { scenario: 'ACTION: save', toolName: 'manage_level', arguments: { action: 'save' }, expected: 'success' },
+  { scenario: 'ACTION: save_level alias', toolName: 'manage_level', arguments: { action: 'save_level' }, expected: 'success' },
   { scenario: 'ACTION: save_as', toolName: 'manage_level', arguments: { action: 'save_as', savePath: SAVE_AS_LEVEL }, expected: 'success' },
   { scenario: 'ACTION: save_level_as', toolName: 'manage_level', arguments: { action: 'save_level_as', savePath: SAVE_LEVEL_AS }, expected: 'success' },
   { scenario: 'Setup: create sublevel', toolName: 'manage_level', arguments: { action: 'create_level', levelName: `LevelSub_${ts}`, levelPath: TEST_FOLDER, useWorldPartition: false }, expected: 'success|already exists' },
   { scenario: 'ACTION: load', toolName: 'manage_level', arguments: { action: 'load', levelPath: MAIN_LEVEL, streaming: false }, expected: 'success' },
+  { scenario: 'ACTION: load_level alias', toolName: 'manage_level', arguments: { action: 'load_level', levelPath: MAIN_LEVEL, streaming: false }, expected: 'success' },
   { scenario: 'Setup: spawn actor in level', toolName: 'control_actor', arguments: { action: 'spawn', classPath: '/Engine/BasicShapes/Cube', actorName: TEST_ACTOR, location: { x: 0, y: 0, z: 100 } }, expected: 'success' },
 
   // === STREAMING ===
   { scenario: 'ACTION: stream', toolName: 'manage_level', arguments: { action: 'stream', levelPath: SUB_LEVEL, shouldBeLoaded: true, shouldBeVisible: true }, expected: 'success|already loaded' },
   { scenario: 'ACTION: unload', toolName: 'manage_level', arguments: { action: 'unload', levelPath: SUB_LEVEL }, expected: 'success|not loaded' },
+  { scenario: 'ACTION: unload_level alias', toolName: 'manage_level', arguments: { action: 'unload_level', levelPath: SUB_LEVEL }, expected: 'success|not loaded' },
   { scenario: 'ADD: add_sublevel', toolName: 'manage_level', arguments: { action: 'add_sublevel', subLevelPath: SUB_LEVEL, streamingMethod: 'AlwaysLoaded' }, expected: 'success|already exists' },
   { scenario: 'ADD: add_sublevel via sublevelPath alias', toolName: 'manage_level', arguments: { action: 'add_sublevel', sublevelPath: SUB_LEVEL, streamingMethod: 'AlwaysLoaded' }, expected: 'success|already exists' },
 
@@ -54,8 +57,8 @@ const testCases = [
   { scenario: 'INFO: get_current_level', toolName: 'manage_level', arguments: { action: 'get_current_level' }, expected: 'success' },
 
   // === ASSET OPERATIONS ===
-  { scenario: 'ACTION: duplicate_level', toolName: 'manage_level', arguments: { action: 'duplicate_level', sourcePath: MAIN_LEVEL, destinationPath: DUPLICATED_LEVEL }, expected: 'success|already exists' },
-  { scenario: 'ACTION: rename_level', toolName: 'manage_level', arguments: { action: 'rename_level', levelPath: DUPLICATED_LEVEL, newName: RENAMED_LEVEL_NAME }, expected: 'success|already exists' },
+  { scenario: 'ACTION: duplicate_level', toolName: 'manage_level', arguments: { action: 'duplicate_level', sourcePath: MAIN_LEVEL, destinationPath: DUPLICATED_LEVEL, overwrite: false }, expected: 'success|already exists' },
+  { scenario: 'ACTION: rename_level', toolName: 'manage_level', arguments: { action: 'rename_level', levelPath: DUPLICATED_LEVEL, newName: RENAMED_LEVEL_NAME, overwrite: false }, expected: 'success|already exists' },
   { scenario: 'DELETE: delete multiple levels', toolName: 'manage_level', arguments: { action: 'delete', levelPaths: [SAVE_AS_LEVEL, SAVE_LEVEL_AS, EXPORTED_LEVEL] }, expected: 'success|not found' },
   { scenario: 'DELETE: delete', toolName: 'manage_level', arguments: { action: 'delete', levelPath: RENAMED_LEVEL }, expected: 'success|not found' },
   { scenario: 'DELETE: delete_level path alias', toolName: 'manage_level', arguments: { action: 'delete_level', path: IMPORTED_LEVEL }, expected: 'success|not found' },

--- a/tests/mcp-tools/core/manage-level.test.mjs
+++ b/tests/mcp-tools/core/manage-level.test.mjs
@@ -24,14 +24,14 @@ const testCases = [
   { scenario: 'Setup: create test folder', toolName: 'manage_asset', arguments: { action: 'create_folder', path: TEST_FOLDER }, expected: 'success|already exists' },
 
   // === CREATE / SAVE / LOAD ===
-  { scenario: 'CREATE: create_level', toolName: 'manage_level', arguments: { action: 'create_level', levelName: `LevelMain_${ts}`, levelPath: TEST_FOLDER, useWorldPartition: false }, expected: 'success|already exists' },
+  { scenario: 'CREATE: create_level', toolName: 'manage_level', arguments: { action: 'create_level', levelName: `LevelMain_${ts}`, levelPath: TEST_FOLDER, useWorldPartition: false, saveDirtyPackages: true }, expected: 'success|already exists' },
   { scenario: 'ACTION: save', toolName: 'manage_level', arguments: { action: 'save' }, expected: 'success' },
   { scenario: 'ACTION: save_level alias', toolName: 'manage_level', arguments: { action: 'save_level' }, expected: 'success' },
   { scenario: 'ACTION: save_as', toolName: 'manage_level', arguments: { action: 'save_as', savePath: SAVE_AS_LEVEL }, expected: 'success' },
   { scenario: 'ACTION: save_level_as', toolName: 'manage_level', arguments: { action: 'save_level_as', savePath: SAVE_LEVEL_AS }, expected: 'success' },
-  { scenario: 'Setup: create sublevel', toolName: 'manage_level', arguments: { action: 'create_level', levelName: `LevelSub_${ts}`, levelPath: TEST_FOLDER, useWorldPartition: false }, expected: 'success|already exists' },
-  { scenario: 'ACTION: load', toolName: 'manage_level', arguments: { action: 'load', levelPath: MAIN_LEVEL, streaming: false }, expected: 'success' },
-  { scenario: 'ACTION: load_level alias', toolName: 'manage_level', arguments: { action: 'load_level', levelPath: MAIN_LEVEL, streaming: false }, expected: 'success' },
+  { scenario: 'Setup: create sublevel', toolName: 'manage_level', arguments: { action: 'create_level', levelName: `LevelSub_${ts}`, levelPath: TEST_FOLDER, useWorldPartition: false, saveDirtyPackages: true }, expected: 'success|already exists' },
+  { scenario: 'ACTION: load', toolName: 'manage_level', arguments: { action: 'load', levelPath: MAIN_LEVEL, streaming: false, saveDirtyPackages: true }, expected: 'success' },
+  { scenario: 'ACTION: load_level alias', toolName: 'manage_level', arguments: { action: 'load_level', levelPath: MAIN_LEVEL, streaming: false, saveDirtyPackages: true }, expected: 'success' },
   { scenario: 'Setup: spawn actor in level', toolName: 'control_actor', arguments: { action: 'spawn', classPath: '/Engine/BasicShapes/Cube', actorName: TEST_ACTOR, location: { x: 0, y: 0, z: 100 } }, expected: 'success' },
 
   // === STREAMING ===


### PR DESCRIPTION
## Summary

Harden MCP tool parity and live Unreal workflows by fixing nested action params, safer level operations, native MCP session validation, and several live handler response issues.

## Changes

- Support nested `params` action payloads in the TypeScript MCP tool registry and consolidated handler routing.
- Harden Unreal plugin level save/copy/load workflows and dirty-package handling.
- Validate native MCP sessions/CORS behavior and align native schema metadata.
- Stabilize action aliases and handler responses for geometry, texture, Insights, widget authoring, and system control flows.
- Update related docs and add/adjust unit, smoke, params, and live test coverage.

## Related Issues

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📚 Documentation update
- [ ] 🔧 Configuration/build change
- [ ] ♻️ Refactoring (no functional changes)
- [x] 🧪 Test addition/update

## Testing

- [x] Tested with Unreal Engine (version: headless MCPtest editor)
- [x] Tested MCP client integration (client: TypeScript MCP server + live WebSocket bridge)
- [x] Added/updated tests

Verification run:

- `npm run type-check`
- `npm run build:core`
- `npm run test:unit` (`302/302`)
- `npm run test:smoke`
- `npm run test:params`
- UBT rebuild: `MCPtestEditor Linux Development` succeeded
- live `manage-level`: `31/31`
- live `system-control`: `56/56`
- previously verified live suites: integration `66/66`, manage-asset `151/151`, manage-gas `30/30`, manage-geometry passed, control-editor `49/49`, animation-physics `97/97`

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Updated relevant documentation (if needed)
- [x] Added/updated tests (if applicable)
- [x] CI passes