### PR TITLE
fix: add_node FunctionResult creates duplicate execute pins

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BehaviorTree/McpAutomationBridge_BehaviorTreeHandlersNodeCreation.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BehaviorTree/McpAutomationBridge_BehaviorTreeHandlersNodeCreation.cpp
@@ -166,7 +166,9 @@ bool HandleAddNode(UMcpAutomationBridgeSubsystem* Subsystem,
   NewNode->NodePosY = Y;
   GraphContext.Graph->AddNode(NewNode, true, false);
   NewNode->PostPlacedNewNode();
-  NewNode->AllocateDefaultPins();
+  // Guard against duplicate pins: some node types already allocate in
+  // PostPlacedNewNode(), so only allocate when the node has no pins yet.
+  if (NewNode->Pins.Num() == 0) { NewNode->AllocateDefaultPins(); }
 
   if (NodeInstanceClass && !NewNode->NodeInstance) {
     GraphContext.Graph->RemoveNode(NewNode);

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BehaviorTree/McpAutomationBridge_BehaviorTreeHandlersSubnodes.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BehaviorTree/McpAutomationBridge_BehaviorTreeHandlersSubnodes.cpp
@@ -220,7 +220,9 @@ bool HandleAddSubnode(UMcpAutomationBridgeSubsystem* Subsystem,
   NewSubnode->NodeInstance = NewObject<UBTNode>(NewSubnode, NodeInstanceClass);
   NewSubnode->CreateNewGuid();
   NewSubnode->PostPlacedNewNode();
-  NewSubnode->AllocateDefaultPins();
+  // Guard against duplicate pins: some node types already allocate in
+  // PostPlacedNewNode(), so only allocate when the node has no pins yet.
+  if (NewSubnode->Pins.Num() == 0) { NewSubnode->AllocateDefaultPins(); }
   ParentNode->AddSubNode(NewSubnode, GraphContext.Graph);
   UpdateBehaviorTreeAsset(GraphContext);
 

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersNodeCreation.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersNodeCreation.cpp
@@ -88,7 +88,16 @@ void CreateDynamicNode(
     Context.TargetGraph->AddNode(NewNode, false, false);
     NewNode->CreateNewGuid();
     NewNode->PostPlacedNewNode();
-    NewNode->AllocateDefaultPins();
+    // Some K2 nodes (e.g. UK2Node_FunctionResult) already allocate their default
+    // pins inside PostPlacedNewNode(); calling AllocateDefaultPins() again then
+    // duplicates them — a FunctionResult ends up with two 'execute' input pins,
+    // one of which stays unconnected and trips a compiler warning. Mirror the
+    // engine's own FGraphNodeCreator::Finalize guard and only allocate when the
+    // node has no pins yet.
+    if (NewNode->Pins.Num() == 0)
+    {
+        NewNode->AllocateDefaultPins();
+    }
     NewNode->NodePosX = X;
     NewNode->NodePosY = Y;
     FBlueprintEditorUtils::MarkBlueprintAsModified(Context.Blueprint);

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersSpecialNodes.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersSpecialNodes.cpp
@@ -184,7 +184,9 @@ bool TryCreateEnhancedInputNode(
         InputAction);
     NewNode->CreateNewGuid();
     NewNode->PostPlacedNewNode();
-    NewNode->AllocateDefaultPins();
+    // Guard against duplicate pins: some node types already allocate in
+    // PostPlacedNewNode(), so only allocate when the node has no pins yet.
+    if (NewNode->Pins.Num() == 0) { NewNode->AllocateDefaultPins(); }
     if (UK2Node* K2Node = Cast<UK2Node>(NewNode))
     {
         K2Node->ReconstructNode();

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/LevelStructure/McpAutomationBridge_LevelStructureBlueprintNodes.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/LevelStructure/McpAutomationBridge_LevelStructureBlueprintNodes.cpp
@@ -130,7 +130,9 @@ bool HandleAddLevelBlueprintNode(
             }
             NewNode->CreateNewGuid();
             NewNode->PostPlacedNewNode();
-            NewNode->AllocateDefaultPins();
+            // Guard against duplicate pins: some node types already allocate in
+            // PostPlacedNewNode(), so only allocate when the node has no pins yet.
+            if (NewNode->Pins.Num() == 0) { NewNode->AllocateDefaultPins(); }
             NewNode->NodePosX = PosX;
             NewNode->NodePosY = PosY;
             EventGraph->AddNode(NewNode, true, false);


### PR DESCRIPTION
## Summary

Creating a `K2Node_FunctionResult` via `manage_blueprint` `add_node` produced
**two** `execute` input pins. The generic node-creation path calls
`PostPlacedNewNode()` and then unconditionally `AllocateDefaultPins()`;
`UK2Node_FunctionResult` already allocates its exec pin inside
`PostPlacedNewNode()`, so the second call duplicated it. One pin stays
unconnected and trips a `"ReturnNode Exec pin has no connections"` compiler
warning.

## Changes

- Guard the post-placement `AllocateDefaultPins()` call with
  `if (NewNode->Pins.Num() == 0)`, matching the engine's own
  `FGraphNodeCreator::Finalize` behavior. Nodes whose `PostPlacedNewNode()`
  already populated pins are no longer re-allocated; every other node type is
  unaffected.

## Related Issues

_(standalone)_

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Tested with Unreal Engine (version: 5.8)
- [x] Tested MCP client integration (client: MCP automation bridge)

`add_node nodeType:FunctionResult` into a fresh function graph → the result node
now has exactly one `execute` input pin (previously two), and the spurious
compiler warning is gone.

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] CI passes
