### PR TITLE
fix: route manage_blueprint AnimBP graph discovery actions to correct handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Game Feature Plugin path validation** – `SanitizeProjectRelativePath` now uses `FPackageName::IsValidLongPackageName` instead of a manual `/Content/` heuristic, correctly recognizing all registered engine mount points (game feature plugins like `/MyGameFeature/`, `/ShooterCore/`, `/ALS/`, etc.).
 - **`manage_level: get_level_info` no longer requires the level to be loaded** – previously returned `LEVEL_NOT_FOUND` for any map asset path that hadn't already been `load_level`'d. Now falls back to `IAssetRegistry::GetAssetByObjectPath` and returns `objectPath`, `assetName`, `packageName`, `assetClass`, and the asset's `tagsAndValues` map alongside `loaded: false`. The loaded case is unchanged but now also includes `loaded: true`. Does not auto-load the level.
+- **`manage_blueprint`: AnimBP graph discovery actions now route to the correct handler** – `list_animbp_graphs` and `get_transition_rule_graph` are implemented in `HandleBlueprintGraphAction` (`McpAutomationBridge_BlueprintGraphHandlers.cpp`) but were missing from the dispatcher's `GraphSubActions` set in `McpAutomationBridgeSubsystem.cpp`, so requests fell through to `HandleBlueprintAction` and returned `UNKNOWN_ACTION`. Adds both actions to the routing set. No handler changes required.
 
 ### Tests
 

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridgeSubsystem.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridgeSubsystem.cpp
@@ -1375,7 +1375,14 @@ void UMcpAutomationBridgeSubsystem::InitializeHandlers() {
                         TEXT("set_node_property"), TEXT("create_reroute_node"),
                         TEXT("get_node_details"),  TEXT("get_graph_details"),
                         TEXT("get_pin_details"),   TEXT("list_node_types"),
-                        TEXT("set_pin_default_value")};
+                        TEXT("set_pin_default_value"),
+                        // Wave 6B Path-a AnimBP graph discovery actions —
+                        // implemented in HandleBlueprintGraphAction (early
+                        // dispatch L691/831) but were missing from this routing
+                        // set, so manage_blueprint requests fell through to
+                        // HandleBlueprintAction and returned UNKNOWN_ACTION.
+                        TEXT("list_animbp_graphs"),
+                        TEXT("get_transition_rule_graph")};
                     if (GraphSubActions.Contains(SubAction)) {
                       return HandleBlueprintGraphAction(R, A, P, S);
                     }


### PR DESCRIPTION
## Summary

`manage_blueprint` actions `list_animbp_graphs` and `get_transition_rule_graph` were implemented in `HandleBlueprintGraphAction` (`McpAutomationBridge_BlueprintGraphHandlers.cpp` early-dispatch around L691/L831, guarded by `MCP_BGH_HAS_ANIM_DISCOVERY`) but were missing from the dispatcher's `GraphSubActions` routing set in `McpAutomationBridgeSubsystem.cpp`. Requests therefore fell through to `HandleBlueprintAction` and returned `UNKNOWN_ACTION`, even though the underlying handler code was present and shipping.

This one-line routing fix wires both actions to the existing handler. No handler changes required.

## Changes

- `plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridgeSubsystem.cpp` — add `list_animbp_graphs` and `get_transition_rule_graph` to `GraphSubActions` set, with a comment explaining the historical reason for the gap.
- `CHANGELOG.md` — entry under `[Unreleased] / Fixed`.

## Related Issues

Discovered while triaging an internal MCP issue list against `dev` HEAD. No upstream issue filed yet — happy to open one if maintainers prefer.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement

## Testing

Per CONTRIBUTING.md "Before Submitting":
- [x] ``npm run lint`` — 0 warnings
- [x] ``npm run test:smoke`` — Smoke Test PASSED (22 tools, manage_tools params OK)
- [x] ``npm run type-check`` — 0 errors
- [x] ``npm run build`` — clean

Live verification in UE 5.7 with plugin rebuilt:
- Before fix: ``manage_blueprint list_animbp_graphs blueprintPath=/Game/.../ABP_Wolf`` returned ``UNKNOWN_ACTION``.
- After fix: same call returns the full AnimGraph + state machine graph list as the handler intended.

## Pre-Merge Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas (added rationale comment above the new Set entries)
- [x] I have made corresponding changes to the documentation (CHANGELOG.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective (live MCP verify above; no unit test added since the change is a routing string-set entry covered by existing dispatch tests if any)
- [x] New and existing tests pass locally (``test:smoke`` PASSED)
- [x] I have updated CHANGELOG.md