### PR TITLE
fix: add_event honors posX/posY and stops duplicating custom-event pins

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Blueprint/Events/McpAutomationBridge_BlueprintHandlersAddEvent.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Blueprint/Events/McpAutomationBridge_BlueprintHandlersAddEvent.cpp
@@ -100,17 +100,34 @@ bool HandleBlueprintAddEvent(const FBlueprintActionContext &Context) {
       return true;
     }
 
-    // Extract parameters from payload
-    int32 EventPosX = 0;
-    int32 EventPosY = 0;
-    if (const TSharedPtr<FJsonObject> *LocObj = nullptr;
-        Payload->TryGetObjectField(TEXT("location"), LocObj)) {
-      EventPosX = (*LocObj)->GetIntegerField(TEXT("x"));
-      EventPosY = (*LocObj)->GetIntegerField(TEXT("y"));
-    } else {
-      EventPosX = Payload->GetIntegerField(TEXT("x"));
-      EventPosY = Payload->GetIntegerField(TEXT("y"));
+    // Read node position. posX/posY are the canonical schema params; fall back
+    // to location.{x,y} then top-level x/y for raw/legacy callers. The old
+    // GetIntegerField path returned 0 on absent keys, so every event piled at
+    // (0,0). posX/posY take precedence.
+    double PX = 0.0;
+    double PY = 0.0;
+    bool bHasX = Payload->TryGetNumberField(TEXT("posX"), PX);
+    bool bHasY = Payload->TryGetNumberField(TEXT("posY"), PY);
+    if (!bHasX || !bHasY) {
+      const TSharedPtr<FJsonObject> *LocObj = nullptr;
+      if (Payload->TryGetObjectField(TEXT("location"), LocObj) && LocObj &&
+          LocObj->IsValid()) {
+        if (!bHasX) {
+          bHasX = (*LocObj)->TryGetNumberField(TEXT("x"), PX);
+        }
+        if (!bHasY) {
+          bHasY = (*LocObj)->TryGetNumberField(TEXT("y"), PY);
+        }
+      }
     }
+    if (!bHasX) {
+      Payload->TryGetNumberField(TEXT("x"), PX);
+    }
+    if (!bHasY) {
+      Payload->TryGetNumberField(TEXT("y"), PY);
+    }
+    const int32 EventPosX = static_cast<int32>(PX);
+    const int32 EventPosY = static_cast<int32>(PY);
 
     const FString FinalType = EventType.IsEmpty() ? TEXT("custom") : EventType;
     const bool bIsCustomEvent =
@@ -143,8 +160,11 @@ bool HandleBlueprintAddEvent(const FBlueprintActionContext &Context) {
         CustomEventNode->CustomFunctionName = EventName;
         CustomEventNode->NodePosX = EventPosX;
         CustomEventNode->NodePosY = EventPosY;
+        // FGraphNodeCreator::Finalize() already allocates the node's default pins
+        // (OutputDelegate + then). Calling AllocateDefaultPins() again duplicated
+        // them — the custom event ended up with two OutputDelegate/then pins.
+        // Finalize is enough.
         NodeCreator.Finalize();
-        CustomEventNode->AllocateDefaultPins();
       } else {
         CustomEventNode->NodePosX = EventPosX;
         CustomEventNode->NodePosY = EventPosY;

--- a/src/tools/handlers/blueprint/blueprint-event-actions.ts
+++ b/src/tools/handlers/blueprint/blueprint-event-actions.ts
@@ -5,6 +5,7 @@ import {
   commonTimingPayload,
   executeBlueprintRequest,
   firstString,
+  optionalNumber,
   optionalString
 } from './blueprint-action-context.js';
 import type { BlueprintActionContext, BlueprintActionHandler } from './blueprint-action-context.js';
@@ -36,6 +37,10 @@ async function handleAddEvent(context: BlueprintActionContext): Promise<Record<s
     eventType: context.argsTyped.eventType ?? 'Custom',
     customEventName: optionalString(context.argsRecord.customEventName) || (!usedNameForBlueprint ? context.argsTyped.name : undefined),
     parameters: context.argsRecord.parameters,
+    posX: optionalNumber(context.argsRecord.posX),
+    posY: optionalNumber(context.argsRecord.posY),
+    x: optionalNumber(context.argsRecord.x),
+    y: optionalNumber(context.argsRecord.y),
     ...commonTimingPayload(context)
   });
 


### PR DESCRIPTION
## Summary

Two `add_event` fixes in one handler:

- **Position ignored** — `add_event` placed every event at `(0,0)`. The C++
  handler read `location`/`x`/`y` (via `GetIntegerField`, →0 when absent) but not
  the canonical `posX`/`posY`, and the TypeScript layer never forwarded any
  position at all.
- **Duplicate custom-event pins** — creating a custom event called
  `FGraphNodeCreator::Finalize()` (which already allocates the node's default
  pins) and then `AllocateDefaultPins()` again, so the event ended up with two
  `OutputDelegate` and two `then` output pins.

## Changes

- TS `handleAddEvent` now forwards `posX`/`posY` (and `x`/`y`).
- C++ reads `posX`/`posY` first (then `location.{x,y}`, then `x`/`y`) via
  `TryGetNumberField`, for both the custom-event and override-event node.
- Removed the redundant `AllocateDefaultPins()` after `Finalize()` in the
  custom-event creation path.

## Related Issues

_(standalone)_

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Tested with Unreal Engine (version: 5.8)
- [x] Tested MCP client integration (client: MCP automation bridge)

`add_event customEventName:E posX:300 posY:400` → event node created at
`(300,400)` (was `(0,0)`), and the node has exactly one `OutputDelegate` + one
`then` pin (was two of each).

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [ ] Updated relevant documentation (changelog is auto-drafted by release-drafter from the PR title)
- [x] CI passes
