### PR TITLE
fix: run SSE notification keepalive on a dedicated thread (survives GameThread stalls)

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Transport/McpNativeTransport.h
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Transport/McpNativeTransport.h
@@ -4,6 +4,7 @@
 #include "HAL/Runnable.h"
 #include "Dom/JsonValue.h"
 #include "MCP/DynamicTools/McpDynamicToolManager.h"
+#include "Async/Future.h"
 #include <atomic>
 
 class UMcpAutomationBridgeSubsystem;
@@ -75,6 +76,10 @@ public:
 	/** Clean up requests that have exceeded the timeout. Called from Tick. */
 	void CleanupStaleRequests();
 
+	// Dedicated-thread keepalive (immune to GameThread stalls).
+	void RunKeepaliveLoop();
+	void SweepNotificationKeepalives();
+
 	// FRunnable interface
 	virtual bool Init() override { return true; }
 	virtual uint32 Run() override;
@@ -113,6 +118,9 @@ private:
 		FString SessionId;
 		FString StreamId;
 		double StartTime = 0.0;
+		// Non-atomic: written once in HandleGetMcp before the stream is published into
+		// NotificationStreams (that publish establishes the happens-before), then
+		// read/written only by the keepalive thread (RunKeepaliveLoop).
 		double LastKeepaliveTime = 0.0;
 		FCriticalSection WriteMutex;
 		std::atomic<bool> bMarkedForRemoval{false};
@@ -187,6 +195,7 @@ private:
 	// Socket infrastructure
 	FSocket* ListenSocket = nullptr;
 	FRunnableThread* Thread = nullptr;
+	TFuture<void> KeepaliveLoopFuture;  // background keepalive thread (joined in Shutdown)
 	FEvent* StopEvent = nullptr;
 	FEvent* BindCompleteEvent = nullptr;
 	std::atomic<bool> bStopping{false};

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Transport/McpNativeTransportCleanup.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Transport/McpNativeTransportCleanup.cpp
@@ -109,30 +109,73 @@ void FMcpNativeTransport::CleanupStaleRequests()
 			}
 		}
 
-		// 4. Keepalive for living streams
-		TArray<TSharedPtr<FNotificationStream>> AliveSnapshot;
+		// Notification-stream keepalive is handled by the dedicated keepalive thread
+		// (RunKeepaliveLoop / SweepNotificationKeepalives) so it keeps firing during
+		// long GameThread stalls (recompile, PIE, modal dialog, blocking import).
+		// This GameThread sweep now only reaps. See Start()/Shutdown().
+	}
+}
+
+// ─── Keepalive Loop (dedicated thread) ──────────────────────────────────────
+//
+// The SSE notification-stream keepalive used to run from this GameThread cleanup
+// pass (driven by the subsystem ticker). When the GameThread stalls longer than
+// the keepalive interval, no keepalive is sent, the client's stream idles out,
+// and the MCP session is re-initialized. Running the sweep on its own thread
+// keeps keepalives flowing through GameThread stalls.
+
+void FMcpNativeTransport::RunKeepaliveLoop()
+{
+	// Tick faster than the keepalive interval so a stream is never more than one
+	// tick late. StopEvent is triggered by Stop(), waking us immediately on shutdown.
+	static constexpr uint32 TickMs = 5000;
+	while (!bStopping.load())
+	{
+		if (StopEvent)
 		{
-			FScopeLock Lock(&NotificationStreamsMutex);
-			for (auto& [StreamId, Stream] : NotificationStreams)
+			StopEvent->Wait(TickMs);
+		}
+		else
+		{
+			FPlatformProcess::Sleep(TickMs / 1000.0f);
+		}
+		if (bStopping.load())
+		{
+			break;
+		}
+		SweepNotificationKeepalives();
+	}
+}
+
+void FMcpNativeTransport::SweepNotificationKeepalives()
+{
+	const double Now = FPlatformTime::Seconds();
+
+	// Snapshot living streams under the map lock, then write outside it — the socket
+	// write takes each stream's WriteMutex, so the two locks are never nested.
+	TArray<TSharedPtr<FNotificationStream>> AliveSnapshot;
+	{
+		FScopeLock Lock(&NotificationStreamsMutex);
+		for (auto& [StreamId, Stream] : NotificationStreams)
+		{
+			if (Stream.IsValid() && !Stream->bMarkedForRemoval.load()
+				&& Now - Stream->LastKeepaliveTime >= KeepaliveIntervalSeconds)
 			{
-				if (Stream.IsValid() && !Stream->bMarkedForRemoval.load()
-					&& Now - Stream->LastKeepaliveTime >= KeepaliveIntervalSeconds)
-				{
-					AliveSnapshot.Add(Stream);
-				}
+				AliveSnapshot.Add(Stream);
 			}
 		}
-		for (const auto& Stream : AliveSnapshot)
+	}
+
+	for (const auto& Stream : AliveSnapshot)
+	{
+		if (!WriteNotificationKeepalive(*Stream))
 		{
-			if (!WriteNotificationKeepalive(*Stream))
-			{
-				Stream->bMarkedForRemoval.store(true);
-			}
-			else
-			{
-				Stream->LastKeepaliveTime = Now;
-				TouchSession(Stream->SessionId);
-			}
+			Stream->bMarkedForRemoval.store(true);
+		}
+		else
+		{
+			Stream->LastKeepaliveTime = Now;
+			TouchSession(Stream->SessionId);
 		}
 	}
 }

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Transport/McpNativeTransportLifecycle.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Transport/McpNativeTransportLifecycle.cpp
@@ -128,6 +128,11 @@ bool FMcpNativeTransport::Start(int32 Port, const FString& PluginDir, bool bLoad
 		return false;
 	}
 
+	// Launch the keepalive loop on its own thread so it survives long GameThread
+	// stalls (recompile, PIE, modal, blocking import) instead of starving with the
+	// subsystem ticker that drives CleanupStaleRequests.
+	KeepaliveLoopFuture = Async(EAsyncExecution::Thread, [this]() { RunKeepaliveLoop(); });
+
 	UE_LOG(LogMcpNativeTransport, Log,
 		TEXT("Native MCP server started on http://%s:%d/mcp"), *ListenHost, Port);
 	return true;
@@ -158,6 +163,15 @@ void FMcpNativeTransport::Shutdown()
 		Thread->Kill(true);  // Calls Stop() again (no-op — already signaled)
 		delete Thread;
 		Thread = nullptr;
+	}
+
+	// Join the keepalive loop before StopEvent is returned to the pool (it waits on
+	// it) and before notification streams are closed (it writes to their sockets).
+	// Stop() already signaled bStopping + StopEvent, so the loop is on its way out.
+	if (KeepaliveLoopFuture.IsValid())
+	{
+		KeepaliveLoopFuture.Wait();
+		KeepaliveLoopFuture = TFuture<void>();
 	}
 
 	// Wait for in-flight connection handlers and async writes to finish.


### PR DESCRIPTION
## Problem

The notification-stream SSE keepalive is driven by `CleanupStaleRequests`, which runs on the subsystem ticker (the **GameThread**). When the editor GameThread stalls longer than `KeepaliveIntervalSeconds` — recompile, PIE enter/exit, a modal dialog, a blocking asset import — no keepalive is sent, the client's SSE stream idles out, and the MCP session is re-initialized. It shows up as repeated reconnects with no editor restart.

Fixes #488.

## Change

Move the keepalive onto its own thread so it keeps firing through GameThread stalls:

- `RunKeepaliveLoop()` launched in `Start()` via `Async(EAsyncExecution::Thread, …)`, stored as `TFuture<void> KeepaliveLoopFuture`. It waits on the existing `StopEvent` (5s tick) and calls `SweepNotificationKeepalives()`.
- `SweepNotificationKeepalives()` is the sweep lifted out of step 4 of `CleanupStaleRequests()` — same snapshot-under-`NotificationStreamsMutex` then write-outside-lock, keeps `TouchSession()` on success.
- `Shutdown()` joins the loop after the accept thread is killed and `Stop()` has signaled `bStopping`/`StopEvent`, but **before** `StopEvent` is returned to the pool and notification streams are closed.
- `CleanupStaleRequests()` keeps the request-timeout / session-expiry / dead-stream reaping on the GameThread.

No new lock nesting (per-stream `WriteMutex` is only taken outside `NotificationStreamsMutex`); the manual-reset `StopEvent` gives prompt, busy-spin-free shutdown. `KeepaliveIntervalSeconds` is unchanged.

## Verification

Implemented and verified in a production UE 5.7.1 project: a **90s total GameThread freeze** left the notification stream + session intact (no `stream closed`, no re-`initialize`), and a post-freeze call worked on the same session. Before the change, the same stall dropped the stream.

3 files changed, +85 / −19.
