### PR TITLE
fix: guard pre-5.4/5.5 UE APIs so the plugin builds on older UE (verified 5.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <summary><b>🐛 Fixed</b></summary>
 
 - **`add_variable` now applies `defaultValue`** — the handler read the `defaultValue` payload field but never assigned it to the new variable, so every Blueprint variable was created with a zero/empty default regardless of the value supplied (e.g. a float requested as `0.35` stayed `0`). The parsed JSON default is now written to `FBPVariableDescription::DefaultValue` with type-aware formatting: booleans as lowercase `true`/`false`, integer/byte categories as whole numbers, floats/doubles via `SanitizeFloat`, and strings/struct literals passed through. UE parses the stored string back into the typed default on compile.
+- **Plugin failed to compile on UE older than 5.4/5.5** — three newer-UE APIs were used without the version guards used elsewhere in the plugin: the `EAllowShrinking::No` overload of `FString::RightChopInline`/`LeftInline` (UE 5.4+), the standalone `PhysicsEngine/SkeletalBodySetup.h` include (UE 5.5+), and a redundant `UObject/StrProperty.h` include. Added the same `#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= N` guards and dropped the redundant include (`FStrProperty` comes from the already-included `UObject/UnrealType.h`). Verified building on UE 5.3.2.
 
 </details>
 

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Environment/McpAutomationBridge_EnvironmentSnapshotPaths.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Environment/McpAutomationBridge_EnvironmentSnapshotPaths.cpp
@@ -16,7 +16,11 @@ bool NormalizeSnapshotRelativePath(FString &Path)
 {
     Path = Path.TrimStartAndEnd();
     Path.ReplaceInline(TEXT("\\"), TEXT("/"));
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 4
     while (Path.StartsWith(TEXT("./"))) Path.RightChopInline(2, EAllowShrinking::No);
+#else
+    while (Path.StartsWith(TEXT("./"))) Path.RightChopInline(2, false);
+#endif
     if (Path.Equals(TEXT("/Temp"), ESearchCase::IgnoreCase))
     {
         Path = TEXT("temp");
@@ -50,7 +54,11 @@ bool IsWindowsReservedFilename(const FString &Filename)
     int32 ExtensionIndex = INDEX_NONE;
     if (Basename.FindChar(TEXT('.'), ExtensionIndex))
     {
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 4
         Basename.LeftInline(ExtensionIndex, EAllowShrinking::No);
+#else
+        Basename.LeftInline(ExtensionIndex, false);
+#endif
     }
     Basename.TrimEndInline();
     while (Basename.RemoveFromEnd(TEXT("."))) Basename.TrimEndInline();

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Skeleton/Physics/McpAutomationBridge_SkeletonHandlersPhysicsBodyRemoval.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Skeleton/Physics/McpAutomationBridge_SkeletonHandlersPhysicsBodyRemoval.cpp
@@ -6,7 +6,9 @@
 #include "Foundation/HandlerUtils/McpHandlerUtils.h"
 #include "PhysicsEngine/PhysicsAsset.h"
 #include "PhysicsEngine/PhysicsConstraintTemplate.h"
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5
 #include "PhysicsEngine/SkeletalBodySetup.h"
+#endif
 
 #if WITH_EDITOR
 using namespace McpSkeletonHandlers;

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Foundation/Reflection/McpPropertyReflectionPrivate.h
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Foundation/Reflection/McpPropertyReflectionPrivate.h
@@ -4,7 +4,6 @@
 #include "Core/Compatibility/McpVersionCompatibility.h"
 #include "Internationalization/Text.h"
 #include "Runtime/Launch/Resources/Version.h"
-#include "UObject/StrProperty.h"
 #include "UObject/TextProperty.h"
 #include "UObject/UnrealType.h"
 


### PR DESCRIPTION
Fixes #492.

Three files used newer-UE APIs without the version guards used elsewhere in the plugin, breaking compilation on UE older than 5.4 / 5.5. **Verified building cleanly on UE 5.3.2** (0 errors, `UnrealEditor-McpAutomationBridge.dll` links). I built 5.3 specifically; the guards restore the pre-5.4 / pre-5.5 API forms, but I have not independently built 5.0–5.2. Guard style matches `Core/Compatibility/McpVersionCompatibility.h`.

### Changes
- **`EAllowShrinking::No` overload (UE 5.4+)** — guarded with `>= 4`; falls back to the `bool` overload on ≤5.3 (two call sites in `…EnvironmentSnapshotPaths.cpp`).
- **`PhysicsEngine/SkeletalBodySetup.h` (standalone header, UE 5.5+)** — guarded with `>= 5`. On ≤5.4 the complete `USkeletalBodySetup` type is still reachable via `PhysicsEngine/PhysicsAsset.h` (its `UE_ENABLE_INCLUDE_ORDER_DEPRECATED_IN_5_5` block, default-on there), so the `SkeletalBodySetups[i]->…` member access is unaffected.
- **Removed redundant `#include "UObject/StrProperty.h"`** — `FStrProperty` is declared in the already-included `UObject/UnrealType.h` on all UE versions.

No behavior change on 5.5+. `CHANGELOG.md` updated under `[Unreleased]`.

### Checklist
- `npm run lint` — passes locally on this branch.
- `npm run test:smoke` — passes locally on this branch (`Smoke Test PASSED`, 23 tools).
- `CHANGELOG.md` updated under `[Unreleased]`.

C++-only change to the bridge plugin; does not touch the TypeScript server. CI (lint/smoke/CodeQL) doesn't compile the plugin, so the UE 5.3 build above is the compile evidence.
