### PR TITLE
fix: prevent fatal editor crash from orphaned/unnamed function graphs

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersCustomEvents.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersCustomEvents.cpp
@@ -2,11 +2,38 @@
 
 #if WITH_EDITOR
 #include "K2Node_CustomEvent.h"
+#include "K2Node_FunctionEntry.h"
 #include "Kismet2/KismetEditorUtilities.h"
 #include "UObject/UnrealType.h"
 
 namespace McpBlueprintGraphHandlers
 {
+// Pre-compile health gate: a function graph whose entry node is missing or unnamed
+// makes the compiler's conform pass call ReplaceFunctionReferences with NAME_None,
+// which is a check() -> fatal editor crash (BlueprintEditorUtils.cpp:5914 in 5.8).
+// That state is reachable through pure automation calls (delete_node on a function
+// entry, then add_node FunctionEntry), but this also protects against blueprints
+// corrupted by any other means. Returns false with the offending graph's name.
+static bool ValidateFunctionGraphRoots(UBlueprint* Blueprint, FString& OutBadGraph)
+{
+    for (UEdGraph* Graph : Blueprint->FunctionGraphs)
+    {
+        if (!Graph)
+        {
+            continue;
+        }
+        TArray<UK2Node_FunctionEntry*> Entries;
+        Graph->GetNodesOfClass<UK2Node_FunctionEntry>(Entries);
+        if (Entries.Num() != 1 || !Entries[0] ||
+            Entries[0]->FunctionReference.GetMemberName().IsNone())
+        {
+            OutBadGraph = Graph->GetName();
+            return false;
+        }
+    }
+    return true;
+}
+
 static void RemoveExistingCustomEvents(
     UBlueprint* Blueprint,
     const FString& EventName)
@@ -118,6 +145,21 @@ bool TryCreateCustomEventNode(
             NodeCreator.CreateNode(false);
         EventNode->CustomFunctionName = FName(*EventName);
         Context.FinalizeNode(NodeCreator, EventNode, X, Y);
+        return true;
+    }
+
+    // This path compiles synchronously below; refuse loudly (instead of crashing
+    // the editor) if any function graph is in the orphaned/unnamed-entry state.
+    FString BadGraph;
+    if (!ValidateFunctionGraphRoots(Context.Blueprint, BadGraph))
+    {
+        Context.SendError(
+            FString::Printf(
+                TEXT("Function graph '%s' has no valid named entry node; compiling now "
+                     "would crash the editor (engine check in ReplaceFunctionReferences). "
+                     "Recreate the function via add_function, then retry."),
+                *BadGraph),
+            TEXT("BLUEPRINT_INVALID_STATE"));
         return true;
     }
 

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersNodeCreation.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersNodeCreation.cpp
@@ -1,6 +1,7 @@
 #include "Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersPrivate.h"
 
 #if WITH_EDITOR
+#include "K2Node_FunctionEntry.h"
 #include "ScopedTransaction.h"
 
 namespace McpBlueprintGraphHandlers
@@ -51,6 +52,21 @@ void CreateDynamicNode(
                 TEXT("Node type '%s' not found. Use list_node_types to see available types."),
                 *NodeType),
             TEXT("NODE_TYPE_NOT_FOUND"));
+        return;
+    }
+
+    // Function entry nodes cannot be created standalone: a generically spawned
+    // entry has a NAME_None signature, and the next blueprint compile crashes
+    // the editor on an engine check() while conforming/renaming that function
+    // (ReplaceFunctionReferences). Entries are created as part of add_function.
+    if (NodeClass->IsChildOf(UK2Node_FunctionEntry::StaticClass()))
+    {
+        Context.SendError(
+            TEXT("K2Node_FunctionEntry cannot be spawned directly — function entry "
+                 "nodes are created (and named) by add_function. Spawning one here "
+                 "would leave an unnamed function graph that crashes the editor on "
+                 "the next compile."),
+            TEXT("NODE_TYPE_NOT_SUPPORTED"));
         return;
     }
 

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersNodeMutations.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersNodeMutations.cpp
@@ -13,11 +13,6 @@ static bool DeleteNode(FActionContext& Context)
         return false;
     }
 
-    const FScopedTransaction Transaction(
-        FText::FromString(TEXT("Delete Blueprint Node")));
-    Context.Blueprint->Modify();
-    Context.TargetGraph->Modify();
-
     FString NodeId;
     Context.Payload->TryGetStringField(TEXT("nodeId"), NodeId);
     UEdGraphNode* TargetNode = Context.FindNode(NodeId);
@@ -42,6 +37,10 @@ static bool DeleteNode(FActionContext& Context)
         return true;
     }
 
+    const FScopedTransaction Transaction(
+        FText::FromString(TEXT("Delete Blueprint Node")));
+    Context.Blueprint->Modify();
+    Context.TargetGraph->Modify();
     FBlueprintEditorUtils::RemoveNode(
         Context.Blueprint,
         TargetNode,

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersNodeMutations.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersNodeMutations.cpp
@@ -27,6 +27,21 @@ static bool DeleteNode(FActionContext& Context)
         return true;
     }
 
+    // Honor the node's own deletability (the same gate the editor UI uses).
+    // Removing structural roots like K2Node_FunctionEntry leaves the function
+    // graph orphaned; a later compile then hits an engine check() and fatally
+    // crashes the editor (see ReplaceFunctionReferences, NAME_None assert).
+    if (!TargetNode->CanUserDeleteNode())
+    {
+        Context.SendError(
+            FString::Printf(
+                TEXT("Node '%s' (%s) is not user-deletable — removing it would corrupt "
+                     "the graph (function entry/result nodes are managed by the editor)."),
+                *TargetNode->GetName(), *TargetNode->GetClass()->GetName()),
+            TEXT("PROTECTED_NODE"));
+        return true;
+    }
+
     FBlueprintEditorUtils::RemoveNode(
         Context.Blueprint,
         TargetNode,


### PR DESCRIPTION
## Summary

A pure automation-call chain fatally crashes the editor:

1. `delete_node` on a function's `K2Node_FunctionEntry` — there is no guard, so the
   function graph is left with no root;
2. `add_node nodeType:K2Node_FunctionEntry` (a repair attempt) — the generically
   spawned entry has a `NAME_None` signature;
3. any subsequent custom-event creation compiles synchronously — the compiler's
   conform pass renames the unnamed function and trips
   `Assertion failed: (OldName != NAME_None) && (NewName != NAME_None)`
   (`FBlueprintEditorUtils::ReplaceFunctionReferences`, BlueprintEditorUtils.cpp:5915
   in 5.8). The editor process dies and the automation session is lost.

This is an isolated, reproducible instance of the chronic stability class reported
in #233. This PR adds three independent layers, any one of which breaks the chain.

## Changes

- `...BlueprintGraphHandlersNodeMutations.cpp` — `delete_node` now honors
  `UEdGraphNode::CanUserDeleteNode()` (the same gate the editor UI uses;
  FunctionEntry/Result override it to false). Protected nodes return a loud
  `PROTECTED_NODE` error instead of silently corrupting the graph.
- `...BlueprintGraphHandlersNodeCreation.cpp` — `create_node` refuses to spawn
  `K2Node_FunctionEntry` subclasses generically (`NODE_TYPE_NOT_SUPPORTED`, with a
  hint that entries are created and named by `add_function`): a standalone entry is
  never valid and is precisely the unnamed-root state that crashes the compile.
- `...BlueprintGraphHandlersCustomEvents.cpp` — the parameterized custom-event path
  validates function-graph roots before its synchronous `CompileBlueprint`: a graph
  with no (or an unnamed) entry returns `BLUEPRINT_INVALID_STATE` naming the bad
  graph, instead of crashing. This also protects blueprints corrupted by any other
  means, not just this chain.

## Related Issues

Related to #233 (chronic instability class — this is one isolated, reproducible
crash chain from it, found during downstream dogfooding).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Tested with Unreal Engine (version: 5.8)
- [x] Tested MCP client integration (client: stdio MCP client via @modelcontextprotocol/sdk)
- [ ] Added/updated tests

Live verification against a running UE 5.8 editor:

- **Layer 1:** `delete_node` on a fresh function's entry node → `PROTECTED_NODE`
  (behavior-differentiating: the unpatched build deletes it and corrupts the graph).
  Negative control: an ordinary node in the same graph still creates and deletes fine.
- **Layer 2:** `create_node nodeType:K2Node_FunctionEntry` → `NODE_TYPE_NOT_SUPPORTED`.
- **Layer 3 (false-positive regression):** parameterized custom-event creation on a
  healthy blueprint still succeeds — the validator passes well-formed graphs. Its
  positive branch is no longer reachable through the tool surface once layers 1-2
  are in place (by design); it remains as defense-in-depth for already-corrupted assets.
- Final integrity: the exercised blueprint compiles and saves cleanly afterwards.
- The original crash (callstack + crash dump captured during dogfooding) was not
  re-triggered on the patched build — the chain is cut at its first two links.

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Updated relevant documentation (if needed) — error messages document the behavior
- [ ] Added/updated tests (if applicable) — verified live instead, matching the repo's focused-fix pattern
- [x] CI passes
