### PR TITLE
fix: ForLoop/WhileLoop/ForEachLoop resolve to StandardMacros macros

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersNodeCatalog.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersNodeCatalog.cpp
@@ -168,10 +168,11 @@ UClass* FindNodeClassByName(const FString& NodeType)
         {TEXT("FlipFlop"), TEXT("K2Node_FlipFlop")},
         {TEXT("Gate"), TEXT("K2Node_Gate")},
         {TEXT("MultiGate"), TEXT("K2Node_MultiGate")},
-        {TEXT("ForLoop"), TEXT("K2Node_ForLoop")},
-        {TEXT("ForLoopWithBreak"), TEXT("K2Node_ForLoopWithBreak")},
-        {TEXT("ForEachLoop"), TEXT("K2Node_ForEachElementInEnum")},
-        {TEXT("WhileLoop"), TEXT("K2Node_WhileLoop")},
+        // ForLoop / ForLoopWithBreak / WhileLoop / ForEachLoop are StandardMacros
+        // library macros (no UK2Node_* class), resolved earlier by
+        // TryCreateMacroNode via K2Node_MacroInstance. Listing them here mis-resolved
+        // them (nonexistent class -> NODE_TYPE_NOT_FOUND; ForEachLoop -> the wrong
+        // enum iterator). Kept out on purpose.
         {TEXT("MakeArray"), TEXT("K2Node_MakeArray")},
         {TEXT("MakeStruct"), TEXT("K2Node_MakeStruct")},
         {TEXT("BreakStruct"), TEXT("K2Node_BreakStruct")},

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersNodeCreation.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersNodeCreation.cpp
@@ -2,10 +2,80 @@
 
 #if WITH_EDITOR
 #include "K2Node_FunctionEntry.h"
+#include "K2Node_MacroInstance.h"
 #include "ScopedTransaction.h"
 
 namespace McpBlueprintGraphHandlers
 {
+// ForLoop / WhileLoop / ForEachLoop and friends are NOT UK2Node_* classes — they
+// are Blueprint macros in the engine StandardMacros library, instantiated via
+// K2Node_MacroInstance. The old name aliases pointed either at a nonexistent class
+// (K2Node_ForLoop/K2Node_WhileLoop -> NODE_TYPE_NOT_FOUND) or at the wrong
+// class (ForEachLoop -> K2Node_ForEachElementInEnum, the enum iterator).
+// Resolve them to the real macro graph and spawn a macro instance.
+static bool TryCreateMacroNode(
+    FActionContext& Context,
+    const FString& NodeType,
+    float X,
+    float Y)
+{
+    static const TMap<FString, FString> StandardMacroByType = {
+        {TEXT("ForLoop"), TEXT("ForLoop")},
+        {TEXT("ForLoopWithBreak"), TEXT("ForLoopWithBreak")},
+        {TEXT("WhileLoop"), TEXT("WhileLoop")},
+        {TEXT("ForEachLoop"), TEXT("ForEachLoop")},
+        {TEXT("ForEachLoopWithBreak"), TEXT("ForEachLoopWithBreak")}};
+
+    // Accept a bare name or a K2Node_-prefixed alias (callers send both forms).
+    FString Key = NodeType;
+    if (!StandardMacroByType.Contains(Key) && Key.StartsWith(TEXT("K2Node_")))
+    {
+        Key = Key.RightChop(7);
+    }
+    const FString* MacroGraphName = StandardMacroByType.Find(Key);
+    if (!MacroGraphName)
+    {
+        return false;
+    }
+
+    UBlueprint* MacroLibrary = LoadObject<UBlueprint>(
+        nullptr,
+        TEXT("/Engine/EditorBlueprintResources/StandardMacros.StandardMacros"));
+    if (!MacroLibrary)
+    {
+        Context.SendError(
+            TEXT("Could not load engine StandardMacros library."),
+            TEXT("MACRO_LIBRARY_NOT_FOUND"));
+        return true;
+    }
+
+    UEdGraph* MacroGraph = nullptr;
+    for (UEdGraph* Graph : MacroLibrary->MacroGraphs)
+    {
+        if (Graph &&
+            Graph->GetName().Equals(*MacroGraphName, ESearchCase::IgnoreCase))
+        {
+            MacroGraph = Graph;
+            break;
+        }
+    }
+    if (!MacroGraph)
+    {
+        Context.SendError(
+            FString::Printf(
+                TEXT("Macro '%s' not found in StandardMacros library."),
+                **MacroGraphName),
+            TEXT("MACRO_NOT_FOUND"));
+        return true;
+    }
+
+    FGraphNodeCreator<UK2Node_MacroInstance> NodeCreator(*Context.TargetGraph);
+    UK2Node_MacroInstance* Node = NodeCreator.CreateNode(false);
+    Node->SetMacroGraph(MacroGraph);
+    Context.FinalizeNode(NodeCreator, Node, X, Y);
+    return true;
+}
+
 bool HandleNodeCreationAction(FActionContext& Context)
 {
     if (Context.SubAction != TEXT("create_node"))
@@ -29,6 +99,7 @@ bool HandleNodeCreationAction(FActionContext& Context)
         TryCreateVariableNode(Context, NodeType, X, Y) ||
         TryCreateFunctionOrEventNode(Context, NodeType, X, Y) ||
         TryCreateCustomEventNode(Context, NodeType, X, Y) ||
+        TryCreateMacroNode(Context, NodeType, X, Y) ||
         TryCreateSpecialNode(Context, NodeType, X, Y))
     {
         return true;

--- a/src/tools/handlers/blueprint/blueprint-graph-actions.ts
+++ b/src/tools/handlers/blueprint/blueprint-graph-actions.ts
@@ -23,10 +23,12 @@ const NODE_ALIASES: Readonly<Record<string, string>> = {
   ForEach: 'K2Node_ForEachElementInEnum',
   Sequence: 'K2Node_ExecutionSequence',
   ExecutionSequence: 'K2Node_ExecutionSequence',
-  ForEachLoop: 'K2Node_ForEachElementInEnum',
-  ForLoop: 'K2Node_ForLoop',
-  ForLoopWithBreak: 'K2Node_ForLoopWithBreak',
-  WhileLoop: 'K2Node_WhileLoop',
+  // ForLoop / ForLoopWithBreak / WhileLoop / ForEachLoop are StandardMacros library
+  // macros (no UK2Node_* class). Do NOT alias them here: the bare name must reach the
+  // bridge so TryCreateMacroNode can spawn a K2Node_MacroInstance. Aliasing ForEachLoop
+  // to K2Node_ForEachElementInEnum was wrong — that is the enum iterator, and the
+  // ForLoop/WhileLoop aliases pointed at nonexistent classes. ('ForEach' above
+  // stays — that one genuinely is the enum-ForEach node.)
   Gate: 'K2Node_Gate',
   DoOnce: 'K2Node_DoOnce',
   FlipFlop: 'K2Node_FlipFlop',

--- a/src/tools/handlers/graph/graph-handlers.ts
+++ b/src/tools/handlers/graph/graph-handlers.ts
@@ -22,10 +22,11 @@ const BLUEPRINT_NODE_ALIASES: Record<string, string> = {
     'IfThenElse': 'K2Node_IfThenElse',
     'Sequence': 'K2Node_ExecutionSequence',
     'ExecutionSequence': 'K2Node_ExecutionSequence',
-    'ForEachLoop': 'K2Node_ForEachElementInEnum',
-    'ForLoop': 'K2Node_ForLoop',  // Basic ForLoop - use ForLoopWithBreak for break support
-    'ForLoopWithBreak': 'K2Node_ForLoopWithBreak',
-    'WhileLoop': 'K2Node_WhileLoop',
+    // ForLoop / ForLoopWithBreak / WhileLoop / ForEachLoop are StandardMacros library
+    // macros (no UK2Node_* class). Do NOT alias them: the bare name must reach the bridge
+    // so TryCreateMacroNode spawns a K2Node_MacroInstance. Aliasing ForEachLoop
+    // to K2Node_ForEachElementInEnum was wrong (the enum iterator). MUST stay in sync with
+    // NODE_ALIASES in blueprint-graph-actions.ts — create_node routes here, add_node there.
     'Switch': 'K2Node_SwitchInteger',
     'SwitchOnInt': 'K2Node_SwitchInteger',
     'SwitchOnString': 'K2Node_SwitchString',


### PR DESCRIPTION
## Summary

Loop node types resolved incorrectly in `manage_blueprint` node creation:

- `ForLoop`, `ForLoopWithBreak`, `WhileLoop` were aliased to `K2Node_ForLoop` /
  `K2Node_WhileLoop` / … which **do not exist as classes** → `NODE_TYPE_NOT_FOUND`.
- `ForEachLoop` was aliased to `K2Node_ForEachElementInEnum`, the **enum**
  iterator — not the array ForEach.

These are Blueprint macros in the engine StandardMacros library and must be
instantiated as `K2Node_MacroInstance`.

## Changes

- New `TryCreateMacroNode` in the node-creation dispatch: loads
  `/Engine/EditorBlueprintResources/StandardMacros`, finds the macro graph
  (`ForLoop` / `ForLoopWithBreak` / `WhileLoop` / `ForEachLoop` /
  `ForEachLoopWithBreak`) and spawns a `K2Node_MacroInstance` via
  `FGraphNodeCreator` + `SetMacroGraph`.
- Removed the incorrect loop aliases from the C++ node catalog and from **both**
  TypeScript node-type alias maps (the `add_node` and `create_node` routes each
  maintain their own map) so the bare name reaches the bridge. The genuine
  enum-ForEach alias (`ForEach` → `K2Node_ForEachElementInEnum`) is preserved.

## Related Issues

_(standalone)_

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Tested with Unreal Engine (version: 5.8)
- [x] Tested MCP client integration (client: MCP automation bridge)

Via both `add_node` and `create_node`: `ForLoop` → "For Loop"
(FirstIndex/LastIndex/LoopBody/Index/Completed), `ForLoopWithBreak` → "For Loop
with Break" (+ Break), `WhileLoop` → macro instance, `ForEachLoop` → "For Each
Loop" array macro (Array / Array Element / Array Index). Previously
`NODE_TYPE_NOT_FOUND` or the wrong enum node.

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] CI passes
