### PR TITLE
feat: UE 5.8 plugin fixes (validate_niagara_system, transactional spawn, ListenPorts warning, MCP_NATIVE_PORT env)

### DIFF
--- a/plugins/McpAutomationBridge/CHANGELOG.md
+++ b/plugins/McpAutomationBridge/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to the MCP Automation Bridge plugin will be documented in th
 
 ---
 
+## [Unreleased]
+
+### Added
+- **`MCP_NATIVE_PORT` environment variable** — overrides the native MCP HTTP/SSE port (`NativeMCPPort`) at startup without editing committed ini, so a project can run several editors at once on distinct ports. Mirrors the existing `MCP_MAX_*` env overrides; falls back to the `Native MCP Port` project setting when unset or invalid.
+
+### Fixed
+- **UE 5.8 build** — use `FJsonObject::HasField()` instead of `Values.Contains(FString)` in the render console handler (`FJsonObject::Values`' key type changed to `UE::TSharedString<TCHAR>` in 5.8).
+- **`validate_niagara_system` now reports real errors** — previously hard-coded `isValid=true`; it now builds a full Niagara system view model and harvests stack issues (e.g. "The module has unmet dependencies.") across the system and emitter stacks. A data-processing-only view model can't be used because `UNiagaraStackModuleItem::RefreshIssues()` emits no per-module issues in that mode.
+- **`ListenPorts` drop warning** — when multi-listen is on and a partial `ListenPorts` override omits a default bridge port (8090/8091), a warning is logged instead of the drop being silent (the user's ports stay authoritative).
+
+### Changed
+- **`control_actor` spawn is now transactional** — a requested `meshPath` that can't be applied no longer leaves a misconfigured actor in the level: it fails `MESH_NOT_FOUND` before spawning if the mesh can't load, or rolls back (`Destroy()` + `MESH_APPLY_FAILED`) if a resolved mesh can't be applied to the spawned actor.
+  - **Potentially breaking:** a request that passed a `meshPath` which failed to resolve previously still produced a spawned actor and a success response; it now returns a `MESH_NOT_FOUND` error and spawns nothing.
+
+---
+
 ## [0.5.30] - 2026-06-05
 
 ### Security

--- a/plugins/McpAutomationBridge/README.md
+++ b/plugins/McpAutomationBridge/README.md
@@ -198,6 +198,7 @@ Tools & Plugins
 | `UE_PROJECT_PATH` | - | Path to your `.uproject` file |
 | `MCP_AUTOMATION_HOST` | `127.0.0.1` | Bridge host address |
 | `MCP_AUTOMATION_PORT` | `8091` | Bridge WebSocket port |
+| `MCP_NATIVE_PORT` | (`Native MCP Port` setting) | Overrides the native MCP HTTP/SSE port at startup without editing ini — pick a per-editor port (e.g. to run several editors at once). Falls back to the project setting when unset/invalid. |
 | `LOG_LEVEL` | `info` | Logging level (debug/info/warn/error) |
 
 ### Plugin Settings
@@ -208,7 +209,7 @@ Configure in **Edit → Project Settings → Plugins → MCP Automation Bridge**
 - **Enable TLS**: Enable secure WebSocket connections
 - **Allow Non-Loopback**: Enable LAN access (security consideration)
 - **Enable Native MCP**: Enable built-in HTTP/SSE MCP server (default: off)
-- **Native MCP Port**: HTTP port for native MCP transport (default: 3000)
+- **Native MCP Port**: HTTP port for native MCP transport (default: 3000; override at startup with the `MCP_NATIVE_PORT` environment variable)
 - **Listen Host**: Bind address (default: 127.0.0.1)
 - **Load All Tools on Start**: Load all 23 canonical tools at startup (default: on)
 - **Native MCP Instructions**: Custom instructions for AI clients

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Core/Subsystem/McpAutomationBridgeSubsystemLifecycle.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Core/Subsystem/McpAutomationBridgeSubsystemLifecycle.cpp
@@ -163,9 +163,40 @@ void UMcpAutomationBridgeSubsystem::StartNativeTransport()
         PluginDir = Plugin->GetBaseDir();
     }
 
+    // Allow an environment-variable override of the native MCP port, mirroring the
+    // plugin's existing MCP_MAX_* env overrides. This lets a project select a per-
+    // instance port (e.g. to run several editors at once on distinct ports) without
+    // editing committed ini — set MCP_NATIVE_PORT in the editor's environment. Falls
+    // back to the NativeMCPPort project setting when the var is unset or invalid.
+    int32 NativePort = Settings->NativeMCPPort;
+    const FString EnvNativePort = FPlatformMisc::GetEnvironmentVariable(TEXT("MCP_NATIVE_PORT"));
+    if (!EnvNativePort.IsEmpty())
+    {
+        int32 ParsedNativePort = 0;
+        if (LexTryParseString(ParsedNativePort, *EnvNativePort) && ParsedNativePort > 0 && ParsedNativePort <= 65535)
+        {
+            NativePort = ParsedNativePort;
+            UE_LOG(
+                LogMcpAutomationBridgeSubsystem,
+                Log,
+                TEXT("Native MCP port overridden by env MCP_NATIVE_PORT=%d (project setting NativeMCPPort=%d)"),
+                NativePort,
+                Settings->NativeMCPPort);
+        }
+        else
+        {
+            UE_LOG(
+                LogMcpAutomationBridgeSubsystem,
+                Warning,
+                TEXT("Ignoring invalid MCP_NATIVE_PORT='%s' (expected an integer 1-65535); using NativeMCPPort=%d"),
+                *EnvNativePort,
+                Settings->NativeMCPPort);
+        }
+    }
+
     NativeTransport = MakeShared<FMcpNativeTransport>(this);
     if (NativeTransport->Start(
-            Settings->NativeMCPPort,
+            NativePort,
             PluginDir,
             Settings->bLoadAllToolsOnStart,
             Settings->NativeMCPInstructions,
@@ -179,6 +210,6 @@ void UMcpAutomationBridgeSubsystem::StartNativeTransport()
         LogMcpAutomationBridgeSubsystem,
         Error,
         TEXT("Failed to start Native MCP server on port %d"),
-        Settings->NativeMCPPort);
+        NativePort);
     NativeTransport.Reset();
 }

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/ControlActor/McpAutomationBridge_ControlActorSpawn.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/ControlActor/McpAutomationBridge_ControlActorSpawn.cpp
@@ -55,6 +55,18 @@ bool UMcpAutomationBridgeSubsystem::HandleControlActorSpawn(
     }
   }
 
+  // If the caller explicitly asked for a mesh but it could not be resolved to a
+  // static/skeletal mesh, fail BEFORE spawning anything. Otherwise we'd create an
+  // actor we can't configure as requested and report it as a (misleading) success.
+  if (!MeshPath.IsEmpty() && !ResolvedStaticMesh && !ResolvedSkeletalMesh) {
+    SendStandardErrorResponse(
+        this, Socket, RequestId, TEXT("MESH_NOT_FOUND"),
+        FString::Printf(TEXT("Requested mesh could not be loaded as a static or "
+                             "skeletal mesh: %s"),
+                        *MeshPath));
+    return true;
+  }
+
   // Force StaticMeshActor if we have a resolved mesh, regardless of class input
   // (unless it's a specific subclass)
   bool bSpawnStaticMeshActor = (ResolvedStaticMesh != nullptr);
@@ -123,40 +135,67 @@ bool UMcpAutomationBridgeSubsystem::HandleControlActorSpawn(
   Spawned = TargetWorld->SpawnActor(ClassToSpawn, &Location, &Rotation,
                                     SpawnParams);
 
-  if (Spawned) {
-    Spawned->Modify();
-    Spawned->SetActorLocationAndRotation(Location, Rotation, false, nullptr,
-                                         ETeleportType::TeleportPhysics);
-    if (bSpawnStaticMeshActor) {
-      if (AStaticMeshActor *StaticMeshActor = Cast<AStaticMeshActor>(Spawned)) {
-        if (UStaticMeshComponent *MeshComponent =
-                StaticMeshActor->GetStaticMeshComponent()) {
-          if (ResolvedStaticMesh) {
-            MeshComponent->SetStaticMesh(ResolvedStaticMesh);
-          }
-          MeshComponent->SetMobility(EComponentMobility::Movable);
-          MeshComponent->MarkRenderStateDirty();
-        }
-      }
-    } else if (bSpawnSkeletalMeshActor) {
-      if (ASkeletalMeshActor *SkelActor = Cast<ASkeletalMeshActor>(Spawned)) {
-        if (USkeletalMeshComponent *SkelComp =
-                SkelActor->GetSkeletalMeshComponent()) {
-          if (ResolvedSkeletalMesh) {
-            SkelComp->SetSkeletalMesh(ResolvedSkeletalMesh);
-          }
-          SkelComp->SetMobility(EComponentMobility::Movable);
-          SkelComp->MarkRenderStateDirty();
-        }
-      }
-    }
-  }
-
-  if (!Spawned) {
+  if (!IsValid(Spawned)) {
+    // SpawnActor returned null / an invalid object — nothing was added to the
+    // world, so there is nothing to roll back.
     SendStandardErrorResponse(this, Socket, RequestId, TEXT("SPAWN_FAILED"),
                               TEXT("Failed to spawn actor"));
-
     return true;
+  }
+
+  // Transactional rollback: if a required post-spawn step fails, destroy the actor
+  // we just created so a failed request leaves the world unchanged rather than
+  // leaking a half-configured actor into the level (mirrors the spline handlers,
+  // which Destroy() the new actor when component setup fails).
+  auto RollbackSpawn = [&Spawned]() {
+    if (IsValid(Spawned)) {
+      Spawned->Destroy();
+    }
+    Spawned = nullptr;
+  };
+
+  Spawned->Modify();
+  Spawned->SetActorLocationAndRotation(Location, Rotation, false, nullptr,
+                                       ETeleportType::TeleportPhysics);
+  if (bSpawnStaticMeshActor) {
+    AStaticMeshActor *StaticMeshActor = Cast<AStaticMeshActor>(Spawned);
+    UStaticMeshComponent *MeshComponent =
+        StaticMeshActor ? StaticMeshActor->GetStaticMeshComponent() : nullptr;
+    if (ResolvedStaticMesh && !MeshComponent) {
+      // A mesh was explicitly resolved but the spawned actor can't hold it.
+      RollbackSpawn();
+      SendStandardErrorResponse(
+          this, Socket, RequestId, TEXT("MESH_APPLY_FAILED"),
+          TEXT("Could not apply the requested static mesh: the spawned actor has "
+               "no static mesh component."));
+      return true;
+    }
+    if (MeshComponent) {
+      if (ResolvedStaticMesh) {
+        MeshComponent->SetStaticMesh(ResolvedStaticMesh);
+      }
+      MeshComponent->SetMobility(EComponentMobility::Movable);
+      MeshComponent->MarkRenderStateDirty();
+    }
+  } else if (bSpawnSkeletalMeshActor) {
+    ASkeletalMeshActor *SkelActor = Cast<ASkeletalMeshActor>(Spawned);
+    USkeletalMeshComponent *SkelComp =
+        SkelActor ? SkelActor->GetSkeletalMeshComponent() : nullptr;
+    if (ResolvedSkeletalMesh && !SkelComp) {
+      RollbackSpawn();
+      SendStandardErrorResponse(
+          this, Socket, RequestId, TEXT("MESH_APPLY_FAILED"),
+          TEXT("Could not apply the requested skeletal mesh: the spawned actor "
+               "has no skeletal mesh component."));
+      return true;
+    }
+    if (SkelComp) {
+      if (ResolvedSkeletalMesh) {
+        SkelComp->SetSkeletalMesh(ResolvedSkeletalMesh);
+      }
+      SkelComp->SetMobility(EComponentMobility::Movable);
+      SkelComp->MarkRenderStateDirty();
+    }
   }
 
   if (bHasScale) {

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/NiagaraAuthoring/McpAutomationBridge_NiagaraAuthoringHandlersInfoValidation.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/NiagaraAuthoring/McpAutomationBridge_NiagaraAuthoringHandlersInfoValidation.cpp
@@ -1,6 +1,13 @@
 #include "Domains/NiagaraAuthoring/McpAutomationBridge_NiagaraAuthoringHandlersContext.h"
 
 #if WITH_EDITOR
+#include "ViewModels/NiagaraSystemViewModel.h"
+#include "ViewModels/NiagaraEmitterHandleViewModel.h"
+#include "ViewModels/Stack/NiagaraStackViewModel.h"
+#include "ViewModels/Stack/NiagaraStackEntry.h"
+#endif
+
+#if WITH_EDITOR
 namespace McpNiagaraAuthoringHandlers
 {
 static void AddSystemInfo(TSharedPtr<FJsonObject>& InfoObj, UNiagaraSystem* System)
@@ -83,6 +90,35 @@ static bool GetNiagaraInfo(FActionContext& Context)
     return true;
 }
 
+// Recursively collect Error/Warning issues from a Niagara stack-entry tree. These are the same
+// issues the Niagara editor surfaces in the stack panel (unmet module dependencies, deprecated
+// modules, compile failures), so harvesting them is the authoritative "is this system broken?".
+static void CollectStackIssues(UNiagaraStackEntry* Entry, TArray<TSharedPtr<FJsonValue>>& Errors, TArray<TSharedPtr<FJsonValue>>& Warnings)
+{
+    if (!Entry)
+    {
+        return;
+    }
+    for (const UNiagaraStackEntry::FStackIssue& Issue : Entry->GetIssues())
+    {
+        const FString Message = Issue.GetShortDescription().ToString();
+        if (Issue.GetSeverity() == EStackIssueSeverity::Error)
+        {
+            Errors.Add(MakeShared<FJsonValueString>(Message));
+        }
+        else if (Issue.GetSeverity() == EStackIssueSeverity::Warning)
+        {
+            Warnings.Add(MakeShared<FJsonValueString>(Message));
+        }
+    }
+    TArray<UNiagaraStackEntry*> Children;
+    Entry->GetUnfilteredChildren(Children);
+    for (UNiagaraStackEntry* Child : Children)
+    {
+        CollectStackIssues(Child, Errors, Warnings);
+    }
+}
+
 static bool ValidateNiagaraSystem(FActionContext& Context)
 {
     if (Context.SystemPath.IsEmpty())
@@ -100,9 +136,12 @@ static bool ValidateNiagaraSystem(FActionContext& Context)
     {
         return true;
     }
+
     TSharedPtr<FJsonObject> ValidationResult = McpHandlerUtils::CreateResultObject();
     TArray<TSharedPtr<FJsonValue>> ErrorsArray;
     TArray<TSharedPtr<FJsonValue>> WarningsArray;
+
+    // Cheap structural warnings, independent of the stack.
     if (System->GetEmitterHandles().Num() == 0)
     {
         WarningsArray.Add(MakeShared<FJsonValueString>(TEXT("System has no emitters.")));
@@ -113,21 +152,71 @@ static bool ValidateNiagaraSystem(FActionContext& Context)
         {
             WarningsArray.Add(MakeShared<FJsonValueString>(FString::Printf(TEXT("Emitter '%s' is disabled."), *Handle.GetName().ToString())));
         }
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
-        MCP_NIAGARA_EMITTER_DATA_TYPE* EmitterData = Handle.GetEmitterData();
-#else
-        MCP_NIAGARA_EMITTER_DATA_TYPE* EmitterData = Handle.GetInstance();
-#endif
-        if (EmitterData && EmitterData->GetRenderers().Num() == 0)
-        {
-            WarningsArray.Add(MakeShared<FJsonValueString>(FString::Printf(TEXT("Emitter '%s' has no renderers."), *Handle.GetName().ToString())));
-        }
     }
-    ValidationResult->SetBoolField(TEXT("isValid"), true);
+
+    // The real validation: harvest the stack issues that the Niagara editor itself computes.
+    // The previous implementation hard-coded isValid=true; an earlier attempt that inspected each
+    // script's ENiagaraScriptCompileStatus missed the common failures ("unmet dependencies",
+    // deprecated modules) because those are *stack issues*, not VM compile-status errors.
+    //
+    // We build a throwaway view model in FULL (non-data-processing) mode and let it refresh the
+    // system + emitter stacks, then collect every Error/Warning stack issue. Full mode is REQUIRED:
+    // UNiagaraStackModuleItem::RefreshIssues() early-outs to an empty issue list whenever the owning
+    // system view model GetIsForDataProcessingOnly() is true (NiagaraStackModuleItem.cpp ~L967), so a
+    // data-processing-only VM can never surface per-module errors — including the dependency check
+    // that produces "The module has unmet dependencies." We keep the heavy bits off: bCanSimulate is
+    // false (so SetupPreviewComponentAndInstance() creates no preview UNiagaraComponent) and
+    // bCanAutoCompile/bCompileForEdit are false. SetupSequencer() still runs but only builds a
+    // detached transient Sequencer (the same construction the Niagara asset editor performs).
+    //
+    // We can't reuse an already-open editor's view model: TNiagaraViewModelManager's lookup
+    // references a static member not exported to other modules, and FNiagaraSystemToolkit lives in
+    // NiagaraEditor/Private. So we always spin our own VM. We deliberately do NOT call the unexported
+    // Cleanup(); letting the shared pointer drop runs ~FNiagaraSystemViewModel -> Cleanup() for us.
+    TSharedRef<FNiagaraSystemViewModel> SystemViewModel = MakeShared<FNiagaraSystemViewModel>();
+    {
+        FNiagaraSystemViewModelOptions Options;
+        Options.bCanAutoCompile = false;
+        Options.bCanModifyEmittersFromTimeline = false;
+        Options.bCanSimulate = false;
+        Options.bCompileForEdit = false;
+        Options.bIsForDataProcessingOnly = false;
+        Options.EditMode = ENiagaraSystemViewModelEditMode::SystemAsset;
+        // Initialize() -> RefreshAll() subscribes to the Niagara message manager keyed by this GUID;
+        // it asserts on an empty key (NiagaraMessageManager.cpp: "Tried to subscribe to an asset
+        // without a set asset key"). A throwaway unique key is fine — we never route messages, and the
+        // view model's destructor (~FNiagaraSystemViewModel -> Cleanup()) tears the subscription down.
+        Options.MessageLogGuid = FGuid::NewGuid();
+        SystemViewModel->Initialize(*System, Options);
+    }
+
+    // Initialize() already RefreshAll()'d the stacks, but harvest defensively by refreshing each
+    // root's children before walking it, so the per-module issues (the dependency check included)
+    // are guaranteed current.
+    auto RefreshAndCollect = [&ErrorsArray, &WarningsArray](UNiagaraStackViewModel* Stack)
+    {
+        if (!Stack)
+        {
+            return;
+        }
+        if (UNiagaraStackEntry* Root = Stack->GetRootEntry())
+        {
+            Root->RefreshChildren();
+            CollectStackIssues(Root, ErrorsArray, WarningsArray);
+        }
+    };
+    RefreshAndCollect(SystemViewModel->GetSystemStackViewModel());
+    for (const TSharedRef<FNiagaraEmitterHandleViewModel>& EmitterHandleViewModel : SystemViewModel->GetEmitterHandleViewModels())
+    {
+        RefreshAndCollect(EmitterHandleViewModel->GetEmitterStackViewModel());
+    }
+
+    const bool bIsValid = ErrorsArray.Num() == 0;
+    ValidationResult->SetBoolField(TEXT("isValid"), bIsValid);
     ValidationResult->SetArrayField(TEXT("errors"), ErrorsArray);
     ValidationResult->SetArrayField(TEXT("warnings"), WarningsArray);
     Context.Result->SetObjectField(TEXT("validationResult"), ValidationResult);
-    Context.Result->SetStringField(TEXT("message"), TEXT("System is valid."));
+    Context.Result->SetStringField(TEXT("message"), bIsValid ? TEXT("System is valid.") : TEXT("System has errors."));
     Context.SendSuccess(true, TEXT("Validation complete."));
     return true;
 }

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Render/McpAutomationBridge_RenderConsole.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Render/McpAutomationBridge_RenderConsole.cpp
@@ -40,7 +40,9 @@ bool ReadBoundedNumberSetting(
 {
     OutSetting.bPresent = false;
     OutSetting.Value = 0.0;
-    if (!Settings.IsValid() || !Settings->Values.Contains(Field))
+    // UE 5.8 changed FJsonObject::Values' key type to UE::TSharedString<TCHAR>, so an FString no
+    // longer implicitly converts in Contains(); use the public HasField() accessor instead.
+    if (!Settings.IsValid() || !Settings->HasField(Field))
     {
         return true;
     }

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Transport/Connection/McpConnectionManager.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Transport/Connection/McpConnectionManager.cpp
@@ -31,6 +31,43 @@ void FMcpConnectionManager::Initialize(
       TlsCertificatePath = Settings->TlsCertificatePath;
     if (!Settings->TlsPrivateKeyPath.IsEmpty())
       TlsPrivateKeyPath = Settings->TlsPrivateKeyPath;
+
+    // ListenPorts is a single comma-separated FString, so a partial ini override
+    // (e.g. ListenPorts=9000) REPLACES the "8090,8091" default wholesale rather than
+    // adding to it (UE config semantics). When multi-listen is on, that can silently
+    // drop a default bridge port the TypeScript bridge / external MCP clients expect
+    // to connect on. We keep the user's ports authoritative (no surprise extra binds)
+    // but warn loudly so an accidental drop is visible instead of a mystery no-connect.
+    if (Settings->bMultiListen && !Settings->ListenPorts.IsEmpty()) {
+      TArray<FString> ConfiguredTokens;
+      Settings->ListenPorts.ParseIntoArray(ConfiguredTokens, TEXT(","), true);
+      TSet<int32> ConfiguredPorts;
+      for (const FString &Token : ConfiguredTokens) {
+        int32 ParsedPort = 0;
+        if (LexTryParseString(ParsedPort, *Token.TrimStartAndEnd()) &&
+            ParsedPort > 0 && ParsedPort <= 65535)
+          ConfiguredPorts.Add(ParsedPort);
+      }
+      // Mirrors the ListenPorts default in UMcpAutomationBridgeSettings' constructor.
+      static const int32 DefaultBridgePorts[] = {8090, 8091};
+      FString MissingDefaults;
+      for (int32 DefaultPort : DefaultBridgePorts) {
+        if (!ConfiguredPorts.Contains(DefaultPort)) {
+          if (!MissingDefaults.IsEmpty())
+            MissingDefaults += TEXT(",");
+          MissingDefaults += FString::FromInt(DefaultPort);
+        }
+      }
+      if (ConfiguredPorts.Num() > 0 && !MissingDefaults.IsEmpty()) {
+        UE_LOG(LogMcpAutomationBridgeSubsystem, Warning,
+               TEXT("ListenPorts=\"%s\" does not include the default bridge port(s) "
+                    "%s. A partial ListenPorts override replaces the \"8090,8091\" "
+                    "default entirely, so MCP clients or the TypeScript bridge "
+                    "expecting %s will not be able to connect. Add them to "
+                    "ListenPorts if this was unintended."),
+               *Settings->ListenPorts, *MissingDefaults, *MissingDefaults);
+      }
+    }
   }
 
   // Allow environment variable overrides for rate limiting (useful for tests)


### PR DESCRIPTION
Hello! I'm working in Unreal 5.8 and I've been using your Unreal MCP plugin. I wanted to contribute some fixes I've done for it to be less error prone. I'm not a UE developer and these were done by Claude Opus on xHigh. I've vetted the work as best I can and the decisions made. I hope this is useful!
---
Five small, **independent** fixes for the McpAutomationBridge plugin on UE 5.8 — each is its own commit, so feel free to take any subset. All were built and HTTP-verified in an isolated UE 5.8 C++ project.

### 1. Build on UE 5.8 (`FJsonObject::Values` key type)
UE 5.8 changed `FJsonObject::Values`' key type to `UE::TSharedString<TCHAR>`, so `Settings->Values.Contains(Field)` (FString) no longer compiles in the Render console handler. Switched to the public `HasField()` accessor — the only 5.8 compile break in the plugin.

### 2. `validate_niagara_system` detects real errors
Previously hard-coded `isValid=true` with only soft structural warnings. Now builds a full Niagara system view model and harvests `UNiagaraStackEntry::GetIssues()` (Error/Warning) across the system + emitter stacks — the same issues the editor shows, including "The module has unmet dependencies." A data-processing-only VM can't be used (`UNiagaraStackModuleItem::RefreshIssues()` returns nothing there). Kept lightweight: `bCanSimulate=false` (no preview component), compile off; `SetupSequencer` only builds a detached transient Sequencer.
Verified: deleted Emitter State module → `isValid:false` + unmet-dependency error; clean system → `isValid:true`.

### 3. `control_actor` spawn is transactional
A requested mesh that couldn't be applied used to still report success, leaving a misconfigured actor in the level. Now: `MESH_NOT_FOUND` before spawning if an explicit `meshPath` can't load; and rollback (`Destroy()` + `MESH_APPLY_FAILED`) if a resolved mesh can't be applied. A failed request leaves the world unchanged.

### 4. Warn when `ListenPorts` drops a default bridge port
A partial `ListenPorts` override replaces the `8090,8091` default wholesale (UE config semantics), silently dropping a port clients expect. Keeps the user's ports authoritative but logs a clear warning (multi-listen) when a default is missing.

### 5. `MCP_NATIVE_PORT` env override
Pick the native MCP port via env without editing committed ini — handy for running several editors at once on distinct ports. Mirrors the existing `MCP_MAX_*` env overrides; additive and non-breaking, falls back to the `NativeMCPPort` setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)