### PR TITLE
fix: accept blueprintPath in inspect get_blueprint_details

### DIFF
--- a/src/tools/handlers/inspect/inspect-object-actions.ts
+++ b/src/tools/handlers/inspect/inspect-object-actions.ts
@@ -23,9 +23,14 @@ function looksLikeComponentPath(value: string | undefined): boolean {
 }
 
 async function handleBlueprintDetails(context: InspectHandlerContext): Promise<Record<string, unknown>> {
-  const requestedPath = await resolveObjectPath(context.normalizedArgs, context.tools) ?? '';
+  // Accept `blueprintPath` in addition to `objectPath`/`path`. Sibling inspect
+  // actions (inspect_cdo, get_property/set_property) already take `blueprintPath`,
+  // so callers reasonably pass it here too; without this it was rejected.
+  const requestedPath = await resolveObjectPath(context.normalizedArgs, context.tools, {
+    pathKeys: ['objectPath', 'blueprintPath', 'path']
+  }) ?? '';
   if (!requestedPath) {
-    throw new Error('inspect:get_blueprint_details - invalid objectPath: must be a non-empty string');
+    throw new Error('inspect:get_blueprint_details - invalid objectPath/blueprintPath: must be a non-empty string');
   }
 
   const res = await executeAutomationRequest(


### PR DESCRIPTION
## Summary

`inspect` `get_blueprint_details` resolved its target only through `resolveObjectPath`'s default path keys (`objectPath`, `path`). A caller passing `blueprintPath` therefore got `inspect:get_blueprint_details - invalid objectPath: must be a non-empty string` and the call failed. This is inconsistent with sibling `inspect` actions — `inspect_cdo` and `get_property`/`set_property` already accept `blueprintPath` — and the `inspect` tool schema advertises `blueprintPath` as a property, so callers reasonably reach for it here. This PR makes `get_blueprint_details` accept `blueprintPath` as well.

## Changes

- `src/tools/handlers/inspect/inspect-object-actions.ts`: pass `pathKeys: ['objectPath', 'blueprintPath', 'path']` to `resolveObjectPath` in `handleBlueprintDetails`, and update the error text to mention both names. `objectPath` stays first, so existing `objectPath` callers are unaffected.

## Related Issues

Related to: found during downstream dogfooding (no existing upstream issue).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Tested with Unreal Engine (version: 5.8)
- [x] Tested MCP client integration (client: stdio MCP client via @modelcontextprotocol/sdk)
- [ ] Added/updated tests

Live verification against a running editor:
- **Before (reproduces the bug):** `get_blueprint_details { blueprintPath: "/Game/.../BP_GA_PlayerMeleeAttack" }` → `invalid objectPath: must be a non-empty string`.
- **After (this change):** same call → `success: true`, blueprint details returned. `objectPath` callers unchanged.

`npm run lint` (incl. `--max-warnings=0`), `npm run type-check`, and `npm run test:smoke` all pass.

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Updated relevant documentation (if needed) — n/a (bug fix, no new surface; `blueprintPath` is already documented in the schema)
- [ ] Added/updated tests (if applicable) — verified live instead, matching the repo's focused-fix pattern
- [x] CI passes
