### PR TITLE
fix: preserve leading underscore in sanitized asset paths

### DIFF
--- a/src/utils/validation/validation.ts
+++ b/src/utils/validation/validation.ts
@@ -185,7 +185,12 @@ export function normalizeAndSanitizeAssetPath(path: string): string {
     if (ROOTS.has(segment)) {
       return segment;
     }
-    return sanitizeAssetName(segment);
+    // A leading underscore is valid in UE package/folder paths (e.g. /Game/_Scratch).
+    // sanitizeAssetName strips leading underscores — correct for a bare asset NAME,
+    // but for a path SEGMENT it silently relocated assets to the wrong folder
+    // (/Game/_Scratch -> /Game/Scratch), diverging from manage_blueprint. Preserve it.
+    const cleaned = sanitizeAssetName(segment);
+    return /^_/.test(segment) && !cleaned.startsWith('_') ? `_${cleaned}` : cleaned;
   });
 
   // Reconstruct path


### PR DESCRIPTION
## Summary

`normalizeAndSanitizeAssetPath` sanitized each path **segment** by passing it
through the asset-**name** sanitizer, which strips leading underscores. A leading
underscore is valid in UE package/folder paths, so paths like `/Game/_Scratch`
were silently rewritten to `/Game/Scratch` — assets (e.g. via `manage_gas
create_*`) were created in the wrong folder, diverging from `manage_blueprint`,
which preserves the path.

## Changes

- In `normalizeAndSanitizeAssetPath`, preserve a single leading underscore on a
  path segment after sanitizing it. The path-traversal (`..`) protection and all
  other sanitization rules are unchanged.

## Related Issues

_(standalone)_

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Tested with Unreal Engine (version: 5.8)
- [x] Tested MCP client integration (client: MCP automation bridge)

`manage_gas create_gameplay_effect path:/Game/_Scratch` → asset created at
`/Game/_Scratch/...` (previously `/Game/Scratch/...`). The `..` traversal guard
still rejects path-escape attempts.

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] CI passes
