### PR TITLE
fix(build): UE 5.8 compatibility — add includes exposed by IWYU/unity regroup

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Lighting/McpAutomationBridge_LightingBuildCompatibility.h
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Lighting/McpAutomationBridge_LightingBuildCompatibility.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "EditorBuildUtils.h"
+#include "LightingBuildOptions.h" // UE5.8: ELightingBuildQuality no longer pulled transitively via EditorBuildUtils.h
 
 class UWorld;
 

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Test/McpAutomationBridge_TestHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Test/McpAutomationBridge_TestHandlers.cpp
@@ -24,6 +24,7 @@
 // -----------------------------------------------------------------------------
 #include "McpAutomationBridgeSubsystem.h"
 #include "Domains/SystemControl/McpAutomationBridge_SystemControlHandlersPrivate.h"
+#include "Foundation/BridgeHelpers/Responses/McpAutomationBridgeHelpersJsonFields.h" // UE5.8: explicit include (unity regroup no longer pulls GetJsonStringField transitively)
 
 // -----------------------------------------------------------------------------
 // Engine Includes


### PR DESCRIPTION
## Summary
Building against UE 5.8 Preview fails with two hard compile errors caused by 5.8's stricter IWYU + unity-build regrouping: symbols previously visible through a neighbouring translation unit are no longer pulled in transitively.

## Changes
- `Domains/Test/McpAutomationBridge_TestHandlers.cpp` → include `McpAutomationBridgeHelpersJsonFields.h` (`GetJsonStringField`, was `C3861`).
- `Domains/Lighting/McpAutomationBridge_LightingBuildCompatibility.h` → include `LightingBuildOptions.h` (`ELightingBuildQuality`, was `C2061`).

Both are latent include-correctness bugs; the includes are IWYU-compliant and safe on 5.0–5.7 (an already-satisfied include is a no-op).

## Testing
`TopDownMultiEditor Win64 Development` builds clean (`Rebuild All: 1 succeeded`) on UE 5.8 Preview.