### PR TITLE
fix: apply defaultValue when adding blueprint variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## 🏷️ [Unreleased]
+
+<details>
+<summary><b>🐛 Fixed</b></summary>
+
+- **`add_variable` now applies `defaultValue`** — the handler read the `defaultValue` payload field but never assigned it to the new variable, so every Blueprint variable was created with a zero/empty default regardless of the value supplied (e.g. a float requested as `0.35` stayed `0`). The parsed JSON default is now written to `FBPVariableDescription::DefaultValue` with type-aware formatting: booleans as lowercase `true`/`false`, integer/byte categories as whole numbers, floats/doubles via `SanitizeFloat`, and strings/struct literals passed through. UE parses the stored string back into the typed default on compile.
+
+</details>
+
+---
+
 ## 🏷️ [0.5.30] - 2026-06-05
 
 > [!IMPORTANT]

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Blueprint/Variables/McpAutomationBridge_BlueprintHandlersAddVariable.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Blueprint/Variables/McpAutomationBridge_BlueprintHandlersAddVariable.cpp
@@ -175,6 +175,40 @@ bool HandleBlueprintAddVariable(const FBlueprintActionContext &Context) {
       NewVar.PropertyFlags |= CPF_Net;
     }
 
+    // Apply the requested default value. FBPVariableDescription stores the
+    // default as a string (the same form the editor's "Default Value" field
+    // serializes to); UE parses it back into the typed default on compile.
+    // Previously the payload's defaultValue was read but never applied, so
+    // every variable was created with a zero/empty default regardless of the
+    // value supplied (e.g. a float HealPct requested as 0.35 stayed 0).
+    if (DefaultVal.IsValid() && DefaultVal->Type != EJson::Null) {
+      FString DefaultStr;
+      switch (DefaultVal->Type) {
+      case EJson::Boolean:
+        DefaultStr = DefaultVal->AsBool() ? TEXT("true") : TEXT("false");
+        break;
+      case EJson::Number: {
+        const double Num = DefaultVal->AsNumber();
+        const bool bIsIntLike =
+            PinType.PinCategory == MCP_PC_Int ||
+            PinType.PinCategory == UEdGraphSchema_K2::PC_Byte;
+        if (bIsIntLike && FMath::Frac(Num) == 0.0) {
+          DefaultStr = FString::Printf(TEXT("%lld"), static_cast<int64>(Num));
+        } else {
+          DefaultStr = FString::SanitizeFloat(Num);
+        }
+        break;
+      }
+      case EJson::String:
+        DefaultStr = DefaultVal->AsString();
+        break;
+      default:
+        DefaultVal->TryGetString(DefaultStr);
+        break;
+      }
+      NewVar.DefaultValue = DefaultStr;
+    }
+
     Blueprint->NewVariables.Add(NewVar);
     FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
     McpSafeCompileBlueprint(Blueprint);


### PR DESCRIPTION
## Summary
`add_variable` read the `defaultValue` payload field but never applied it, so every Blueprint variable was created with a zero/empty default regardless of the value supplied (e.g. a float requested as 0.35 stayed 0).

## Changes
- Apply the parsed `defaultValue` to `FBPVariableDescription::DefaultValue` in `HandleBlueprintAddVariable`, with type-aware formatting: bool → lowercase true/false, int/byte → whole number, float/double → SanitizeFloat, string/struct → passthrough.
- Added a `Fixed` entry under `[Unreleased]` in CHANGELOG.md.

## Related Issues
<!-- leave blank or link one if it exists -->

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing
- [x] Tested with Unreal Engine (version: 5.5)
- [ ] Tested MCP client integration
- [ ] Added/updated tests

## Pre-Merge Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Updated relevant documentation
- [ ] Added/updated tests 
- [ ] CI passes