### PR TITLE
fix: float/double pin types use PC_Real category (schema rejects, int coercion, custom-event param loss)

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersCustomEventParameters.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersCustomEventParameters.cpp
@@ -16,13 +16,20 @@ FProperty* CreateCustomEventParameter(
     const FName PropertyName(*ParameterName);
     FProperty* Property = nullptr;
 
-    if (PinType.PinCategory == UEdGraphSchema_K2::PC_Float)
+    if (PinType.PinCategory == UEdGraphSchema_K2::PC_Real)
     {
-        Property = new FFloatProperty(Function, PropertyName, RF_Public);
-    }
-    else if (PinType.PinCategory == UEdGraphSchema_K2::PC_Real)
-    {
-        Property = new FDoubleProperty(Function, PropertyName, RF_Public);
+        // UE5 real pins carry their precision in PinSubCategory (PC_Float or
+        // PC_Double); a bare PC_Float pin category is invalid and no longer
+        // produced by ResolveCustomEventPinType, so dispatch on the
+        // subcategory instead.
+        if (PinType.PinSubCategory == UEdGraphSchema_K2::PC_Float)
+        {
+            Property = new FFloatProperty(Function, PropertyName, RF_Public);
+        }
+        else
+        {
+            Property = new FDoubleProperty(Function, PropertyName, RF_Public);
+        }
     }
     else if (PinType.PinCategory == UEdGraphSchema_K2::PC_Int)
     {

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersPinTypes.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersPinTypes.cpp
@@ -14,7 +14,12 @@ FEdGraphPinType ResolveCustomEventPinType(const FString& TypeName)
 
     if (CleanType.Equals(TEXT("float"), ESearchCase::IgnoreCase))
     {
-        PinType.PinCategory = UEdGraphSchema_K2::PC_Float;
+        // PC_Float is a SUBcategory of PC_Real in UE5, not a valid pin
+        // category; a bare PC_Float category makes the K2 schema reject the
+        // pin and the parameter gets dropped on node reconstruction. (There
+        // is no NAME_Float hardcoded name, hence the schema constant here.)
+        PinType.PinCategory = UEdGraphSchema_K2::PC_Real;
+        PinType.PinSubCategory = UEdGraphSchema_K2::PC_Float;
         return PinType;
     }
     if (CleanType.Equals(TEXT("double"), ESearchCase::IgnoreCase))

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Foundation/Blueprint/McpBlueprintUtilsPinTypes.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Foundation/Blueprint/McpBlueprintUtilsPinTypes.cpp
@@ -36,9 +36,18 @@ FEdGraphPinType MakePinType(const FString& InType)
     const FString Lower = InType.ToLower();
     const FString CleanType = InType.TrimStartAndEnd();
 
-    if (Lower == TEXT("float") || Lower == TEXT("double"))
+    if (Lower == TEXT("float"))
     {
-        PinType.PinCategory = UEdGraphSchema_K2::PC_Float;
+        // PC_Float/PC_Double are SUBcategories of PC_Real in UE5; using them as the
+        // category makes the K2 schema reject connections and the compiler coerce or
+        // drop the pins (custom-event float params get deleted on reconstruct).
+        PinType.PinCategory = UEdGraphSchema_K2::PC_Real;
+        PinType.PinSubCategory = UEdGraphSchema_K2::PC_Float;
+    }
+    else if (Lower == TEXT("double") || Lower == TEXT("real"))
+    {
+        PinType.PinCategory = UEdGraphSchema_K2::PC_Real;
+        PinType.PinSubCategory = UEdGraphSchema_K2::PC_Double;
     }
     else if (Lower == TEXT("int") || Lower == TEXT("integer"))
     {


### PR DESCRIPTION
## Symptoms (live on UE 5.8, all from the same root cause)

1. **Float pin connections are rejected by the K2 schema** — e.g. connecting a Blueprint function's float input to `Conv_FloatToDouble.InFloat` fails with a schema rejection (`CONNECTION_FAILED`).
2. **Float function parameters are silently coerced to int at call sites** — a function created with float inputs shows `int` pins (default `0`) on its call nodes after the kismet compile.
3. **Custom-event float parameters are deleted on node reconstruction** — the parameter stays in the event definition but the node pin disappears, leaving a permanent `Event node ... is out-of-date. Please refresh it.` compile error (fatal). Int/String parameters are unaffected.

## Root cause

`PC_Float`/`PC_Double` are **subcategories of `PC_Real`** in UE5, not pin categories. Two sites emit a bare `PC_Float` **category**:

- `McpBlueprintUtilsPinTypes.cpp` — `MakePinType("float"/"double")`
- `McpAutomationBridge_BlueprintGraphHandlersPinTypes.cpp` — `ResolveCustomEventPinType("float")` (the `double` branch there is already correct: `PC_Real` + `NAME_Double`)

`McpAutomationBridge_BlueprintGraphHandlersCustomEventParameters.cpp` then uses that invalid bare-`PC_Float` category as an internal marker to choose `FFloatProperty` vs `FDoubleProperty`.

## Fix (3 files, body-only)

- `MakePinType`: `float` → `PC_Real` + `PC_Float` subcategory; `double`/`real` → `PC_Real` + `PC_Double` subcategory.
- `ResolveCustomEventPinType`: `float` branch now emits `PC_Real` + `PC_Float` subcategory (mirrors the already-correct double branch).
- `CreateCustomEventParameter`: dispatches `FFloatProperty`/`FDoubleProperty` on the **PinSubCategory** under `PC_Real`; the bare-`PC_Float` marker branch is provably dead after the resolver fix and removed.

Note: `UnrealNames.inl` registers `NAME_Double` but no `NAME_Float`, hence `UEdGraphSchema_K2::PC_Float` as the subcategory constant.

## Verification (UE 5.8.0, Win64)

- Function float input pin now reports category `real`; connecting it to `Conv_FloatToDouble.InFloat` succeeds.
- Custom event created with a Float parameter compiles cleanly; the pin survives reconstruction (`pinType: real`).
- Call sites show `real` with default `0.0` (previously `int` with default `0`).
- Existing int/string/bool paths unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)