### PR TITLE
fix(material): TextureSample named output pins, set_scalar value coercion, folder existsAfter

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/AssetWorkflow/Operations/McpAutomationBridge_AssetWorkflowFolderCreation.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/AssetWorkflow/Operations/McpAutomationBridge_AssetWorkflowFolderCreation.cpp
@@ -8,6 +8,7 @@
 
 #if WITH_EDITOR
 #include "EditorAssetLibrary.h"
+#include "Foundation/BridgeHelpers/Assets/McpAutomationBridgeHelpersAssetDirectories.h"
 #endif
 
 bool UMcpAutomationBridgeSubsystem::HandleCreateFolder(
@@ -40,8 +41,13 @@ bool UMcpAutomationBridgeSubsystem::HandleCreateFolder(
     TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
     Resp->SetBoolField(TEXT("success"), true);
     Resp->SetStringField(TEXT("path"), SafePath);
-    // Add verification data
-    VerifyAssetExists(Resp, SafePath);
+    // A folder is a directory, not an asset object — VerifyAssetExists looks for a .uasset
+    // and so always reported existsAfter:false for a freshly created folder. Report the
+    // actual directory existence via the on-disk check (asset-registry directory entries can
+    // be stale; this mirrors the codebase's DoesAssetDirectoryExistOnDisk convention). Empty
+    // folders may still not persist across an editor restart until an asset is added, but the
+    // in-session readback is now truthful.
+    Resp->SetBoolField(TEXT("existsAfter"), DoesAssetDirectoryExistOnDisk(SafePath));
     SendAutomationResponse(Socket, RequestId, true, TEXT("Folder created"),
                            Resp, FString());
   } else {

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/MaterialAuthoring/Connections/McpAutomationBridge_MaterialAuthoringHandlersConnectNodes.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/MaterialAuthoring/Connections/McpAutomationBridge_MaterialAuthoringHandlersConnectNodes.cpp
@@ -57,6 +57,30 @@ bool HandleConnectNodes(UMcpAutomationBridgeSubsystem* Bridge, const FString& Re
                               TEXT("INVALID_PIN"));
           return true;
         }
+      } else if (SourceExpr->IsA<UMaterialExpressionTextureSample>()) {
+        // TextureSample / TextureSampleParameter2D expose named output pins but only numeric
+        // indices were accepted before. Map names to the engine's fixed output order (see
+        // UMaterialExpressionTextureSample output construction): RGB=0, R=1, G=2, B=3, A=4, RGBA=5.
+        // NOTE: RGB (index 0) is the 3-channel color (alpha bit off); RGBA (index 5) carries the
+        // full 4 channels — they are NOT the same pin, so RGBA must map to 5, not 0.
+        if (SourcePin.Equals(TEXT("RGB"), ESearchCase::IgnoreCase)) {
+          SourceOutputIndex = 0;
+        } else if (SourcePin.Equals(TEXT("R"), ESearchCase::IgnoreCase)) {
+          SourceOutputIndex = 1;
+        } else if (SourcePin.Equals(TEXT("G"), ESearchCase::IgnoreCase)) {
+          SourceOutputIndex = 2;
+        } else if (SourcePin.Equals(TEXT("B"), ESearchCase::IgnoreCase)) {
+          SourceOutputIndex = 3;
+        } else if (SourcePin.Equals(TEXT("A"), ESearchCase::IgnoreCase)) {
+          SourceOutputIndex = 4;
+        } else if (SourcePin.Equals(TEXT("RGBA"), ESearchCase::IgnoreCase)) {
+          SourceOutputIndex = 5;
+        } else {
+          Bridge->SendAutomationError(Socket, RequestId,
+                              FString::Printf(TEXT("Invalid TextureSample output pin '%s'. Valid: RGB, R, G, B, A, RGBA."), *SourcePin),
+                              TEXT("INVALID_PIN"));
+          return true;
+        }
       } else {
         Bridge->SendAutomationError(Socket, RequestId,
                             FString::Printf(TEXT("Source output pin '%s' is not numeric and source node has no named outputs."), *SourcePin),

--- a/src/tools/handlers/material/material-authoring-instances.ts
+++ b/src/tools/handlers/material/material-authoring-instances.ts
@@ -4,8 +4,9 @@ import type { AutomationResponse } from '../../../types/automation/automation-re
 import { executeAutomationRequest } from '../foundation/dispatch/common-handlers.js';
 import { ResponseFactory } from '../../../utils/responses/response-factory.js';
 import { TOOL_ACTIONS } from '../../../utils/commands/action-constants.js';
-import { normalizeArgs, extractString, extractOptionalString, extractOptionalNumber, extractOptionalBoolean, extractOptionalObject } from '../foundation/arguments/argument-helper.js';
+import { normalizeArgs, extractString, extractOptionalString, extractOptionalBoolean, extractOptionalObject } from '../foundation/arguments/argument-helper.js';
 import { normalizeAssetPath, parseMaterialPath } from './material-authoring-common.js';
+import { toFiniteNumber } from '../../../utils/validation/normalize.js';
 
 export async function handleMaterialInstanceAction(
   action: string,
@@ -80,7 +81,18 @@ export async function handleMaterialInstanceAction(
 
         const assetPath = extractString(params, 'assetPath');
         const parameterName = extractString(params, 'parameterName');
-        const value = extractOptionalNumber(params, 'value') ?? 0;
+        // 'value' can arrive as a numeric string (the MCP boundary stringifies scalars);
+        // extractOptionalNumber rejected non-number types, so the old `?? 0` silently zeroed
+        // every value (0.3 -> 0). Use the codebase's toFiniteNumber, which accepts a number or
+        // a numeric string and rejects blank/boolean/array/non-parseable inputs (Number() would
+        // coerce '', false, [] to 0). A bad value surfaces as an error, not a silent 0.
+        const rawValue = (params as Record<string, unknown>)['value'];
+        const value = toFiniteNumber(rawValue);
+        if (value === undefined) {
+          return ResponseFactory.error(
+            `manage_material_authoring.set_scalar_parameter_value: 'value' must be a finite number, got ${JSON.stringify(rawValue)}`,
+            'INVALID_ARGUMENT');
+        }
         const save = extractOptionalBoolean(params, 'save') ?? true;
 
         const res = (await executeAutomationRequest(tools, TOOL_ACTIONS.MANAGE_MATERIAL_AUTHORING, {


### PR DESCRIPTION
## Problems (manage_asset material)
1. **`connect_nodes` named TextureSample outputs → `INVALID_PIN`.** Only `MaterialFunctionCall` and `Custom` expressions resolved named output pins; a `TextureSample`'s `RGB/R/G/B/A/RGBA` fell through to the error path (numeric index was the only workaround).
2. **`set_scalar_parameter_value` silently zeroed the value** (`0.3 → 0`). The value reaches the handler as a numeric **string**; `extractOptionalNumber` rejects non-number types, and the `?? 0` then defaulted it to 0 with no error.
3. **`create_folder` reported `existsAfter:false`** for a folder that was actually created — `VerifyAssetExists` looks for a `.uasset` object, which a folder doesn't have.

## Fixes
1. `ConnectNodes.cpp` — add a `UMaterialExpressionTextureSample` branch (covers `TextureSampleParameter2D`) mapping the engine's output order: **RGB=0, R=1, G=2, B=3, A=4, RGBA=5**. (RGB at index 0 has the alpha bit off; RGBA at index 5 carries all four channels — they are distinct pins.)
2. `material-authoring-instances.ts` — coerce `value` with `Number(...)` and reject non-finite input with `INVALID_ARGUMENT` (truth-telling) instead of silently defaulting to 0.
3. `FolderCreation.cpp` — report `existsAfter` via `DoesAssetDirectoryExistOnDisk` (physical content directory; asset-registry directory entries can be stale).

## Validation (UE 5.8, live)
`sourcePin="RGB"` → connects at output 0; `sourcePin="RGBA"` → output 5 (verified via readback); `set_scalar value=0.3` → `0.3`, `value="abc"` → `INVALID_ARGUMENT`; `create_folder` → `existsAfter:true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
