### PR TITLE
fix: connect_pins reports auto-inserted conversion nodes

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersPinMutations.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersPinMutations.cpp
@@ -96,6 +96,21 @@ static bool ConnectPins(FActionContext& Context)
         return true;
     }
 
+    // Snapshot node GUIDs so we can detect an auto-inserted conversion node.
+    // When the pin types differ but an autocast exists, the schema silently
+    // spawns a conversion node (e.g. real->int Truncate) inside
+    // TryCreateConnection and still returns true. Surfacing it stops the caller
+    // from unknowingly accepting a precision/semantic change.
+    TSet<FGuid> NodeGuidsBefore;
+    NodeGuidsBefore.Reserve(Context.TargetGraph->Nodes.Num());
+    for (UEdGraphNode* ExistingNode : Context.TargetGraph->Nodes)
+    {
+        if (ExistingNode)
+        {
+            NodeGuidsBefore.Add(ExistingNode->NodeGuid);
+        }
+    }
+
     if (!Context.TargetGraph->GetSchema()->TryCreateConnection(
             FromPin,
             ToPin))
@@ -106,11 +121,38 @@ static bool ConnectPins(FActionContext& Context)
         return true;
     }
 
+    // A node present now but not before == the auto-inserted conversion node.
+    UEdGraphNode* ConversionNode = nullptr;
+    for (UEdGraphNode* MaybeNew : Context.TargetGraph->Nodes)
+    {
+        if (MaybeNew && !NodeGuidsBefore.Contains(MaybeNew->NodeGuid))
+        {
+            ConversionNode = MaybeNew;
+            break;
+        }
+    }
+
     FBlueprintEditorUtils::MarkBlueprintAsModified(Context.Blueprint);
     SaveLoadedAssetThrottled(Context.Blueprint);
     TSharedPtr<FJsonObject> Result = McpHandlerUtils::CreateResultObject();
+    if (ConversionNode)
+    {
+        Result->SetBoolField(TEXT("conversionInserted"), true);
+        Result->SetStringField(
+            TEXT("conversionNodeId"), ConversionNode->NodeGuid.ToString());
+        Result->SetStringField(
+            TEXT("conversionNodeTitle"),
+            ConversionNode->GetNodeTitle(ENodeTitleType::ListView).ToString());
+        Result->SetStringField(
+            TEXT("note"),
+            TEXT("Pin types differed; an automatic conversion node was inserted "
+                 "between the pins (possible precision/semantic change)."));
+    }
     McpHandlerUtils::AddVerification(Result, Context.Blueprint);
-    Context.SendResponse(TEXT("Pins connected."), Result);
+    Context.SendResponse(
+        ConversionNode ? TEXT("Pins connected (conversion node inserted).")
+                       : TEXT("Pins connected."),
+        Result);
     return true;
 }
 


### PR DESCRIPTION
## Summary

`manage_blueprint` `connect_pins` reported `"Pins connected."` even when the pin
types differed and the schema **silently inserted an automatic conversion node**
(e.g. a `Truncate` for a real→int link). The caller had no way to know a
precision/semantic-changing cast had been added.

## Changes

- In the `connect_pins` handler, snapshot the graph's node GUIDs before
  `TryCreateConnection`; after a successful connect, any node now present that
  wasn't before is the auto-inserted conversion node.
- Surface it in the response: `conversionInserted: true`, `conversionNodeId`,
  `conversionNodeTitle` (e.g. `"Truncate"`), plus a short note. The success
  message becomes `"Pins connected (conversion node inserted)."`.
- Same-type connections are unchanged — no new fields, message unchanged.

## Related Issues

_(standalone)_

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Tested with Unreal Engine (version: 5.8)
- [x] Tested MCP client integration (client: MCP automation bridge)

`real`-output → `int`-input connect → `success:true` + `conversionInserted:true,
conversionNodeTitle:"Truncate"` and a new Truncate node appears in the graph.
`int`-output → `int`-input connect → clean `"Pins connected."`, no extra fields.

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [ ] Updated relevant documentation (changelog is auto-drafted by release-drafter from the PR title)
- [x] CI passes
