### PR TITLE
fix(plugin): use complete landscape bounds fallback

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_ControlHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_ControlHandlers.cpp
@@ -2101,10 +2101,10 @@ bool UMcpAutomationBridgeSubsystem::HandleControlActorGetBoundingBox(
     }
 
     if (BoxExtent.IsNearlyZero()) {
-      const FBox ProxyBounds = Landscape->GetProxyBounds();
-      if (ProxyBounds.IsValid) {
-        Origin = ProxyBounds.GetCenter();
-        BoxExtent = ProxyBounds.GetExtent();
+      const FBox CompleteBounds = Landscape->GetCompleteBounds();
+      if (CompleteBounds.IsValid) {
+        Origin = CompleteBounds.GetCenter();
+        BoxExtent = CompleteBounds.GetExtent();
       }
     }
 


### PR DESCRIPTION
## Summary
- Replace the landscape bounding-box fallback in `HandleControlActorGetBoundingBox` with `ALandscape::GetCompleteBounds()`
- Avoid relying on `GetProxyBounds()` for `ALandscape`, improving compatibility across checked UE 5.x versions

Fixes #423

## Validation
- `./scripts/package-plugin.sh /data/UnrealEngine-5.3.2 /tmp/opencode/McpAutomationBridge-UE5.3.2`
- `./scripts/package-plugin.sh /data/UnrealEngine-5.5.4 /tmp/opencode/McpAutomationBridge-UE5.5.4`
- `./scripts/package-plugin.sh /data/UnrealEngine /tmp/opencode/McpAutomationBridge-UE5.7.4`
- `./scripts/package-plugin.sh /data/UnrealEngine-5.8.0-preview-1 /tmp/opencode/McpAutomationBridge-UE5.8.0-preview-1`

