### PR TITLE
fix: add_variable float/double produce PC_Real pins (Get/Set resolved as int)

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Blueprint/Variables/McpAutomationBridge_BlueprintHandlersAddVariablePinType.h
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Blueprint/Variables/McpAutomationBridge_BlueprintHandlersAddVariablePinType.h
@@ -10,8 +10,17 @@ inline bool ResolveAddVariablePinType(const FString &VarType,
                                       FEdGraphPinType &PinType,
                                       FString &OutError) {
   const FString LowerType = VarType.ToLower();
-  if (LowerType == TEXT("float") || LowerType == TEXT("double")) {
-    PinType.PinCategory = MCP_PC_Float;
+  if (LowerType == TEXT("float")) {
+    // UE5: PC_Float is a SUBcategory of PC_Real, not a valid pin category.
+    // A bare PC_Float category here makes the variable's Get/Set node pins
+    // resolve as int downstream (the compiler then injects Truncate /
+    // To Float casts — silent precision loss). Same family as the
+    // MakePinType fix for function/event parameters.
+    PinType.PinCategory = UEdGraphSchema_K2::PC_Real;
+    PinType.PinSubCategory = UEdGraphSchema_K2::PC_Float;
+  } else if (LowerType == TEXT("double") || LowerType == TEXT("real")) {
+    PinType.PinCategory = UEdGraphSchema_K2::PC_Real;
+    PinType.PinSubCategory = UEdGraphSchema_K2::PC_Double;
   } else if (LowerType == TEXT("int") || LowerType == TEXT("integer")) {
     PinType.PinCategory = MCP_PC_Int;
   } else if (LowerType == TEXT("bool") || LowerType == TEXT("boolean")) {


### PR DESCRIPTION
## Summary

`add_variable` set `PinCategory` to `PC_Float` for `"float"`/`"double"`. In UE5
`PC_Float` is a SUBcategory of `PC_Real`, not a valid pin category, so the
member variable's Get/Set node pins resolved as **int** downstream: the
compiler silently injected `To Float (Integer)` casts on gets and a `Truncate`
on sets — float values (health, ranges, ...) were quietly truncated at
runtime, plus graph clutter from the auto-inserted cast nodes. Same fix family
as the function/event parameter `MakePinType` change (#458); this is the
member-variable path that change did not cover.

## Changes

- `ResolveAddVariablePinType`: `"float"` → `PC_Real` + `PC_Float` subcategory;
  `"double"` (and `"real"`) → `PC_Real` + `PC_Double` — previously both
  collapsed to a bare `PC_Float` category. Variables created before this fix
  keep their serialized broken type and need to be recreated (or retyped in
  the editor) once.

## Related Issues

Found during downstream dogfooding (float-correctness class; sibling of #458).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Tested with Unreal Engine (version: 5.8)
- [x] Tested MCP client integration (client: stdio MCP client via @modelcontextprotocol/sdk)
- [ ] Added/updated tests

Live verification against a running UE 5.8 editor:

- `add_variable {variableType:"Float"}` then `create_node VariableGet` →
  `get_node_details` reports the value pin as `real` (unpatched build: `int`).
- Compile of the same blueprint is clean (`UpToDate`) with no auto-inserted
  `Truncate` / `To Float (Integer)` cast nodes.

`npm run lint` (incl. `--max-warnings=0`), `npm run type-check`,
`npm run test:smoke`, and `npm run test:native-parity` (0 mismatches) all pass
(TS surface untouched — native-only header fix).

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Updated relevant documentation (if needed) — comment documents the UE5 pin-category rule
- [ ] Added/updated tests (if applicable) — verified live instead, matching the repo's focused-fix pattern
- [x] CI passes
