### PR TITLE
fix: surface engine-log errors without overriding the handler's verdict

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Core/Subsystem/McpAutomationBridgeSubsystemResponses.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Core/Subsystem/McpAutomationBridgeSubsystemResponses.cpp
@@ -95,13 +95,15 @@ void UMcpAutomationBridgeSubsystem::SendAutomationResponse(
 
         if (CapturedErrors.Num() > 0)
         {
-            bEffectiveSuccess = false;
-            EffectiveErrorCode = TEXT("ENGINE_ERROR");
-            const FString FirstError = SanitizeEngineErrorForResponse(CapturedErrors[0]);
-            EffectiveMessage = FString::Printf(
-                TEXT("Handler reported success but Unreal logged errors: %s"),
-                *FirstError.Left(240));
-
+            // Surface, don't override: engine-log errors observed during the
+            // request are ATTACHED for the caller to judge, but the handler's
+            // own verdict stands. Downgrading success here conflated transport
+            // success with asset-level warnings and produced false negatives —
+            // a handler that completed its work (node created, asset saved)
+            // was reported as failed, triggering pointless retries and
+            // undo-then-reapply flows. Handlers that can genuinely fail are
+            // responsible for reporting it themselves (e.g. blueprint_compile
+            // returns its real compile status).
             TSharedPtr<FJsonObject> AugmentedResult = MakeShared<FJsonObject>();
             if (Result.IsValid())
             {
@@ -120,7 +122,7 @@ void UMcpAutomationBridgeSubsystem::SendAutomationResponse(
                 ErrorValues.Add(MakeShared<FJsonValueString>(
                     SanitizeEngineErrorForResponse(CapturedErrors[ErrorIndex])));
             }
-            AugmentedResult->SetBoolField(TEXT("success"), false);
+            AugmentedResult->SetBoolField(TEXT("engineErrorsObserved"), true);
             AugmentedResult->SetNumberField(
                 TEXT("engineErrorCount"),
                 TotalCapturedErrorCount);
@@ -129,11 +131,6 @@ void UMcpAutomationBridgeSubsystem::SendAutomationResponse(
             {
                 AugmentedResult->SetBoolField(TEXT("engineErrorsTruncated"), true);
             }
-
-            TSharedPtr<FJsonObject> ErrorObj = MakeShared<FJsonObject>();
-            ErrorObj->SetStringField(TEXT("code"), EffectiveErrorCode);
-            ErrorObj->SetStringField(TEXT("message"), EffectiveMessage);
-            AugmentedResult->SetObjectField(TEXT("error"), ErrorObj);
             EffectiveResult = AugmentedResult;
         }
     }


### PR DESCRIPTION
## Summary

When a handler reported success but Unreal logged ANY error during the
request, the response layer downgraded the whole response: top-level success
was flipped to false (`ENGINE_ERROR`), the message was replaced with
"Handler reported success but Unreal logged errors", and `success:false` plus
an error object were injected into the result — even though the handler had
completed its work (node created, asset saved). This is a false negative:
callers retry operations that actually succeeded, or run undo-then-reapply
flows against state that is fine, and the real outcome is only discoverable by
ignoring `success` and re-reading payload fields.

## Changes

- Keep the safety net's information, drop its override: captured engine
  errors are still attached to the result (`engineErrors`, `engineErrorCount`,
  `engineErrorsTruncated`, plus a new `engineErrorsObserved:true` flag), but
  the handler's own verdict — top-level success, message, errorCode, and the
  result's own fields — now stands.
- Handlers that can genuinely fail are responsible for reporting it
  themselves (e.g. blueprint compile now returns its real compile status —
  see #462), which keeps failure reporting attributable instead of ambient.
- Clean-path responses (no captured errors) are byte-identical to before.

## Related Issues

Found during downstream dogfooding (false-negative class; designed as a pair
with #462).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Tested with Unreal Engine (version: 5.8)
- [x] Tested MCP client integration (client: stdio MCP client via @modelcontextprotocol/sdk)
- [ ] Added/updated tests

Live verification against a running UE 5.8 editor:

- A call that succeeds while the engine logs an error (creating a custom
  event whose name collides with a native parent function) now returns
  `success:true` with its own handler message, plus `engineErrorsObserved:true`,
  `engineErrorCount:1` and the sanitized error text attached. The unpatched
  build returned `success:false`/`ENGINE_ERROR` for the same call.
- Clean calls carry none of the engineError fields (response unchanged).
- After deleting the conflicting event, a compile of the same blueprint
  reports `UpToDate` (interops with #462's real compile status).

`npm run lint` (incl. `--max-warnings=0`), `npm run type-check`,
`npm run test:smoke`, and `npm run test:native-parity` (0 mismatches) all
pass; the vitest suite shows no new failures (the ENGINE_ERROR envelope unit
test is mock-fed and asserts the unchanged TS-side contract).

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Updated relevant documentation (if needed) — comment documents the surface-don't-override policy
- [ ] Added/updated tests (if applicable) — verified live instead, matching the repo's focused-fix pattern
- [x] CI passes
