### PR TITLE
fix: CustomEvent Bool parameter crashes the editor (FBoolProperty::SetBoolSize(0))

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersCustomEventParameters.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersCustomEventParameters.cpp
@@ -36,7 +36,9 @@ FProperty* CreateCustomEventParameter(
     {
         FBoolProperty* BoolProperty =
             new FBoolProperty(Function, PropertyName, RF_Public);
-        BoolProperty->SetBoolSize(0, true);
+        // A native bool's size is sizeof(bool); SetBoolSize(0, ...) leaves
+        // ElementSize 0 and trips check(GetElementSize() != 0) -> editor crash.
+        BoolProperty->SetBoolSize(sizeof(bool), true);
         Property = BoolProperty;
     }
     else if (PinType.PinCategory == UEdGraphSchema_K2::PC_String)


### PR DESCRIPTION
## Summary
Creating a Custom Event node with a **Bool** parameter crashes the editor outright. Int / Float / String / Name / Byte / etc. parameters are unaffected — only `Bool`.

## Repro
1. Open any Blueprint with an EventGraph.
2. Add a Custom Event with a single Bool parameter, e.g. `parameters: [{ "name": "Flag", "type": "Bool" }]`.
3. Editor crashes immediately (CrashReportClient relaunch).

## Crash
```
Assertion failed: GetElementSize() != 0 [File:...\CoreUObject\Private\UObject\PropertyBool.cpp] [Line: 93]
FBoolProperty::SetBoolSize()
  McpBlueprintGraphHandlers::CreateCustomEventParameter()
  McpBlueprintGraphHandlers::AddParameters()
  McpBlueprintGraphHandlers::TryCreateCustomEventNode()
```

## Root cause
`CreateCustomEventParameter`'s `PC_Boolean` branch constructs the `FBoolProperty` then calls `SetBoolSize(0, true)`. Passing `0` sets `ElementSize = 0`, which synchronously trips `check(GetElementSize() != 0)` inside `SetBoolSize` (PropertyBool.cpp:93). It is not a compile-time issue — the assert fires during parameter construction.

## Fix
A native (non-bitfield) bool's element size is `sizeof(bool)`:
```cpp
BoolProperty->SetBoolSize(sizeof(bool), true);
```

## Testing
Verified live on UE 5.8: a single `Bool` param and a mixed `[Bool, Int, Float]` param set now create without crashing, produce a `bool` pin, compile clean, and survive node reconstruction.
