### PR TITLE
fix: set_scs_transform silently no-ops on schema-form array inputs

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/SCS/McpAutomationBridge_SCSHandlersSetTransform.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/SCS/McpAutomationBridge_SCSHandlersSetTransform.cpp
@@ -70,9 +70,25 @@ TSharedPtr<FJsonObject> FSCSHandlers::SetSCSComponentTransform(
     return Result;
   }
 
-  FVector Location(0, 0, 0);
-  FRotator Rotation(0, 0, 0);
-  FVector Scale(1, 1, 1);
+  USceneComponent *SceneComp =
+      Cast<USceneComponent>(ComponentNode->ComponentTemplate);
+  if (!SceneComp) {
+    Result->SetBoolField(TEXT("success"), false);
+    Result->SetStringField(
+        TEXT("error"),
+        TEXT("Component is not a SceneComponent (no transform)"));
+    Result->SetStringField(TEXT("errorCode"), TEXT("SCS_NOT_SCENE_COMPONENT"));
+    return Result;
+  }
+
+  // Read-modify-write: start from the template's CURRENT values so a partial
+  // payload (e.g. location only) does not stomp rotation/scale back to defaults.
+  FVector Location = SceneComp->GetRelativeLocation();
+  FRotator Rotation = SceneComp->GetRelativeRotation();
+  FVector Scale = SceneComp->GetRelativeScale3D();
+  bool bHasLocation = false;
+  bool bHasRotation = false;
+  bool bHasScale = false;
 
   const TArray<TSharedPtr<FJsonValue>> *LocArray;
   if (TransformData->TryGetArrayField(TEXT("location"), LocArray) &&
@@ -80,6 +96,7 @@ TSharedPtr<FJsonObject> FSCSHandlers::SetSCSComponentTransform(
     Location.X = (*LocArray)[0]->AsNumber();
     Location.Y = (*LocArray)[1]->AsNumber();
     Location.Z = (*LocArray)[2]->AsNumber();
+    bHasLocation = true;
   } else {
     const TSharedPtr<FJsonObject> *LocObj = nullptr;
     if (TransformData->TryGetObjectField(TEXT("location"), LocObj) && LocObj &&
@@ -87,6 +104,7 @@ TSharedPtr<FJsonObject> FSCSHandlers::SetSCSComponentTransform(
       (*LocObj)->TryGetNumberField(TEXT("x"), Location.X);
       (*LocObj)->TryGetNumberField(TEXT("y"), Location.Y);
       (*LocObj)->TryGetNumberField(TEXT("z"), Location.Z);
+      bHasLocation = true;
     }
   }
 
@@ -96,6 +114,7 @@ TSharedPtr<FJsonObject> FSCSHandlers::SetSCSComponentTransform(
     Rotation.Pitch = (*RotArray)[0]->AsNumber();
     Rotation.Yaw = (*RotArray)[1]->AsNumber();
     Rotation.Roll = (*RotArray)[2]->AsNumber();
+    bHasRotation = true;
   } else {
     const TSharedPtr<FJsonObject> *RotObj = nullptr;
     if (TransformData->TryGetObjectField(TEXT("rotation"), RotObj) && RotObj &&
@@ -103,6 +122,7 @@ TSharedPtr<FJsonObject> FSCSHandlers::SetSCSComponentTransform(
       (*RotObj)->TryGetNumberField(TEXT("pitch"), Rotation.Pitch);
       (*RotObj)->TryGetNumberField(TEXT("yaw"), Rotation.Yaw);
       (*RotObj)->TryGetNumberField(TEXT("roll"), Rotation.Roll);
+      bHasRotation = true;
     }
   }
 
@@ -112,6 +132,7 @@ TSharedPtr<FJsonObject> FSCSHandlers::SetSCSComponentTransform(
     Scale.X = (*ScaleArray)[0]->AsNumber();
     Scale.Y = (*ScaleArray)[1]->AsNumber();
     Scale.Z = (*ScaleArray)[2]->AsNumber();
+    bHasScale = true;
   } else {
     const TSharedPtr<FJsonObject> *ScaleObj = nullptr;
     if (TransformData->TryGetObjectField(TEXT("scale"), ScaleObj) && ScaleObj &&
@@ -119,13 +140,26 @@ TSharedPtr<FJsonObject> FSCSHandlers::SetSCSComponentTransform(
       (*ScaleObj)->TryGetNumberField(TEXT("x"), Scale.X);
       (*ScaleObj)->TryGetNumberField(TEXT("y"), Scale.Y);
       (*ScaleObj)->TryGetNumberField(TEXT("z"), Scale.Z);
+      bHasScale = true;
     }
+  }
+
+  // Writing engine defaults because the caller's fields never arrived is the
+  // silent no-op this handler was bitten by — refuse loudly instead.
+  if (!bHasLocation && !bHasRotation && !bHasScale) {
+    Result->SetBoolField(TEXT("success"), false);
+    Result->SetStringField(
+        TEXT("error"),
+        TEXT("No transform fields provided — pass at least one of location/"
+             "rotation/scale as a [x,y,z] array (or {x,y,z}/{pitch,yaw,roll} object)."));
+    Result->SetStringField(TEXT("errorCode"), TEXT("INVALID_ARGUMENT"));
+    return Result;
   }
 
   FTransform NewTransform(Rotation, Location, Scale);
 
-  if (USceneComponent *SceneComp =
-          Cast<USceneComponent>(ComponentNode->ComponentTemplate)) {
+  {
+    SceneComp->Modify();
     SceneComp->SetRelativeTransform(NewTransform);
 
     bool bCompiled = false;
@@ -162,12 +196,6 @@ TSharedPtr<FJsonObject> FSCSHandlers::SetSCSComponentTransform(
     Result->SetBoolField(TEXT("saved"), bSaved);
     AddSCSNodeVerification(Result, SCS, VerifiedNode);
     McpHandlerUtils::AddVerification(Result, Blueprint);
-  } else {
-    Result->SetBoolField(TEXT("success"), false);
-    Result->SetStringField(
-        TEXT("error"),
-        TEXT("Component is not a SceneComponent (no transform)"));
-    Result->SetStringField(TEXT("errorCode"), TEXT("SCS_NOT_SCENE_COMPONENT"));
   }
 #else
   return UnsupportedSCSAction();

--- a/src/tools/handlers/blueprint/blueprint-scs-actions.ts
+++ b/src/tools/handlers/blueprint/blueprint-scs-actions.ts
@@ -79,6 +79,12 @@ async function handleSetScsTransform(context: BlueprintActionContext): Promise<R
 }
 
 function vector3Payload(value: unknown, fallback: number): readonly [number, number, number] | undefined {
+  // The schema advertises these as number arrays ([x, y, z]); accept that form
+  // first — dropping it here silently forwarded nothing, so the native handler
+  // wrote defaults and reported success (a no-op that looked like a pass).
+  if (Array.isArray(value) && value.length >= 3) {
+    return [numberOrFallback(value[0], fallback), numberOrFallback(value[1], fallback), numberOrFallback(value[2], fallback)];
+  }
   if (!isRecord(value)) {
     return undefined;
   }
@@ -86,6 +92,10 @@ function vector3Payload(value: unknown, fallback: number): readonly [number, num
 }
 
 function rotationPayload(value: unknown): readonly [number, number, number] | undefined {
+  // Schema form: [pitch, yaw, roll] number array (the {pitch,yaw,roll} object stays for compat).
+  if (Array.isArray(value) && value.length >= 3) {
+    return [numberOrFallback(value[0], 0), numberOrFallback(value[1], 0), numberOrFallback(value[2], 0)];
+  }
   if (!isRecord(value)) {
     return undefined;
   }


### PR DESCRIPTION
## Summary

`manage_blueprint` `set_scs_transform` reported `success/compiled/saved` while
writing nothing: two independent read-backs (`get_scs`, `inspect_cdo`) showed
untouched defaults. Root cause is an input-contract gap, not the write path —
the schema advertises `location`/`rotation`/`scale` as number arrays
(`[x,y,z]` / `[pitch,yaw,roll]`), but the TS forwarder only accepted
`{x,y,z}`-style objects and silently dropped arrays. The native handler then
received no fields, built an engine-default transform, applied it, verified it
against itself, and reported success.

## Changes

- `src/tools/handlers/blueprint/blueprint-scs-actions.ts` —
  `vector3Payload`/`rotationPayload` now accept the schema's array form first;
  the object form is kept for compatibility.
- `...Domains/SCS/McpAutomationBridge_SCSHandlersSetTransform.cpp` — hardening
  on the native side: start from the template's CURRENT relative values
  (read-modify-write), so a partial payload (e.g. location only) no longer
  stomps rotation/scale back to defaults; track which fields actually arrived
  and refuse loudly (`INVALID_ARGUMENT`) when none did — writing engine
  defaults on behalf of a caller whose fields never arrived is exactly the
  silent no-op this action was bitten by. Also `Modify()` before the write,
  and the not-a-SceneComponent check now runs before parsing. The existing
  post-write verification is unchanged; with the input contract fixed it now
  verifies the caller's intent rather than the defaults.

## Related Issues

Found during downstream dogfooding (silent-success class; no existing upstream issue).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Tested with Unreal Engine (version: 5.8)
- [x] Tested MCP client integration (client: stdio MCP client via @modelcontextprotocol/sdk)
- [ ] Added/updated tests

Live verification against a running UE 5.8 editor (fresh Actor BP, SceneComponent
root + StaticMeshComponent child):

- Array-form set `location:[100,200,300] rotation:[10,45,5] scale:[2,2,2]` →
  success, and BOTH independent read-backs (`get_scs`, `inspect_cdo`) now show
  the written values (previously: defaults).
- Partial payload (`location` only) → other fields keep their previous values
  (behavior-differentiating: the unpatched native code reset them to defaults).
- Empty payload → loud `INVALID_ARGUMENT` (previously: silent default write
  reported as success).
- Object-form inputs (`{x,y,z}`) still work (compatibility).

`npm run lint` (incl. `--max-warnings=0`), `npm run type-check`, `npm run build`,
`npm run test:smoke`, and `npm run test:native-parity` (0 mismatches) all pass.

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Updated relevant documentation (if needed) — error message documents the accepted forms
- [ ] Added/updated tests (if applicable) — verified live instead, matching the repo's focused-fix pattern
- [x] CI passes
