### PR TITLE
fix: ResolveObjectFromPath returns UPackage instead of the asset (DataAsset/GE)

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Foundation/HandlerUtils/McpHandlerUtilsObjectResolution.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Foundation/HandlerUtils/McpHandlerUtilsObjectResolution.cpp
@@ -96,6 +96,33 @@ UObject* ResolveObjectFromPath(const FString& ObjectPath, FString* OutResolvedPa
     if (Path.StartsWith(TEXT("/Game/")) || Path.StartsWith(TEXT("/Engine/")) || Path.StartsWith(TEXT("/Script/")) ||
         FPackageName::IsValidLongPackageName(Path, true))
     {
+        // Canonical asset resolution FIRST: LoadObject auto-resolves PackageName ->
+        // PackageName.AssetName, returning a real asset (DataAsset/GE/...) as the object instead of
+        // falling through to the UPackage fallback below. Additive: pure-package callers still reach
+        // the old path. Guard against a bare path resolving to its own UPackage.
+        if (UObject* DirectObj = LoadObject<UObject>(nullptr, *Path))
+        {
+            if (!DirectObj->IsA<UPackage>())
+            {
+                if (OutResolvedPath)
+                {
+                    *OutResolvedPath = DirectObj->GetPathName();
+                }
+                return DirectObj;
+            }
+        }
+        if (!Path.Contains(TEXT(".")))
+        {
+            const FString DottedPath = Path + TEXT(".") + FPackageName::GetShortName(Path);
+            if (UObject* DottedObj = LoadObject<UObject>(nullptr, *DottedPath))
+            {
+                if (OutResolvedPath)
+                {
+                    *OutResolvedPath = DottedObj->GetPathName();
+                }
+                return DottedObj;
+            }
+        }
         FString PackagePath = Path;
         if (PackagePath.Contains(TEXT(".")))
         {

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Foundation/HandlerUtils/McpHandlerUtilsObjectResolution.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Foundation/HandlerUtils/McpHandlerUtilsObjectResolution.cpp
@@ -116,11 +116,17 @@ UObject* ResolveObjectFromPath(const FString& ObjectPath, FString* OutResolvedPa
             const FString DottedPath = Path + TEXT(".") + FPackageName::GetShortName(Path);
             if (UObject* DottedObj = LoadObject<UObject>(nullptr, *DottedPath))
             {
-                if (OutResolvedPath)
+                // Mirror the DirectObj guard above: the dotted path can also resolve to a
+                // UPackage (the exact case this fix avoids) — don't return it, fall through
+                // to the package path below so genuine package callers still work.
+                if (!DottedObj->IsA<UPackage>())
                 {
-                    *OutResolvedPath = DottedObj->GetPathName();
+                    if (OutResolvedPath)
+                    {
+                        *OutResolvedPath = DottedObj->GetPathName();
+                    }
+                    return DottedObj;
                 }
-                return DottedObj;
             }
         }
         FString PackagePath = Path;


### PR DESCRIPTION
## Problem
`inspect_object` / `set_property` on a DataAsset (or other non-actor asset) returned `className:Package` / `UNKNOWN_PROPERTY`.

## Root cause
`ResolveObjectFromPath` (`Foundation/HandlerUtils/McpHandlerUtilsObjectResolution.cpp`): when the inner object cannot be found by name in the loaded package, it returns the `UPackage` itself.

## Fix
Try `LoadObject` first (canonical `PackageName` → `PackageName.AssetName` resolution) with a guard against returning a `UPackage`, plus a dotted-path retry. Additive — the existing package path is preserved for genuine package callers.

## Testing
Verified live on UE 5.8: DataAsset `inspect_object` now returns the real class; `set_property` succeeds; normal Blueprint resolution unaffected.