### PR TITLE
fix(native-mcp): deliver async landscape responses

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridgeSubsystem.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridgeSubsystem.cpp
@@ -711,6 +711,14 @@ void UMcpAutomationBridgeSubsystem::SendAutomationResponse(
   // CurrentRequestOrigin from the active ProcessAutomationRequest call.
   ERequestOrigin EffectiveOrigin = (Origin == ERequestOrigin::WebSocket)
       ? CurrentRequestOrigin : Origin;
+  // Some handlers complete later via AsyncTask(GameThread) after the request
+  // scope has already reset CurrentRequestOrigin. A live native pending request
+  // is authoritative in that case and must receive the response over SSE.
+  if (Origin == ERequestOrigin::WebSocket && NativeTransport &&
+      NativeTransport->HasPendingRequest(RequestId))
+  {
+    EffectiveOrigin = ERequestOrigin::NativeHTTP;
+  }
   if (EffectiveOrigin == ERequestOrigin::NativeHTTP && NativeTransport)
   {
     if (!NativeTransport->CompletePendingRequest(RequestId, bEffectiveSuccess, EffectiveMessage, EffectiveResult, EffectiveErrorCode))

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_ControlHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_ControlHandlers.cpp
@@ -69,6 +69,8 @@
 // -----------------------------------------------------------------------------
 #include "EditorAssetLibrary.h"
 #include "EngineUtils.h"
+#include "Landscape.h"
+#include "LandscapeInfo.h"
 
 // -----------------------------------------------------------------------------
 // Editor-only Includes: Editor Subsystems (paths vary by UE version)
@@ -2063,6 +2065,57 @@ bool UMcpAutomationBridgeSubsystem::HandleControlActorGetBoundingBox(
 
   FVector Origin, BoxExtent;
   Found->GetActorBounds(false, Origin, BoxExtent);
+
+  if (ALandscape* Landscape = Cast<ALandscape>(Found)) {
+    ULandscapeInfo* LandscapeInfo = Landscape->GetLandscapeInfo();
+    int32 MinX = 0, MinY = 0, MaxX = 0, MaxY = 0;
+    if (LandscapeInfo && LandscapeInfo->GetLandscapeExtent(MinX, MinY, MaxX, MaxY)) {
+      const FVector MinWorld = Landscape->GetTransform().TransformPosition(
+          FVector(static_cast<double>(MinX), static_cast<double>(MinY), -256.0));
+      const FVector MaxWorld = Landscape->GetTransform().TransformPosition(
+          FVector(static_cast<double>(MaxX), static_cast<double>(MaxY), 256.0));
+      const FBox LandscapeBox(MinWorld.ComponentMin(MaxWorld),
+                              MinWorld.ComponentMax(MaxWorld));
+      Origin = LandscapeBox.GetCenter();
+      BoxExtent = LandscapeBox.GetExtent();
+    } else {
+      const FBox ProxyBounds = Landscape->GetProxyBounds();
+      if (ProxyBounds.IsValid) {
+        Origin = ProxyBounds.GetCenter();
+        BoxExtent = ProxyBounds.GetExtent();
+      }
+    }
+
+    if (BoxExtent.IsNearlyZero()) {
+      int32 ComponentsX = 0;
+      int32 ComponentsY = 0;
+      int32 QuadsPerComponent = Landscape->ComponentSizeQuads;
+      for (const FName& TagName : Landscape->Tags) {
+        const FString Tag = TagName.ToString();
+        FString Value;
+        if (Tag.Split(TEXT("="), nullptr, &Value)) {
+          if (Tag.StartsWith(TEXT("MCP_LandscapeComponentsX="))) {
+            ComponentsX = FCString::Atoi(*Value);
+          } else if (Tag.StartsWith(TEXT("MCP_LandscapeComponentsY="))) {
+            ComponentsY = FCString::Atoi(*Value);
+          } else if (Tag.StartsWith(TEXT("MCP_LandscapeQuadsPerComponent="))) {
+            QuadsPerComponent = FCString::Atoi(*Value);
+          }
+        }
+      }
+      if (ComponentsX > 0 && ComponentsY > 0 && QuadsPerComponent > 0) {
+        const FVector LocalMax(ComponentsX * QuadsPerComponent,
+                               ComponentsY * QuadsPerComponent,
+                               512.0);
+        const FVector MinWorld = Landscape->GetTransform().TransformPosition(FVector::ZeroVector);
+        const FVector MaxWorld = Landscape->GetTransform().TransformPosition(LocalMax);
+        const FBox LandscapeBox(MinWorld.ComponentMin(MaxWorld),
+                                MinWorld.ComponentMax(MaxWorld));
+        Origin = LandscapeBox.GetCenter();
+        BoxExtent = LandscapeBox.GetExtent();
+      }
+    }
+  }
 
   TSharedPtr<FJsonObject> Data = McpHandlerUtils::CreateResultObject();
 

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_ControlHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_ControlHandlers.cpp
@@ -2109,7 +2109,7 @@ bool UMcpAutomationBridgeSubsystem::HandleControlActorGetBoundingBox(
         const double MaxYFromMetadata = Metadata.ComponentsY * Metadata.QuadsPerComponent;
         const FBox LandscapeBox = BuildLandscapeBox(
             Landscape->GetTransform(), 0.0, 0.0, MaxXFromMetadata,
-            MaxYFromMetadata, 0.0, 512.0);
+            MaxYFromMetadata, -256.0, 256.0);
         Origin = LandscapeBox.GetCenter();
         BoxExtent = LandscapeBox.GetExtent();
       }

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_ControlHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_ControlHandlers.cpp
@@ -56,6 +56,7 @@
 #include "McpAutomationBridgeHelpers.h"
 #include "McpHandlerUtils.h"
 #include "McpAutomationBridgeSubsystem.h"
+#include "McpLandscapeMetadataTags.h"
 #include "Misc/App.h"
 #include "Misc/CommandLine.h"
 #include "Misc/DateTime.h"
@@ -2066,19 +2067,34 @@ bool UMcpAutomationBridgeSubsystem::HandleControlActorGetBoundingBox(
   FVector Origin, BoxExtent;
   Found->GetActorBounds(false, Origin, BoxExtent);
 
-  if (ALandscape* Landscape = Cast<ALandscape>(Found)) {
+  auto BuildLandscapeBox = [](const FTransform& Transform, double MinX,
+                              double MinY, double MaxX, double MaxY,
+                              double MinZ, double MaxZ) {
+    FBox LandscapeBox(EForceInit::ForceInit);
+    const FVector Corners[] = {
+        FVector(MinX, MinY, MinZ), FVector(MinX, MaxY, MinZ),
+        FVector(MaxX, MinY, MinZ), FVector(MaxX, MaxY, MinZ),
+        FVector(MinX, MinY, MaxZ), FVector(MinX, MaxY, MaxZ),
+        FVector(MaxX, MinY, MaxZ), FVector(MaxX, MaxY, MaxZ),
+    };
+    for (const FVector& Corner : Corners) {
+      LandscapeBox += Transform.TransformPosition(Corner);
+    }
+    return LandscapeBox;
+  };
+
+  if (ALandscape* Landscape = Cast<ALandscape>(Found);
+      Landscape && BoxExtent.IsNearlyZero()) {
     ULandscapeInfo* LandscapeInfo = Landscape->GetLandscapeInfo();
     int32 MinX = 0, MinY = 0, MaxX = 0, MaxY = 0;
     if (LandscapeInfo && LandscapeInfo->GetLandscapeExtent(MinX, MinY, MaxX, MaxY)) {
-      const FVector MinWorld = Landscape->GetTransform().TransformPosition(
-          FVector(static_cast<double>(MinX), static_cast<double>(MinY), -256.0));
-      const FVector MaxWorld = Landscape->GetTransform().TransformPosition(
-          FVector(static_cast<double>(MaxX), static_cast<double>(MaxY), 256.0));
-      const FBox LandscapeBox(MinWorld.ComponentMin(MaxWorld),
-                              MinWorld.ComponentMax(MaxWorld));
+      const FBox LandscapeBox = BuildLandscapeBox(
+          Landscape->GetTransform(), MinX, MinY, MaxX, MaxY, -256.0, 256.0);
       Origin = LandscapeBox.GetCenter();
       BoxExtent = LandscapeBox.GetExtent();
-    } else {
+    }
+
+    if (BoxExtent.IsNearlyZero()) {
       const FBox ProxyBounds = Landscape->GetProxyBounds();
       if (ProxyBounds.IsValid) {
         Origin = ProxyBounds.GetCenter();
@@ -2087,30 +2103,13 @@ bool UMcpAutomationBridgeSubsystem::HandleControlActorGetBoundingBox(
     }
 
     if (BoxExtent.IsNearlyZero()) {
-      int32 ComponentsX = 0;
-      int32 ComponentsY = 0;
-      int32 QuadsPerComponent = Landscape->ComponentSizeQuads;
-      for (const FName& TagName : Landscape->Tags) {
-        const FString Tag = TagName.ToString();
-        FString Value;
-        if (Tag.Split(TEXT("="), nullptr, &Value)) {
-          if (Tag.StartsWith(TEXT("MCP_LandscapeComponentsX="))) {
-            ComponentsX = FCString::Atoi(*Value);
-          } else if (Tag.StartsWith(TEXT("MCP_LandscapeComponentsY="))) {
-            ComponentsY = FCString::Atoi(*Value);
-          } else if (Tag.StartsWith(TEXT("MCP_LandscapeQuadsPerComponent="))) {
-            QuadsPerComponent = FCString::Atoi(*Value);
-          }
-        }
-      }
-      if (ComponentsX > 0 && ComponentsY > 0 && QuadsPerComponent > 0) {
-        const FVector LocalMax(ComponentsX * QuadsPerComponent,
-                               ComponentsY * QuadsPerComponent,
-                               512.0);
-        const FVector MinWorld = Landscape->GetTransform().TransformPosition(FVector::ZeroVector);
-        const FVector MaxWorld = Landscape->GetTransform().TransformPosition(LocalMax);
-        const FBox LandscapeBox(MinWorld.ComponentMin(MaxWorld),
-                                MinWorld.ComponentMax(MaxWorld));
+      FMcpLandscapeMetadata Metadata;
+      if (McpLandscapeMetadataTags::DecodeLandscapeMetadata(Landscape, Metadata)) {
+        const double MaxXFromMetadata = Metadata.ComponentsX * Metadata.QuadsPerComponent;
+        const double MaxYFromMetadata = Metadata.ComponentsY * Metadata.QuadsPerComponent;
+        const FBox LandscapeBox = BuildLandscapeBox(
+            Landscape->GetTransform(), 0.0, 0.0, MaxXFromMetadata,
+            MaxYFromMetadata, 0.0, 512.0);
         Origin = LandscapeBox.GetCenter();
         BoxExtent = LandscapeBox.GetExtent();
       }

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_EnvironmentHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_EnvironmentHandlers.cpp
@@ -414,11 +414,12 @@ bool UMcpAutomationBridgeSubsystem::HandleBuildEnvironmentAction(
     // =========================================================================
     if (LowerSub == TEXT("add_foliage_instances"))
     {
-        // Transform from build_environment schema to foliage handler schema
         FString FoliageTypePath;
-        Payload->TryGetStringField(TEXT("foliageType"), FoliageTypePath);
-        const TArray<TSharedPtr<FJsonValue>> *Transforms = nullptr;
-        Payload->TryGetArrayField(TEXT("transforms"), Transforms);
+        if (!Payload->TryGetStringField(TEXT("foliageTypePath"), FoliageTypePath) ||
+            FoliageTypePath.IsEmpty())
+        {
+            Payload->TryGetStringField(TEXT("foliageType"), FoliageTypePath);
+        }
 
         TSharedPtr<FJsonObject> FoliagePayload = McpHandlerUtils::CreateResultObject();
         if (!FoliageTypePath.IsEmpty())
@@ -426,42 +427,22 @@ bool UMcpAutomationBridgeSubsystem::HandleBuildEnvironmentAction(
             FoliagePayload->SetStringField(TEXT("foliageTypePath"), FoliageTypePath);
         }
 
-        // Extract locations from transforms
-        TArray<TSharedPtr<FJsonValue>> Locations;
+        // Preserve full transform data so callers can specify rotation and scale.
+        const TArray<TSharedPtr<FJsonValue>> *Transforms = nullptr;
+        Payload->TryGetArrayField(TEXT("transforms"), Transforms);
         if (Transforms)
         {
-            for (const TSharedPtr<FJsonValue> &V : *Transforms)
-            {
-                if (!V.IsValid() || V->Type != EJson::Object)
-                {
-                    continue;
-                }
-                const TSharedPtr<FJsonObject> *TObj = nullptr;
-                if (!V->TryGetObject(TObj) || !TObj)
-                {
-                    continue;
-                }
-                const TSharedPtr<FJsonObject> *LocObj = nullptr;
-                if (!(*TObj)->TryGetObjectField(TEXT("location"), LocObj) || !LocObj)
-                {
-                    continue;
-                }
-                
-                double X = 0, Y = 0, Z = 0;
-                (*LocObj)->TryGetNumberField(TEXT("x"), X);
-                (*LocObj)->TryGetNumberField(TEXT("y"), Y);
-                (*LocObj)->TryGetNumberField(TEXT("z"), Z);
-
-                TSharedPtr<FJsonObject> L = McpHandlerUtils::CreateResultObject();
-                L->SetNumberField(TEXT("x"), X);
-                L->SetNumberField(TEXT("y"), Y);
-                L->SetNumberField(TEXT("z"), Z);
-                Locations.Add(MakeShared<FJsonValueObject>(L));
-            }
+            FoliagePayload->SetArrayField(TEXT("transforms"), *Transforms);
         }
-        FoliagePayload->SetArrayField(TEXT("locations"), Locations);
-        return HandlePaintFoliage(RequestId, TEXT("paint_foliage"), FoliagePayload,
-                                  RequestingSocket);
+
+        const TArray<TSharedPtr<FJsonValue>> *Locations = nullptr;
+        if (Payload->TryGetArrayField(TEXT("locations"), Locations) && Locations)
+        {
+            FoliagePayload->SetArrayField(TEXT("locations"), *Locations);
+        }
+
+        return HandleAddFoliageInstances(RequestId, TEXT("add_foliage_instances"),
+                                         FoliagePayload, RequestingSocket);
     }
     else if (LowerSub == TEXT("get_foliage_instances"))
     {

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_FoliageHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_FoliageHandlers.cpp
@@ -1005,6 +1005,13 @@ bool UMcpAutomationBridgeSubsystem::HandleAddFoliageInstances(
     }
   }
 
+  if (ParsedTransforms.Num() == 0) {
+    SendAutomationError(RequestingSocket, RequestId,
+                        TEXT("transforms or locations must contain at least one valid location"),
+                        TEXT("INVALID_ARGUMENT"));
+    return true;
+  }
+
   if (!GEditor || !GEditor->GetEditorWorldContext().World()) {
     SendAutomationError(RequestingSocket, RequestId,
                         TEXT("Editor world not available"),

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_LandscapeHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_LandscapeHandlers.cpp
@@ -112,6 +112,7 @@
 #include "McpAutomationBridgeGlobals.h"
 #include "McpAutomationBridgeHelpers.h"
 #include "McpAutomationBridgeSubsystem.h"
+#include "McpLandscapeMetadataTags.h"
 #include "ScopedTransaction.h"
 
 // =============================================================================
@@ -421,9 +422,8 @@ bool UMcpAutomationBridgeSubsystem::HandleCreateLandscape(
     Landscape->NumSubsections = CaptSectionsPerComponent;
     // Keep authoring metadata on the actor so generic actor bounds can still
     // report a useful footprint when UE has not generated landscape components.
-    Landscape->Tags.AddUnique(FName(*FString::Printf(TEXT("MCP_LandscapeComponentsX=%d"), CaptComponentsX)));
-    Landscape->Tags.AddUnique(FName(*FString::Printf(TEXT("MCP_LandscapeComponentsY=%d"), CaptComponentsY)));
-    Landscape->Tags.AddUnique(FName(*FString::Printf(TEXT("MCP_LandscapeQuadsPerComponent=%d"), CaptQuadsPerComponent)));
+    McpLandscapeMetadataTags::EncodeLandscapeMetadata(
+        Landscape, CaptComponentsX, CaptComponentsY, CaptQuadsPerComponent);
 
     if (!CaptMaterialPath.IsEmpty()) {
       UMaterialInterface *Mat =

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_LandscapeHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_LandscapeHandlers.cpp
@@ -419,6 +419,11 @@ bool UMcpAutomationBridgeSubsystem::HandleCreateLandscape(
     Landscape->SubsectionSizeQuads =
         CaptQuadsPerComponent / CaptSectionsPerComponent;
     Landscape->NumSubsections = CaptSectionsPerComponent;
+    // Keep authoring metadata on the actor so generic actor bounds can still
+    // report a useful footprint when UE has not generated landscape components.
+    Landscape->Tags.AddUnique(FName(*FString::Printf(TEXT("MCP_LandscapeComponentsX=%d"), CaptComponentsX)));
+    Landscape->Tags.AddUnique(FName(*FString::Printf(TEXT("MCP_LandscapeComponentsY=%d"), CaptComponentsY)));
+    Landscape->Tags.AddUnique(FName(*FString::Printf(TEXT("MCP_LandscapeQuadsPerComponent=%d"), CaptQuadsPerComponent)));
 
     if (!CaptMaterialPath.IsEmpty()) {
       UMaterialInterface *Mat =
@@ -585,9 +590,12 @@ bool UMcpAutomationBridgeSubsystem::HandleCreateLandscape(
     Resp->SetBoolField(TEXT("success"), true);
     Resp->SetStringField(TEXT("landscapePath"), Landscape->GetPackage()->GetPathName());
     Resp->SetStringField(TEXT("actorLabel"), Landscape->GetActorLabel());
+    Resp->SetStringField(TEXT("landscapeName"), Landscape->GetActorLabel());
     Resp->SetNumberField(TEXT("componentsX"), CaptComponentsX);
     Resp->SetNumberField(TEXT("componentsY"), CaptComponentsY);
     Resp->SetNumberField(TEXT("quadsPerComponent"), CaptQuadsPerComponent);
+    Resp->SetNumberField(TEXT("extentX"), CaptComponentsX * CaptQuadsPerComponent * Landscape->GetActorScale3D().X * 0.5);
+    Resp->SetNumberField(TEXT("extentY"), CaptComponentsY * CaptQuadsPerComponent * Landscape->GetActorScale3D().Y * 0.5);
 
     Subsystem->SendAutomationResponse(RequestingSocket, RequestId, true,
                                       TEXT("Landscape created successfully"),

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpLandscapeMetadataTags.h
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpLandscapeMetadataTags.h
@@ -3,6 +3,7 @@
 #include "CoreMinimal.h"
 #include "GameFramework/Actor.h"
 
+/** Authoring dimensions encoded on MCP-created Landscape actors. */
 struct FMcpLandscapeMetadata
 {
   int32 ComponentsX = 0;
@@ -16,8 +17,12 @@ static constexpr const TCHAR* ComponentsXKey = TEXT("MCP_LandscapeComponentsX");
 static constexpr const TCHAR* ComponentsYKey = TEXT("MCP_LandscapeComponentsY");
 static constexpr const TCHAR* QuadsPerComponentKey = TEXT("MCP_LandscapeQuadsPerComponent");
 
-// Landscape dimensions are stored as actor tags so generic actor tools can
-// recover authoring bounds before Unreal has generated landscape components.
+/**
+ * Replaces a single integer metadata tag on an actor.
+ *
+ * Landscape dimensions are stored as actor tags so generic actor tools can
+ * recover authoring bounds before Unreal has generated landscape components.
+ */
 inline void AddIntTag(AActor* Actor, const TCHAR* Key, int32 Value)
 {
   if (!Actor)
@@ -32,6 +37,7 @@ inline void AddIntTag(AActor* Actor, const TCHAR* Key, int32 Value)
   Actor->Tags.Add(FName(*FString::Printf(TEXT("%s%d"), *Prefix, Value)));
 }
 
+/** Encodes MCP landscape authoring dimensions onto an actor's tags. */
 inline void EncodeLandscapeMetadata(AActor* Actor, int32 ComponentsX, int32 ComponentsY, int32 QuadsPerComponent)
 {
   AddIntTag(Actor, ComponentsXKey, ComponentsX);
@@ -39,6 +45,7 @@ inline void EncodeLandscapeMetadata(AActor* Actor, int32 ComponentsX, int32 Comp
   AddIntTag(Actor, QuadsPerComponentKey, QuadsPerComponent);
 }
 
+/** Reads one integer metadata tag from an actor. */
 inline bool TryReadIntTag(const AActor* Actor, const TCHAR* Key, int32& OutValue)
 {
   if (!Actor)
@@ -59,6 +66,7 @@ inline bool TryReadIntTag(const AActor* Actor, const TCHAR* Key, int32& OutValue
   return false;
 }
 
+/** Decodes and validates MCP landscape authoring dimensions from actor tags. */
 inline bool DecodeLandscapeMetadata(const AActor* Actor, FMcpLandscapeMetadata& OutMetadata)
 {
   const bool bHasComponentsX = TryReadIntTag(Actor, ComponentsXKey, OutMetadata.ComponentsX);

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpLandscapeMetadataTags.h
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpLandscapeMetadataTags.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+
+struct FMcpLandscapeMetadata
+{
+  int32 ComponentsX = 0;
+  int32 ComponentsY = 0;
+  int32 QuadsPerComponent = 0;
+};
+
+namespace McpLandscapeMetadataTags
+{
+static constexpr const TCHAR* ComponentsXKey = TEXT("MCP_LandscapeComponentsX");
+static constexpr const TCHAR* ComponentsYKey = TEXT("MCP_LandscapeComponentsY");
+static constexpr const TCHAR* QuadsPerComponentKey = TEXT("MCP_LandscapeQuadsPerComponent");
+
+// Landscape dimensions are stored as actor tags so generic actor tools can
+// recover authoring bounds before Unreal has generated landscape components.
+inline void AddIntTag(AActor* Actor, const TCHAR* Key, int32 Value)
+{
+  if (!Actor)
+  {
+    return;
+  }
+
+  const FString Prefix = FString::Printf(TEXT("%s="), Key);
+  Actor->Tags.RemoveAll([&Prefix](const FName& TagName) {
+    return TagName.ToString().StartsWith(Prefix);
+  });
+  Actor->Tags.Add(FName(*FString::Printf(TEXT("%s%d"), *Prefix, Value)));
+}
+
+inline void EncodeLandscapeMetadata(AActor* Actor, int32 ComponentsX, int32 ComponentsY, int32 QuadsPerComponent)
+{
+  AddIntTag(Actor, ComponentsXKey, ComponentsX);
+  AddIntTag(Actor, ComponentsYKey, ComponentsY);
+  AddIntTag(Actor, QuadsPerComponentKey, QuadsPerComponent);
+}
+
+inline bool TryReadIntTag(const AActor* Actor, const TCHAR* Key, int32& OutValue)
+{
+  if (!Actor)
+  {
+    return false;
+  }
+
+  const FString Prefix = FString::Printf(TEXT("%s="), Key);
+  for (const FName& TagName : Actor->Tags)
+  {
+    const FString Tag = TagName.ToString();
+    if (Tag.StartsWith(Prefix))
+    {
+      OutValue = FCString::Atoi(*Tag.RightChop(Prefix.Len()));
+      return true;
+    }
+  }
+  return false;
+}
+
+inline bool DecodeLandscapeMetadata(const AActor* Actor, FMcpLandscapeMetadata& OutMetadata)
+{
+  const bool bHasComponentsX = TryReadIntTag(Actor, ComponentsXKey, OutMetadata.ComponentsX);
+  const bool bHasComponentsY = TryReadIntTag(Actor, ComponentsYKey, OutMetadata.ComponentsY);
+  const bool bHasQuads = TryReadIntTag(Actor, QuadsPerComponentKey, OutMetadata.QuadsPerComponent);
+  return bHasComponentsX && bHasComponentsY && bHasQuads &&
+      OutMetadata.ComponentsX > 0 && OutMetadata.ComponentsY > 0 &&
+      OutMetadata.QuadsPerComponent > 0;
+}
+} // namespace McpLandscapeMetadataTags


### PR DESCRIPTION
## Summary

Fixes Native MCP tool calls that complete asynchronously after their original request context has reset. This caused `build_environment.create_landscape` and related Landscape authoring actions to succeed inside Unreal but fail to deliver the final SSE response to the MCP client. The PR also tightens Landscape authoring follow-up behavior by returning useful bounds metadata, preserving valid native Landscape bounds, and fixing `build_environment.add_foliage_instances` forwarding for `foliageTypePath`.

## Changes

- Route responses back to pending Native MCP HTTP/SSE requests when asynchronous handlers complete after `CurrentRequestOrigin` has reset.
- Preserve `build_environment.add_foliage_instances` transform payloads and accept `foliageTypePath` consistently with the public schema.
- Add shared Landscape metadata tag encode/decode helpers so created Landscape dimensions are written and read through one implementation.
- Add Landscape authoring metadata to newly created landscapes and use it only as a fallback for `control_actor.get_actor_bounds` when Unreal returns zero native bounds.
- Build fallback Landscape AABBs from all transformed XY corners and symmetric Z extremes so rotated Landscapes produce correct non-zero bounds and consistent centers.
- Include `landscapeName` and extent hints in `create_landscape` responses for easier follow-up validation.

## Related Issues

Related to local scene authoring findings in `unreal-mcp-scene-authoring-issues.md`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration/build change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test addition/update

## Testing

- [x] Tested with Unreal Engine (version: 5.7)
- [x] Tested MCP client integration (client: Native MCP HTTP)
- [ ] Added/updated tests

Validation performed:

- Reproduced the pre-fix failure with Native MCP `build_environment.create_landscape`: Unreal logged `Landscape created successfully`, then `Failed to deliver automation_response`, while the MCP client eventually reported the server/session shutting down.
- Rebuilt with UBT after closing Unreal Editor: `test_thirdEditor Win64 Development -Project=D:\me\code\ue\test_third\test_third.uproject -WaitMutex -NoHotReloadFromIDE`.
- Restarted Unreal Engine 5.7 and verified Native MCP HTTP calls returned SSE results for `build_environment.create_landscape`, `build_environment.set_landscape_material`, and `build_environment.paint_landscape_layer`.
- Applied the review follow-up with Live Coding via Native MCP `control_editor.console_command` using `LiveCoding.Compile`; Unreal logged `Live coding succeeded`.
- Verified `control_actor.get_actor_bounds` returns non-zero bounds for a newly created MCP Landscape.
- Verified `control_actor.get_actor_bounds` returns non-zero extents after rotating a newly created MCP Landscape by yaw 37 degrees.
- Verified the metadata fallback uses symmetric Z bounds by confirming a rotated newly created MCP Landscape reports `origin.z = 0` instead of the prior offset center.
- Verified `build_environment.add_foliage_instances` with `foliageTypePath` reaches asset validation and no longer fails with a missing foliage type parameter error.
- Ran `npm run build:core` successfully.
- Ran `git diff --check` successfully.

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Updated relevant documentation (if needed)
- [ ] Added/updated tests (not added; runtime behavior was validated against UE 5.7 via Native MCP HTTP)
- [ ] CI passes