### PR TITLE
fix: SCS add-component verification rejects valid auto-attach-to-root child

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/SCS/McpAutomationBridge_SCSHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/SCS/McpAutomationBridge_SCSHandlers.cpp
@@ -181,7 +181,11 @@ bool SCSParentMatches(USimpleConstructionScript *SCS, USCS_Node *Node,
   }
   USCS_Node *ActualParent = FindSCSParentNode(SCS, Node);
   if (ExpectedParentName.IsEmpty()) {
-    return ActualParent == nullptr || IsSCSRootNode(SCS, Node);
+    // No specific parent requested: accept the engine's default placements — the node is
+    // root, is not yet parented, or was auto-attached as a child of the root (the default
+    // for a 2nd component added without an explicit parent).
+    return ActualParent == nullptr || IsSCSRootNode(SCS, Node) ||
+           IsSCSRootNode(SCS, ActualParent);
   }
   if (IsSCSRootAlias(ExpectedParentName)) {
     return ActualParent ? IsSCSRootNode(SCS, ActualParent)


### PR DESCRIPTION
## Problem
`add_scs_component` returns `SCS_VERIFICATION_FAILED` when adding a **second** component without an explicit parent, even though the component is correctly added.

Repro:
1. Add `Root1` (SceneComponent), no parent → becomes root.
2. Add `Child1` (StaticMeshComponent), no parent → the engine auto-attaches it to the root → response is `success:false` (`"...parent did not match requested parent ''"`), while the inner `scsVerification` block reports `parentVerified:true`.

## Root cause
`SCSParentMatches()` in `Private/Domains/SCS/McpAutomationBridge_SCSHandlers.cpp`. When no parent is requested (`ExpectedParentName.IsEmpty()`) it returns `ActualParent == nullptr || IsSCSRootNode(SCS, Node)` — only accepts a node that **is** the root or is parentless. A 2nd no-parent component auto-attaches as a **child of the root**, so it is neither → `false` → `SCS_VERIFICATION_FAILED`.

## Fix
Accept the child-of-root case in the empty-parent branch:
```cpp
return ActualParent == nullptr || IsSCSRootNode(SCS, Node) ||
       IsSCSRootNode(SCS, ActualParent);
```
Only the `ExpectedParentName.IsEmpty()` branch changes; the `IsSCSRootAlias` and explicit-parent branches are untouched. Reparent path unaffected; strictness preserved (a no-parent component nested under a non-root component still fails).

## Testing
Verified live on **UE 5.8**: a 2nd no-parent component now returns `success:true` with `parent:Root1`; a component added with an explicit valid parent still verifies correctly; no regression.