### PR TITLE
fix: get_niagara_info reports 0 emitters when called with systemPath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <summary><b>🐛 Fixed</b></summary>
 
 - **`add_variable` now applies `defaultValue`** — the handler read the `defaultValue` payload field but never assigned it to the new variable, so every Blueprint variable was created with a zero/empty default regardless of the value supplied (e.g. a float requested as `0.35` stayed `0`). The parsed JSON default is now written to `FBPVariableDescription::DefaultValue` with type-aware formatting: booleans as lowercase `true`/`false`, integer/byte categories as whole numbers, floats/doubles via `SanitizeFloat`, and strings/struct literals passed through. UE parses the stored string back into the typed default on compile.
+- **`get_niagara_info` / `validate_niagara_system` no longer query an auto-created default system** — these read-only Niagara queries share `handleEffectAuthoringAction` with the authoring actions, which injects `ensureDefaultNiagaraAuthoringAssets()` defaults into `systemPath`/`assetPath` when a field is unset. Because the native `GetNiagaraInfo` handler prefers `assetPath`, a caller passing only `systemPath` had its empty `assetPath` overwritten with the throwaway default system, so the query reported `emitterCount: 0` with an empty emitter list for a perfectly valid asset. Read-only query actions now bypass default-asset injection and simply mirror whichever path the caller supplied across `assetPath`/`systemPath`.
 
 </details>
 

--- a/src/tools/handlers/effect/effect-niagara-actions.ts
+++ b/src/tools/handlers/effect/effect-niagara-actions.ts
@@ -38,6 +38,10 @@ const EFFECT_AUTHORING_ACTIONS = new Set<string>([
   'get_niagara_info', 'validate_niagara_system'
 ]);
 
+const NIAGARA_READONLY_QUERY_ACTIONS = new Set<string>([
+  'get_niagara_info', 'validate_niagara_system'
+]);
+
 export async function handleEffectGraphAction(
   action: string,
   mutableArgs: Record<string, unknown>,
@@ -68,6 +72,15 @@ export async function handleEffectAuthoringAction(
   tools: ITools
 ): Promise<Record<string, unknown> | undefined> {
   if (!EFFECT_AUTHORING_ACTIONS.has(action)) return undefined;
+
+  if (NIAGARA_READONLY_QUERY_ACTIONS.has(action)) {
+    const queryPath = (mutableArgs.assetPath ?? mutableArgs.systemPath) as string | undefined;
+    if (queryPath) {
+      mutableArgs.assetPath = queryPath;
+      mutableArgs.systemPath = queryPath;
+    }
+    return executeAutomationRequest(tools, 'manage_niagara_authoring', mutableArgs) as Promise<Record<string, unknown>>;
+  }
 
   const usesImplicitSystem = !mutableArgs.systemPath;
   const defaultAssets = await ensureDefaultNiagaraAuthoringAssets(tools);


### PR DESCRIPTION
## Summary

`get_niagara_info` (and `validate_niagara_system`) can report an empty result for a valid Niagara System when the caller passes the asset via `systemPath`. The query returns `emitterCount: 0` with an empty `emitters` array even though the system has emitters.

Root cause is in the TypeScript layer, not the native bridge.

## Changes

- Add a read-only bypass in `handleEffectAuthoringAction` for `get_niagara_info` and `validate_niagara_system`.
- These actions no longer trigger `ensureDefaultNiagaraAuthoringAssets()` default-asset injection; they only mirror the caller-supplied path across `assetPath`/`systemPath` before dispatching.
- CHANGELOG updated under `[Unreleased]`.

## Root Cause

`get_niagara_info` and `validate_niagara_system` are listed in `EFFECT_AUTHORING_ACTIONS`, so they run through `handleEffectAuthoringAction`, which is designed for *authoring* actions (`add_*_module`, etc.). That handler fills in default assets when a path is unset:

```ts
if (!mutableArgs.systemPath) { mutableArgs.systemPath = defaultAssets.systemPath; }
...
if (!mutableArgs.assetPath)  { mutableArgs.assetPath  = defaultAssets.systemPath; }
```

The native `GetNiagaraInfo` handler resolves its target as `AssetPath.IsEmpty() ? SystemPath : AssetPath` — i.e. `assetPath` wins. So when a caller passes only `systemPath`, the empty `assetPath` gets overwritten with the freshly-created, empty default system, and the native handler inspects that empty system instead of the requested one.

Calling the same action with `assetPath` already worked, which confirms the issue is the default-asset override path rather than the C++ handler.

## Reproduction

1. Pick any Niagara System asset that has one or more emitters.
2. Call `manage_effect` with:
   ```json
   { "action": "get_niagara_info", "systemPath": "/Game/Path/To/YourSystem.YourSystem" }
   ```
3. Before fix: `emitterCount: 0`, empty `emitters`, `userParameterCount: 0`.
4. Call again using `assetPath` instead of `systemPath` → correct result. After fix: both `systemPath` and `assetPath` return the correct emitter list.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Tested with Unreal Engine (version: 5.7)
- [x] Tested MCP client integration
- [x] `npm run build` / `tsc --noEmit` pass
- [x] `npm run test:smoke` passes

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Updated CHANGELOG under [Unreleased]
- [ ] CI passes
