### PR TITLE
feat: add remove_function action to manage_blueprint

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Blueprint/Functions/McpAutomationBridge_BlueprintHandlersRemoveFunction.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Blueprint/Functions/McpAutomationBridge_BlueprintHandlersRemoveFunction.cpp
@@ -1,0 +1,174 @@
+#include "Domains/Blueprint/McpAutomationBridge_BlueprintActionContext.h"
+#include "Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphCompatibility.h"
+#include "Foundation/BridgeHelpers/Assets/McpAutomationBridgeHelpersAssetSaveRegistry.h"
+#include "Foundation/BridgeHelpers/Blueprints/McpAutomationBridgeHelpersBlueprintAssetLoad.h"
+#include "Foundation/BridgeHelpers/Blueprints/McpAutomationBridgeHelpersBlueprintCompilation.h"
+#include "Foundation/HandlerUtils/McpHandlerUtils.h"
+
+#if WITH_EDITOR
+#include "Engine/Blueprint.h"
+#include "Kismet2/BlueprintEditorUtils.h"
+#endif
+
+namespace McpBlueprintHandlers {
+#if WITH_EDITOR
+// Delete a user-defined Blueprint function graph. Counterpart to add_function:
+// before this, functions were create-only (the action enum had no remove path),
+// so a wrong-signature function could not be deleted or re-signed via MCP at all
+// -- only through the editor UI. To re-sign a function, call
+// remove_function then add_function; add_function is create-only and returns
+// "Function already exists" if the graph is present (no in-place overwrite path).
+bool HandleBlueprintRemoveFunction(const FBlueprintActionContext &Context) {
+  MCP_BLUEPRINT_ACTION_LOCALS(Context);
+  if (ActionMatchesPattern(TEXT("blueprint_remove_function")) ||
+      ActionMatchesPattern(TEXT("remove_function")) ||
+      AlphaNumLower.Contains(TEXT("blueprintremovefunction")) ||
+      AlphaNumLower.Contains(TEXT("removefunction"))) {
+    FString Path = ResolveBlueprintRequestedPath();
+    if (Path.IsEmpty()) {
+      Bridge.SendAutomationResponse(
+          RequestingSocket, RequestId, false,
+          TEXT("blueprint_remove_function requires a blueprint path."), nullptr,
+          TEXT("INVALID_BLUEPRINT_PATH"));
+      return true;
+    }
+
+    // Accept functionName, falling back to name/memberName for parameter
+    // consistency with add_function.
+    FString FuncName;
+    if (!LocalPayload->TryGetStringField(TEXT("functionName"), FuncName) ||
+        FuncName.IsEmpty()) {
+      if (!LocalPayload->TryGetStringField(TEXT("name"), FuncName) ||
+          FuncName.IsEmpty()) {
+        LocalPayload->TryGetStringField(TEXT("memberName"), FuncName);
+      }
+    }
+    FuncName = FuncName.TrimStartAndEnd();
+    if (FuncName.IsEmpty()) {
+      Bridge.SendAutomationResponse(
+          RequestingSocket, RequestId, false,
+          TEXT("functionName (or name/memberName) required. Example: "
+               "{\"functionName\": \"MyFunction\"}"),
+          nullptr, TEXT("INVALID_ARGUMENT"));
+      return true;
+    }
+
+    FString Normalized;
+    FString LoadErr;
+    UBlueprint *Blueprint = LoadBlueprintAsset(Path, Normalized, LoadErr);
+    const FString RegistryKey = !Normalized.IsEmpty() ? Normalized : Path;
+    if (!Blueprint) {
+      TSharedPtr<FJsonObject> Err = McpHandlerUtils::CreateResultObject();
+      if (!LoadErr.IsEmpty()) {
+        Err->SetStringField(TEXT("error"), LoadErr);
+      }
+      Bridge.SendAutomationResponse(RequestingSocket, RequestId, false,
+                                    TEXT("Failed to load blueprint"), Err,
+                                    TEXT("BLUEPRINT_NOT_FOUND"));
+      return true;
+    }
+
+#if MCP_HAS_EDGRAPH_SCHEMA_K2
+    // FunctionGraphs is the source of truth for user-defined functions (the
+    // same list add_function appends to). Inherited/engine functions and the
+    // EventGraph are not here and cannot be removed this way.
+    UEdGraph *Target = nullptr;
+    for (UEdGraph *Graph : Blueprint->FunctionGraphs) {
+      if (Graph &&
+          Graph->GetName().Equals(FuncName, ESearchCase::IgnoreCase)) {
+        Target = Graph;
+        break;
+      }
+    }
+
+    if (!Target) {
+      // Graph-authoritative, truth-telling: a function genuinely not present is
+      // a loud NOT_FOUND, never a bogus idempotent success.
+      TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
+      Resp->SetStringField(TEXT("functionName"), FuncName);
+      Resp->SetStringField(TEXT("blueprintPath"), RegistryKey);
+      Resp->SetStringField(
+          TEXT("hint"),
+          TEXT("No user-defined function with this name. Inherited/engine "
+               "functions and the EventGraph cannot be removed; use delete_node "
+               "for individual nodes."));
+      Bridge.SendAutomationResponse(RequestingSocket, RequestId, false,
+                                    TEXT("Function not found."), Resp,
+                                    TEXT("NOT_FOUND"));
+      return true;
+    }
+
+    FBlueprintEditorUtils::RemoveGraph(Blueprint, Target,
+                                       EGraphRemoveFlags::Recompile);
+    const bool bSaved = McpSafeAssetSave(Blueprint);
+
+    // Verify against the graph, not against our own assumption: rescan
+    // FunctionGraphs after the remove+recompile.
+    bool bStillPresent = false;
+    for (UEdGraph *Graph : Blueprint->FunctionGraphs) {
+      if (Graph &&
+          Graph->GetName().Equals(FuncName, ESearchCase::IgnoreCase)) {
+        bStillPresent = true;
+        break;
+      }
+    }
+
+    TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
+    Resp->SetStringField(TEXT("functionName"), FuncName);
+    Resp->SetStringField(TEXT("blueprintPath"), RegistryKey);
+    Resp->SetBoolField(TEXT("removed"), !bStillPresent);
+    Resp->SetBoolField(TEXT("saved"), bSaved);
+    McpHandlerUtils::AddVerification(Resp, Blueprint);
+
+    if (bStillPresent) {
+      Bridge.SendAutomationResponse(RequestingSocket, RequestId, false,
+                                    TEXT("Function removal did not take effect."),
+                                    Resp, TEXT("REMOVE_FAILED"));
+      return true;
+    }
+
+    // Keep the per-asset registry's functions[] in sync (add_function records
+    // there); otherwise a stale entry would survive the graph removal.
+    TSharedPtr<FJsonObject> Entry =
+        FMcpAutomationBridge_EnsureBlueprintEntry(RegistryKey);
+    if (Entry->HasField(TEXT("functions"))) {
+      TArray<TSharedPtr<FJsonValue>> Funcs =
+          Entry->GetArrayField(TEXT("functions"));
+      for (int32 i = Funcs.Num() - 1; i >= 0; --i) {
+        const TSharedPtr<FJsonValue> &V = Funcs[i];
+        FString CandidateName;
+        if (V.IsValid() && V->Type == EJson::Object &&
+            V->AsObject()->TryGetStringField(TEXT("name"), CandidateName) &&
+            CandidateName.Equals(FuncName, ESearchCase::IgnoreCase)) {
+          Funcs.RemoveAt(i);
+        }
+      }
+      Entry->SetArrayField(TEXT("functions"), Funcs);
+    }
+
+    Bridge.SendAutomationResponse(RequestingSocket, RequestId, true,
+                                  TEXT("Function removed."), Resp, FString());
+
+    TSharedPtr<FJsonObject> Notify = McpHandlerUtils::CreateResultObject();
+    Notify->SetStringField(TEXT("type"), TEXT("automation_event"));
+    Notify->SetStringField(TEXT("event"), TEXT("remove_function_completed"));
+    Notify->SetStringField(TEXT("requestId"), RequestId);
+    Notify->SetObjectField(TEXT("result"), Resp);
+    Bridge.BroadcastAutomationEvent(Notify, RequestingSocket);
+    UE_LOG(LogMcpAutomationBridgeSubsystem, Log,
+           TEXT("HandleBlueprintAction: function '%s' removed from '%s'"),
+           *FuncName, *RegistryKey);
+    return true;
+#else
+    Bridge.SendAutomationResponse(
+        RequestingSocket, RequestId, false,
+        TEXT("blueprint_remove_function requires editor build with K2 schema"),
+        nullptr, TEXT("NOT_AVAILABLE"));
+    return true;
+#endif // MCP_HAS_EDGRAPH_SCHEMA_K2
+  }
+
+  return false;
+}
+#endif
+} // namespace McpBlueprintHandlers

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Blueprint/McpAutomationBridge_BlueprintHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Blueprint/McpAutomationBridge_BlueprintHandlers.cpp
@@ -40,6 +40,7 @@ bool UMcpAutomationBridgeSubsystem::HandleBlueprintAction(
       McpBlueprintHandlers::HandleBlueprintAddEvent,
       McpBlueprintHandlers::HandleBlueprintRemoveEvent,
       McpBlueprintHandlers::HandleBlueprintAddFunction,
+      McpBlueprintHandlers::HandleBlueprintRemoveFunction,
       McpBlueprintHandlers::HandleBlueprintSetDefaultObject,
       McpBlueprintHandlers::HandleBlueprintCompile,
       McpBlueprintHandlers::HandleBlueprintProbeCreateExists,

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Blueprint/McpAutomationBridge_BlueprintHandlersDeclarations.h
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Blueprint/McpAutomationBridge_BlueprintHandlersDeclarations.h
@@ -156,6 +156,7 @@ bool HandleBlueprintRemoveRenameVariable(const FBlueprintActionContext &Context)
 bool HandleBlueprintAddEvent(const FBlueprintActionContext &Context);
 bool HandleBlueprintRemoveEvent(const FBlueprintActionContext &Context);
 bool HandleBlueprintAddFunction(const FBlueprintActionContext &Context);
+bool HandleBlueprintRemoveFunction(const FBlueprintActionContext &Context);
 bool HandleBlueprintSetDefaultObject(const FBlueprintActionContext &Context);
 bool HandleBlueprintCompile(const FBlueprintActionContext &Context);
 bool HandleBlueprintProbeCreateExists(const FBlueprintActionContext &Context);

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Routing/McpConsolidatedActionRoutingBlueprints.h
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Routing/McpConsolidatedActionRoutingBlueprints.h
@@ -15,6 +15,7 @@ inline const TArray<FString>& ManageBlueprintCore()
 		TEXT("set_scs_transform"), TEXT("set_scs_property"),
 		TEXT("ensure_exists"), TEXT("probe_handle"), TEXT("add_variable"),
 		TEXT("remove_variable"), TEXT("rename_variable"), TEXT("add_function"),
+		TEXT("remove_function"),
 		TEXT("add_event"), TEXT("remove_event"),
 		TEXT("add_construction_script"), TEXT("set_variable_metadata"),
 		TEXT("set_metadata"), TEXT("create_node"), TEXT("add_node"),

--- a/src/tools/definitions/core/blueprint/manage-blueprint-core-properties.ts
+++ b/src/tools/definitions/core/blueprint/manage-blueprint-core-properties.ts
@@ -7,7 +7,7 @@ action: {
           enum: [
             'create', 'create_blueprint', 'get_blueprint', 'get', 'compile',
             'add_component', 'set_default', 'modify_scs', 'get_scs', 'add_scs_component', 'remove_scs_component', 'reparent_scs_component', 'set_scs_transform', 'set_scs_property',
-            'ensure_exists', 'probe_handle', 'add_variable', 'remove_variable', 'rename_variable', 'add_function', 'add_event', 'remove_event', 'add_construction_script', 'set_variable_metadata', 'set_metadata',
+            'ensure_exists', 'probe_handle', 'add_variable', 'remove_variable', 'rename_variable', 'add_function', 'remove_function', 'add_event', 'remove_event', 'add_construction_script', 'set_variable_metadata', 'set_metadata',
             'create_node', 'add_node', 'delete_node', 'connect_pins', 'break_pin_links', 'set_node_property', 'create_reroute_node', 'get_node_details', 'get_graph_details', 'get_pin_details',
             'list_node_types', 'set_pin_default_value'
           ,

--- a/src/tools/handlers/blueprint/blueprint-event-actions.ts
+++ b/src/tools/handlers/blueprint/blueprint-event-actions.ts
@@ -19,6 +19,12 @@ export const blueprintEventHandlers: Readonly<Record<string, BlueprintActionHand
     ...commonTimingPayload(context)
   }),
   add_function: async (context) => await handleAddFunction(context),
+  remove_function: async (context) => await executeBlueprintRequest(context, 'blueprint_remove_function', {
+    blueprintCandidates: blueprintCandidates(context),
+    requestedPath: blueprintTarget(context),
+    functionName: optionalString(context.argsRecord.functionName) ?? optionalString(context.argsTyped.memberName) ?? '',
+    ...commonTimingPayload(context)
+  }),
   add_construction_script: async (context) => await executeBlueprintRequest(context, 'blueprint_add_construction_script', {
     blueprintCandidates: blueprintCandidates(context),
     requestedPath: blueprintTarget(context),

--- a/src/tools/handlers/blueprint/blueprint-event-actions.ts
+++ b/src/tools/handlers/blueprint/blueprint-event-actions.ts
@@ -22,7 +22,7 @@ export const blueprintEventHandlers: Readonly<Record<string, BlueprintActionHand
   remove_function: async (context) => await executeBlueprintRequest(context, 'blueprint_remove_function', {
     blueprintCandidates: blueprintCandidates(context),
     requestedPath: blueprintTarget(context),
-    functionName: optionalString(context.argsRecord.functionName) ?? optionalString(context.argsTyped.memberName) ?? '',
+    functionName: optionalString(context.argsRecord.functionName) ?? optionalString(context.argsTyped.name) ?? optionalString(context.argsTyped.memberName) ?? '',
     ...commonTimingPayload(context)
   }),
   add_construction_script: async (context) => await executeBlueprintRequest(context, 'blueprint_add_construction_script', {

--- a/src/tools/handlers/blueprint/blueprint-event-actions.ts
+++ b/src/tools/handlers/blueprint/blueprint-event-actions.ts
@@ -19,12 +19,20 @@ export const blueprintEventHandlers: Readonly<Record<string, BlueprintActionHand
     ...commonTimingPayload(context)
   }),
   add_function: async (context) => await handleAddFunction(context),
-  remove_function: async (context) => await executeBlueprintRequest(context, 'blueprint_remove_function', {
-    blueprintCandidates: blueprintCandidates(context),
-    requestedPath: blueprintTarget(context),
-    functionName: optionalString(context.argsRecord.functionName) ?? optionalString(context.argsTyped.name) ?? optionalString(context.argsTyped.memberName) ?? '',
-    ...commonTimingPayload(context)
-  }),
+  remove_function: async (context) => {
+    // Mirror add_function's path/name disambiguation. blueprintTarget() is name-first,
+    // so with both { blueprintPath, name } it would treat the function name as the
+    // Blueprint path. Resolve the path blueprintPath-first, and only fall back to `name`
+    // for the function name when it was NOT consumed as the Blueprint path.
+    const blueprintName = firstString(context.argsTyped.blueprintPath, context.argsRecord.path, context.argsTyped.name) ?? '';
+    const usedNameForBlueprint = !context.argsTyped.blueprintPath && !context.argsRecord.path && Boolean(context.argsTyped.name);
+    return await executeBlueprintRequest(context, 'blueprint_remove_function', {
+      blueprintCandidates: [blueprintName],
+      requestedPath: blueprintName,
+      functionName: optionalString(context.argsRecord.functionName) || optionalString(context.argsTyped.memberName) || (!usedNameForBlueprint ? optionalString(context.argsTyped.name) : undefined) || '',
+      ...commonTimingPayload(context)
+    });
+  },
   add_construction_script: async (context) => await executeBlueprintRequest(context, 'blueprint_add_construction_script', {
     blueprintCandidates: blueprintCandidates(context),
     requestedPath: blueprintTarget(context),

--- a/tests/unit/tools/blueprint_handlers.test.ts
+++ b/tests/unit/tools/blueprint_handlers.test.ts
@@ -6,6 +6,8 @@ vi.mock('../../../src/tools/handlers/foundation/dispatch/common-handlers.js', ()
 }));
 
 import { handleBlueprintGet } from '../../../src/tools/handlers/blueprint/blueprint-handlers.js';
+import { blueprintEventHandlers } from '../../../src/tools/handlers/blueprint/blueprint-event-actions.js';
+import type { BlueprintActionContext } from '../../../src/tools/handlers/blueprint/blueprint-action-context.js';
 import { executeAutomationRequest } from '../../../src/tools/handlers/foundation/dispatch/common-handlers.js';
 
 describe('Blueprint Handlers', () => {
@@ -93,5 +95,28 @@ describe('Blueprint Handlers', () => {
         ]
       }
     });
+  });
+
+  it('remove_function with { blueprintPath, name } targets the blueprint, not the function name', async () => {
+    mockExecuteAutomationRequest.mockResolvedValue({ success: true, message: 'Function removed' });
+
+    const args = { blueprintPath: '/Game/Test/BP_Thing', name: 'MyFunction' };
+    const context = { argsTyped: args, argsRecord: args, tools: mockTools } as unknown as BlueprintActionContext;
+
+    await blueprintEventHandlers.remove_function(context);
+
+    // Regression: blueprintTarget() resolves name-first, so without disambiguation the
+    // function name "MyFunction" would be sent as the Blueprint path. The path must
+    // resolve to blueprintPath, and `name` must be used as the function name instead.
+    expect(mockExecuteAutomationRequest).toHaveBeenCalledWith(
+      mockTools,
+      'blueprint_remove_function',
+      expect.objectContaining({
+        requestedPath: '/Game/Test/BP_Thing',
+        blueprintCandidates: ['/Game/Test/BP_Thing'],
+        functionName: 'MyFunction'
+      }),
+      undefined
+    );
   });
 });


### PR DESCRIPTION
## Summary

`manage_blueprint` could create Blueprint functions but never remove one — there
was no `remove_function` action, so a wrong-signature function could only be
deleted from the editor UI. This adds a `remove_function` action that deletes a
user-defined function graph.

## Changes

- New `remove_function` action: added to the `manage_blueprint` action enum, the
  TypeScript handler, and the native routing allowlist.
- New C++ handler `HandleBlueprintRemoveFunction`: resolves the function graph by
  name from `Blueprint->FunctionGraphs` (the source of truth), removes it via
  `FBlueprintEditorUtils::RemoveGraph(..., EGraphRemoveFlags::Recompile)`,
  re-scans to verify the removal took effect, and keeps the per-asset registry in
  sync.
- Returns a loud `NOT_FOUND` (with a hint pointing to `delete_node` for
  inherited/engine functions) when the named function does not exist, instead of
  a misleading idempotent success.
- Accepts `functionName` (with `name`/`memberName` fallbacks). Re-signing a
  function is achieved with `remove_function` followed by `add_function`.

## Related Issues

Related to #228 (Blueprint/GAS function authoring pushing users to local Python workarounds).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Testing

- [x] Tested with Unreal Engine (version: 5.8)
- [x] Tested MCP client integration (client: MCP automation bridge)

`remove_function` on an existing function → `removed: true`, function gone from
`FunctionGraphs`. Calling it again on the now-removed function → `NOT_FOUND` with
hint (not a fake success). Re-creating it with a different signature via
`add_function` works.

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [ ] Updated relevant documentation (changelog is auto-drafted by release-drafter from the PR title)
- [x] CI passes
