### PR TITLE
fix: blueprint compile reports the real outcome (was hardcoded compiled:true)

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Blueprint/Queries/McpAutomationBridge_BlueprintHandlersCompile.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Blueprint/Queries/McpAutomationBridge_BlueprintHandlersCompile.cpp
@@ -41,17 +41,50 @@ bool HandleBlueprintCompile(const FBlueprintActionContext &Context) {
                              Err, TEXT("NOT_FOUND"));
       return true;
     }
-    McpSafeCompileBlueprint(BP);
+    // Report the REAL compile outcome: McpSafeCompileBlueprint already returns
+    // it (BS_UpToDate / BS_UpToDateWithWarnings) — previously the result was
+    // discarded and `compiled` hardcoded to true, so a fatally broken blueprint
+    // reported compiled:true (and was even saved to disk below).
+    const bool bCompiled = McpSafeCompileBlueprint(BP);
     bool bSaved = false;
+    bool bSaveSkipped = false;
     if (bSaveAfterCompile) {
-      bSaved = SaveLoadedAssetThrottled(BP);
+      if (bCompiled) {
+        bSaved = SaveLoadedAssetThrottled(BP);
+      } else {
+        // Don't persist a blueprint that just failed to compile.
+        bSaveSkipped = true;
+      }
     }
+
+    const TCHAR *StatusName = TEXT("Unknown");
+    switch (BP->Status) {
+      case BS_UpToDate:             StatusName = TEXT("UpToDate"); break;
+      case BS_UpToDateWithWarnings: StatusName = TEXT("UpToDateWithWarnings"); break;
+      case BS_Error:                StatusName = TEXT("Error"); break;
+      case BS_Dirty:                StatusName = TEXT("Dirty"); break;
+      case BS_BeingCreated:         StatusName = TEXT("BeingCreated"); break;
+      default: break;
+    }
+
     TSharedPtr<FJsonObject> Out = McpHandlerUtils::CreateResultObject();
-    Out->SetBoolField(TEXT("compiled"), true);
+    Out->SetBoolField(TEXT("compiled"), bCompiled);
+    Out->SetStringField(TEXT("compilerStatus"), StatusName);
     Out->SetBoolField(TEXT("saved"), bSaved);
+    if (bSaveSkipped) {
+      Out->SetBoolField(TEXT("saveSkipped"), true);
+      Out->SetStringField(
+          TEXT("saveHint"),
+          TEXT("saveAfterCompile was requested but the compile failed; the "
+               "broken blueprint was NOT written to disk."));
+    }
     Out->SetStringField(TEXT("blueprintPath"), Path);
-    Bridge.SendAutomationResponse(RequestingSocket, RequestId, true,
-                           TEXT("Blueprint compiled"), Out, FString());
+    Bridge.SendAutomationResponse(
+        RequestingSocket, RequestId, /*bSuccess=*/bCompiled,
+        bCompiled ? TEXT("Blueprint compiled")
+                  : TEXT("Blueprint compile FAILED — see the editor's Compiler "
+                         "Results / log for the errors."),
+        Out, bCompiled ? FString() : FString(TEXT("COMPILE_FAILED")));
     return true;
 #else
     Bridge.SendAutomationResponse(RequestingSocket, RequestId, false,


### PR DESCRIPTION
## Summary

The `manage_blueprint` `compile` handler already calls `McpSafeCompileBlueprint`,
which returns the real outcome (`Status == BS_UpToDate / BS_UpToDateWithWarnings`)
— but the return value was discarded and the response hardcoded `compiled:true`
with top-level success. A blueprint with a FATAL compile error therefore reported
`compiled:true`, and with `saveAfterCompile` the broken blueprint was even
persisted to disk. Automation built on top of this proceeds on a broken asset.

## Changes

- `compiled` now carries the real compile outcome; a failed compile returns
  `success:false` with errorCode `COMPILE_FAILED`.
- New `compilerStatus` field exposes the blueprint's post-compile status name
  (`UpToDate` / `UpToDateWithWarnings` / `Error` / ...) for diagnostics.
- `saveAfterCompile` no longer writes a blueprint that just failed to compile:
  the response carries `saveSkipped:true` with a hint instead of silently
  persisting a broken asset.
- Healthy-blueprint behavior is unchanged (`compiled:true`, save honored;
  warnings still count as compiled, matching the helper's semantics).

## Related Issues

Found during downstream dogfooding (silent-success class; no existing upstream issue).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Tested with Unreal Engine (version: 5.8)
- [x] Tested MCP client integration (client: stdio MCP client via @modelcontextprotocol/sdk)
- [ ] Added/updated tests

Live verification against a running UE 5.8 editor:

- Healthy blueprint, `compile` + `saveAfterCompile:true` →
  `compiled:true, compilerStatus:"UpToDate", saved:true` (unchanged behavior).
- Deliberately broken blueprint (a custom event whose name collides with a
  native parent function — a real compiler FATAL), same call →
  `success:false`, `COMPILE_FAILED`, `compiled:false`, `compilerStatus:"Error"`,
  `saved:false`, `saveSkipped:true`. The unpatched build returned
  `compiled:true, saved:true` for the same blueprint and wrote it to disk.
- After repairing the blueprint, the same call returns `UpToDate` again.

`npm run test:smoke` and `npm run test:native-parity` (0 mismatches) pass
(TS surface untouched — this is a native-only fix).

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Updated relevant documentation (if needed) — response fields document the behavior
- [ ] Added/updated tests (if applicable) — verified live instead, matching the repo's focused-fix pattern
- [x] CI passes
