### PR TITLE
fix: execute_python file mode in automation bridge

### DIFF
--- a/plugins/McpAutomationBridge/McpAutomationBridge.uplugin
+++ b/plugins/McpAutomationBridge/McpAutomationBridge.uplugin
@@ -25,6 +25,10 @@
   ],
   "Plugins": [
     {
+      "Name": "PythonScriptPlugin",
+      "Enabled": true
+    },
+    {
       "Name": "EditorScriptingUtilities",
       "Enabled": true
     },

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/McpAutomationBridge.Build.cs
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/McpAutomationBridge.Build.cs
@@ -161,7 +161,7 @@ public class McpAutomationBridge : ModuleRules
                 "ApplicationCore","Slate","SlateCore","Projects","InputCore","DeveloperSettings","Settings","EngineSettings",
                 "Sockets","Networking","EditorSubsystem","EditorScriptingUtilities","BlueprintGraph","SSL",
                 "Kismet","KismetCompiler","AssetRegistry","AssetTools","SourceControl",
-                "AudioEditor", "AudioMixer",
+                "AudioEditor", "AudioMixer", "PythonScriptPlugin",
                 // Native MCP uses raw sockets (Sockets/Networking already listed above)
                 // Optional plugins are handled by AddOptionalDynamicModule() below with delay-load
             });

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_SystemControlHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_SystemControlHandlers.cpp
@@ -19,6 +19,7 @@
 #include "Materials/Material.h"
 #include "Materials/MaterialInstanceConstant.h"
 #include "Exporters/Exporter.h"
+#include "IPythonScriptPlugin.h"
 #include "Misc/FileHelper.h"
 #endif
 
@@ -654,6 +655,19 @@ bool UMcpAutomationBridgeSubsystem::HandleSystemControlAction(
 
     // Build Python wrapper
     FString Wrapper;
+    auto AppendPythonExec = [&Wrapper](const FString& PyScriptPath,
+                                       const FString& PyScriptDir) {
+      Wrapper += FString::Printf(TEXT("    _script_path = r'%s'\n"), *PyScriptPath);
+      Wrapper += FString::Printf(TEXT("    _script_dir = r'%s'\n"), *PyScriptDir);
+      Wrapper += TEXT("    _exec_globals = globals()\n");
+      Wrapper += TEXT("    _exec_globals['__name__'] = '__main__'\n");
+      Wrapper += TEXT("    _exec_globals['__file__'] = _script_path\n");
+      Wrapper += TEXT("    _exec_globals['__package__'] = None\n");
+      Wrapper += TEXT("    _exec_globals['__cached__'] = None\n");
+      Wrapper += TEXT("    if _script_dir and _script_dir not in sys.path:\n");
+      Wrapper += TEXT("        sys.path.insert(0, _script_dir)\n");
+      Wrapper += FString::Printf(TEXT("    exec(compile(_user_code, r'%s', 'exec'), _exec_globals)\n"), *PyScriptPath);
+    };
     Wrapper += TEXT("import sys\nimport traceback\n\n");
     Wrapper += FString::Printf(TEXT("_out = open(r'%s', 'w', encoding='utf-8')\n"), *PyOutputPath);
     Wrapper += FString::Printf(TEXT("_err = open(r'%s', 'w', encoding='utf-8')\n"), *PyErrorPath);
@@ -670,9 +684,10 @@ bool UMcpAutomationBridgeSubsystem::HandleSystemControlAction(
         return true;
       }
       FString PyCodePath = NormalizePyPath(CodePath);
+      FString PyCodeDir = NormalizePyPath(FPaths::GetPath(CodePath));
       Wrapper += FString::Printf(TEXT("    with open(r'%s', 'r', encoding='utf-8') as _f:\n"), *PyCodePath);
       Wrapper += TEXT("        _user_code = _f.read()\n");
-      Wrapper += FString::Printf(TEXT("    exec(compile(_user_code, r'%s', 'exec'))\n"), *PyCodePath);
+      AppendPythonExec(PyCodePath, PyCodeDir);
     } else {
       // SECURITY: Sanitize file path to prevent directory traversal
       FString SafeFilePath = SanitizeProjectFilePath(File);
@@ -717,9 +732,10 @@ bool UMcpAutomationBridgeSubsystem::HandleSystemControlAction(
 
       // Use absolute path in Python wrapper (forward slashes)
       FString PyFilePath = NormalizePyPath(AbsoluteFilePath);
+      FString PyFileDir = NormalizePyPath(FPaths::GetPath(AbsoluteFilePath));
       Wrapper += FString::Printf(TEXT("    with open(r'%s', 'r', encoding='utf-8') as _f:\n"), *PyFilePath);
       Wrapper += TEXT("        _user_code = _f.read()\n");
-      Wrapper += FString::Printf(TEXT("    exec(compile(_user_code, r'%s', 'exec'))\n"), *PyFilePath);
+      AppendPythonExec(PyFilePath, PyFileDir);
     }
 
     Wrapper += TEXT("except:\n");
@@ -740,25 +756,35 @@ bool UMcpAutomationBridgeSubsystem::HandleSystemControlAction(
       return true;
     }
 
-    // Get world context (same pattern as console_command handler)
-    UWorld* World = nullptr;
-    if (GEditor) {
-      World = GEditor->GetEditorWorldContext().World();
-    }
-    if (!World && GEngine && GEngine->GetWorldContexts().Num() > 0) {
-      World = GEngine->GetWorldContexts()[0].World();
-    }
-
     SendProgressUpdate(RequestId, 0.0f, TEXT("Executing Python script"), true, CurrentRequestOrigin);
 
-    // Execute via py console command with execution time tracking
-    static constexpr double MaxPythonExecutionSeconds = 60.0;
-    FString PyCommand = FString::Printf(TEXT("py \"%s\""), *ScriptPath);
-    bool bExecHandled = false;
-    double ExecStartTime = FPlatformTime::Seconds();
-    if (GEngine) {
-      bExecHandled = GEngine->Exec(World, *PyCommand);
+    IPythonScriptPlugin* PythonPlugin = FModuleManager::LoadModulePtr<IPythonScriptPlugin>(TEXT("PythonScriptPlugin"));
+    if (!PythonPlugin) {
+      SendAutomationError(RequestingSocket, RequestId,
+                          TEXT("Python Editor Script Plugin module is not loaded"),
+                          TEXT("PYTHON_NOT_AVAILABLE"));
+      return true;
     }
+    if (!PythonPlugin->IsPythonInitialized()) {
+      PythonPlugin->ForceEnablePythonAtRuntime();
+    }
+    if (!PythonPlugin->IsPythonInitialized()) {
+      SendAutomationError(RequestingSocket, RequestId,
+                          TEXT("Python Editor Script Plugin is not initialized yet"),
+                          TEXT("PYTHON_NOT_AVAILABLE"));
+      return true;
+    }
+
+    // Execute through PythonScriptPlugin directly. The console "py" command can
+    // defer file loading on a fresh editor startup, racing temp-file cleanup.
+    static constexpr double MaxPythonExecutionSeconds = 60.0;
+    FPythonCommandEx PythonCommand;
+    PythonCommand.Command = FString::Printf(TEXT("\"%s\""), *ScriptPath);
+    PythonCommand.ExecutionMode = EPythonCommandExecutionMode::ExecuteFile;
+    PythonCommand.FileExecutionScope = EPythonFileExecutionScope::Private;
+    PythonCommand.Flags |= EPythonCommandFlags::Unattended;
+    double ExecStartTime = FPlatformTime::Seconds();
+    bool bPythonCommandSucceeded = PythonPlugin->ExecPythonCommandEx(PythonCommand);
     double ExecElapsed = FPlatformTime::Seconds() - ExecStartTime;
     SendProgressUpdate(RequestId, 90.0f, TEXT("Collecting Python output"), true, CurrentRequestOrigin);
     if (ExecElapsed > MaxPythonExecutionSeconds) {
@@ -773,18 +799,25 @@ bool UMcpAutomationBridgeSubsystem::HandleSystemControlAction(
     FFileHelper::LoadFileToString(Output, *OutputPath);
     FFileHelper::LoadFileToString(Error, *ErrorPath);
     FFileHelper::LoadFileToString(Status, *StatusPath);
+    if (!bPythonCommandSucceeded && Status.TrimStartAndEnd().IsEmpty()) {
+      FString PythonError = PythonCommand.CommandResult;
+      for (const FPythonLogOutputEntry& LogOutput : PythonCommand.LogOutput) {
+        if (!PythonError.IsEmpty()) {
+          PythonError += TEXT("\n");
+        }
+        PythonError += FString::Printf(TEXT("[%s] %s"), LexToString(LogOutput.Type), *LogOutput.Output);
+      }
+      if (!PythonError.IsEmpty()) {
+        if (!Error.IsEmpty()) {
+          Error += TEXT("\n");
+        }
+        Error += PythonError;
+      }
+    }
 
     // Cleanup happens automatically via FTempFileCleanup destructor
 
-    // Check if Python is available
-    if (!bExecHandled && Status.IsEmpty()) {
-      SendAutomationError(RequestingSocket, RequestId,
-                          TEXT("Python command not recognized. Is the Python Editor Script Plugin enabled?"),
-                          TEXT("PYTHON_NOT_AVAILABLE"));
-      return true;
-    }
-
-    bool bSuccess = Status.TrimStartAndEnd().Equals(TEXT("1"));
+    bool bSuccess = bPythonCommandSucceeded && Status.TrimStartAndEnd().Equals(TEXT("1"));
     TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
     Result->SetStringField(TEXT("output"), Output.TrimEnd());
     Result->SetStringField(TEXT("error"), Error.TrimEnd());

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_SystemControlHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/McpAutomationBridge_SystemControlHandlers.cpp
@@ -765,6 +765,7 @@ bool UMcpAutomationBridgeSubsystem::HandleSystemControlAction(
                           TEXT("PYTHON_NOT_AVAILABLE"));
       return true;
     }
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6)
     if (!PythonPlugin->IsPythonInitialized()) {
       PythonPlugin->ForceEnablePythonAtRuntime();
     }
@@ -774,6 +775,11 @@ bool UMcpAutomationBridgeSubsystem::HandleSystemControlAction(
                           TEXT("PYTHON_NOT_AVAILABLE"));
       return true;
     }
+#else
+    // UE 5.0-5.5 IPythonScriptPlugin does not expose initialization helpers.
+    // Loading the module and executing through ExecPythonCommandEx is the
+    // compatible path for those versions.
+#endif
 
     // Execute through PythonScriptPlugin directly. The console "py" command can
     // defer file loading on a fresh editor startup, racing temp-file cleanup.

--- a/tests/mcp-tools/core/system-control.test.mjs
+++ b/tests/mcp-tools/core/system-control.test.mjs
@@ -10,8 +10,11 @@ const TEST_FOLDER = '/Game/MCPTest/SystemControl';
 const WIDGET_NAME = 'WBP_SystemControl_Test';
 const WIDGET_PATH = `${TEST_FOLDER}/${WIDGET_NAME}`;
 const VALIDATION_MATERIAL = `${TEST_FOLDER}/M_SystemControlValidation`;
-const PYTHON_FILE_RELATIVE = `Saved/MCPTests/system-control-${Date.now()}.py`;
+const PYTHON_TEST_ID = Date.now();
+const PYTHON_FILE_RELATIVE = `Saved/MCPTests/system-control-${PYTHON_TEST_ID}.py`;
+const PYTHON_HELPER_RELATIVE = `Saved/MCPTests/system-control-${PYTHON_TEST_ID}-helper.txt`;
 const PYTHON_FILE_LITERAL = JSON.stringify(PYTHON_FILE_RELATIVE);
+const PYTHON_HELPER_LITERAL = JSON.stringify(PYTHON_HELPER_RELATIVE);
 const PROJECT_SETTING_SECTION = '/Script/Engine.Engine';
 const PROJECT_SETTING_KEY = `McpSystemControlSmoke_${Date.now()}`;
 const PROJECT_SETTING_SECTION_LITERAL = JSON.stringify(PROJECT_SETTING_SECTION);
@@ -20,17 +23,26 @@ const CREATE_PYTHON_FILE_CODE = `
 import os
 import unreal
 path = os.path.join(unreal.Paths.project_dir(), ${PYTHON_FILE_LITERAL})
+helper_path = os.path.join(unreal.Paths.project_dir(), ${PYTHON_HELPER_LITERAL})
 os.makedirs(os.path.dirname(path), exist_ok=True)
+with open(helper_path, 'w', encoding='utf-8') as f:
+    f.write('sibling-file-ok')
 with open(path, 'w', encoding='utf-8') as f:
-    f.write('print("system-control-file-ok")\\n')
+    f.write('import os\\n')
+    f.write('helper_path = os.path.join(os.path.dirname(__file__), os.path.basename(${PYTHON_HELPER_LITERAL}))\\n')
+    f.write('with open(helper_path, "r", encoding="utf-8") as helper:\\n')
+    f.write('    print("system-control-file-ok:" + helper.read())\\n')
 print("system-control-file-created")
 `.trim();
 const DELETE_PYTHON_FILE_CODE = `
 import os
 import unreal
 path = os.path.join(unreal.Paths.project_dir(), ${PYTHON_FILE_LITERAL})
+helper_path = os.path.join(unreal.Paths.project_dir(), ${PYTHON_HELPER_LITERAL})
 if os.path.exists(path):
     os.remove(path)
+if os.path.exists(helper_path):
+    os.remove(helper_path)
 print("system-control-file-cleaned")
 `.trim();
 const CLEANUP_PROJECT_SETTING_CODE = `
@@ -102,7 +114,9 @@ const testCases = [
   { scenario: 'CONFIG: set_project_setting', toolName: 'system_control', arguments: { action: 'set_project_setting', section: PROJECT_SETTING_SECTION, key: PROJECT_SETTING_KEY, value: '1' }, expected: 'success' },
   { scenario: 'ACTION: execute_python', toolName: 'system_control', arguments: { action: 'execute_python', code: 'print("system-control-ok")' }, expected: 'success' },
   { scenario: 'Setup: create execute_python file', toolName: 'system_control', arguments: { action: 'execute_python', code: CREATE_PYTHON_FILE_CODE }, expected: 'success' },
-  { scenario: 'ACTION: execute_python file', toolName: 'system_control', arguments: { action: 'execute_python', file: PYTHON_FILE_RELATIVE }, expected: 'success', assertions: [{ path: 'structuredContent.result.output', equals: 'system-control-file-ok', label: 'python file output captured' }] },
+  // This result is asserted on the returned MCP response, so it also catches
+  // temp wrapper cleanup racing file execution before output/status are written.
+  { scenario: 'ACTION: execute_python file', toolName: 'system_control', arguments: { action: 'execute_python', file: PYTHON_FILE_RELATIVE }, expected: 'success', assertions: [{ path: 'structuredContent.result.output', equals: 'system-control-file-ok:sibling-file-ok', label: 'python file has __file__ and synchronous output' }] },
 
   // === CLEANUP ===
   { scenario: 'Cleanup: delete execute_python file', toolName: 'system_control', arguments: { action: 'execute_python', code: DELETE_PYTHON_FILE_CODE }, expected: 'success' },


### PR DESCRIPTION
## Summary
- execute system_control execute_python wrappers through PythonScriptPlugin directly instead of the console py command to avoid temp wrapper cleanup racing deferred file execution
- populate script-like globals for file/code execution, including __file__, __name__, __package__, and sibling script directory on sys.path
- declare the PythonScriptPlugin dependency and extend the system-control integration test to assert immediate file-mode output using __file__

## Validation
- git diff --check
- node --check tests/mcp-tools/core/system-control.test.mjs
- parsed plugins/McpAutomationBridge/McpAutomationBridge.uplugin as JSON
- equivalent bridge code was built successfully in the Livlet UE 5.7 project before upstreaming this fork patch