### PR TITLE
fix(blueprint): prevent editor crash creating ConstructObjectFromClass nodes (SpawnActorFromClass)

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersNodeCreation.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersNodeCreation.cpp
@@ -42,8 +42,10 @@ namespace McpBlueprintGraphHandlers
 // Shared helper: resolve a class string (Blueprint asset path, generated-class
 // path, or native class name) to a UClass. Used by every node branch that has
 // a class pin (DynamicCast TargetType, CreateWidget WidgetType, etc.) so all
-// callers accept the same input formats consistently.
-static UClass* ResolveTargetClassFromString(const FString& InClassString)
+// callers accept the same input formats consistently. Declared in the shared
+// private header so other translation units (e.g. the ConstructObject-family
+// path in SpecialNodes) resolve classes identically.
+UClass* ResolveTargetClassFromString(const FString& InClassString)
 {
     if (InClassString.IsEmpty())
     {
@@ -345,6 +347,22 @@ void CreateDynamicNode(
         return;
     }
 #endif
+
+    // UK2Node_ConstructObjectFromClass and its subclasses (SpawnActorFromClass,
+    // ConstructObjectFromClass, ...) hard-crash the editor on the generic path
+    // below: their PostPlacedNewNode() dereferences a checked pin accessor (e.g.
+    // UK2Node_SpawnActorFromClass::GetScaleMethodPin() -> FindPinChecked) before
+    // AllocateDefaultPins() has created any pins. They need pins allocated first.
+    //
+    // This must run *below* the specialized CreateWidget handler above:
+    // UK2Node_CreateWidget is itself a ConstructObjectFromClass subclass, so if
+    // this ran first it would swallow CreateWidget and silently drop its typed
+    // targetClass. Widget nodes are fully handled above; here we cover the
+    // remaining ConstructObject-family nodes (SpawnActorFromClass, etc.).
+    if (TryCreateConstructObjectNode(Context, NodeClass, X, Y))
+    {
+        return;
+    }
 
     UEdGraphNode* NewNode =
         NewObject<UEdGraphNode>(Context.TargetGraph, NodeClass);

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersPrivate.h
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersPrivate.h
@@ -83,6 +83,11 @@ bool HandleNodeDetailAction(FActionContext& Context);
 #if WITH_EDITOR
 const TTuple<FString, FString>* FindCommonFunctionNode(const FString& NodeType);
 UClass* FindNodeClassByName(const FString& NodeType);
+// Resolve a class string (Blueprint asset path like /Game/..., generated-class
+// path, or native class name) to a UClass. Shared so every create_node branch
+// with a class pin accepts the same input formats — including /Game/ Blueprint
+// paths, which the name-oriented ResolveUClass() cannot load.
+UClass* ResolveTargetClassFromString(const FString& InClassString);
 FEdGraphPinType ResolveCustomEventPinType(const FString& TypeName);
 FProperty* CreateCustomEventParameter(
     UFunction* Function,
@@ -115,6 +120,11 @@ bool TryCreateSpecialNode(
     float X,
     float Y);
 bool TryCreateEnhancedInputNode(
+    FActionContext& Context,
+    UClass* NodeClass,
+    float X,
+    float Y);
+bool TryCreateConstructObjectNode(
     FActionContext& Context,
     UClass* NodeClass,
     float X,

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersSpecialNodes.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersSpecialNodes.cpp
@@ -3,6 +3,7 @@
 #if WITH_EDITOR
 #include "EdGraph/EdGraphSchema.h"
 #include "InputAction.h"
+#include "K2Node_ConstructObjectFromClass.h"
 #include "K2Node_DynamicCast.h"
 #include "K2Node_InputAxisEvent.h"
 #include "Misc/PackageName.h"
@@ -209,6 +210,95 @@ bool TryCreateEnhancedInputNode(
     Result->SetStringField(TEXT("inputActionPath"), CleanActionPath);
     McpHandlerUtils::AddVerification(Result, Context.Blueprint);
     Context.SendResponse(TEXT("Enhanced Input node created."), Result);
+    return true;
+}
+
+bool TryCreateConstructObjectNode(
+    FActionContext& Context,
+    UClass* NodeClass,
+    float X,
+    float Y)
+{
+    // Covers the whole UK2Node_ConstructObjectFromClass family:
+    // SpawnActorFromClass, ConstructObjectFromClass, CreateWidget,
+    // AddComponentByClass, ... — every one of which crashes on the generic path.
+    if (!NodeClass->IsChildOf(UK2Node_ConstructObjectFromClass::StaticClass()))
+    {
+        return false;
+    }
+
+    UEdGraphNode* NewNode =
+        NewObject<UEdGraphNode>(Context.TargetGraph, NodeClass);
+    if (!NewNode)
+    {
+        Context.SendError(
+            TEXT("Failed to instantiate node."),
+            TEXT("CREATE_FAILED"));
+        return true;
+    }
+
+    Context.TargetGraph->AddNode(NewNode, false, false);
+    NewNode->Modify();
+    NewNode->CreateNewGuid();
+
+    // ROOT-CAUSE FIX: allocate pins BEFORE PostPlacedNewNode(). Nodes in this
+    // family read checked pins inside PostPlacedNewNode() — e.g.
+    // UK2Node_SpawnActorFromClass::GetScaleMethodPin() => FindPinChecked() — which
+    // check()-crashes the editor when the pin doesn't exist yet. The editor's
+    // palette spawn survives because the cached template node already carries pins;
+    // the generic create_node path (PostPlacedNewNode then AllocateDefaultPins)
+    // does not, so it asserts. Allocating first makes the checked accessor safe.
+    NewNode->AllocateDefaultPins();
+    NewNode->PostPlacedNewNode();
+
+    // Optional: apply a construct/spawn class so the expose-on-spawn pins are
+    // generated. Prefer `targetClass` (the spelling the rest of create_node
+    // uses) and fall back to the legacy spawnClass/actorClass/class spellings
+    // for backward compatibility. A classless node is still valid (and no
+    // longer crashes), so silently skip when absent or unresolved.
+    FString SpawnClassName;
+    if (Context.Payload->TryGetStringField(TEXT("targetClass"), SpawnClassName) ||
+        Context.Payload->TryGetStringField(TEXT("spawnClass"), SpawnClassName) ||
+        Context.Payload->TryGetStringField(TEXT("actorClass"), SpawnClassName) ||
+        Context.Payload->TryGetStringField(TEXT("class"), SpawnClassName))
+    {
+        // Resolve via the shared resolver so /Game/... Blueprint asset paths
+        // load correctly (ResolveUClass only handles native/name lookups and
+        // returns CLASS_NOT_FOUND for /Game/ paths).
+        if (UClass* DesiredClass = ResolveTargetClassFromString(SpawnClassName))
+        {
+            if (UK2Node_ConstructObjectFromClass* ConstructNode =
+                    Cast<UK2Node_ConstructObjectFromClass>(NewNode))
+            {
+                if (UEdGraphPin* ClassPin = ConstructNode->GetClassPin())
+                {
+                    // Mirror how the engine itself seeds the class (ExpandNode):
+                    // set DefaultObject, clear the textual default, then rebuild
+                    // pins. Pins already exist here, so ReconstructNode is safe.
+                    ClassPin->DefaultObject = DesiredClass;
+                    ClassPin->DefaultValue.Reset();
+                    NewNode->ReconstructNode();
+                }
+            }
+        }
+    }
+
+    NewNode->NodePosX = X;
+    NewNode->NodePosY = Y;
+    if (const UEdGraphSchema* Schema = Context.TargetGraph->GetSchema())
+    {
+        Schema->ForceVisualizationCacheClear();
+    }
+    Context.TargetGraph->NotifyGraphChanged();
+    FBlueprintEditorUtils::MarkBlueprintAsModified(Context.Blueprint);
+    SaveLoadedAssetThrottled(Context.Blueprint);
+
+    TSharedPtr<FJsonObject> Result = McpHandlerUtils::CreateResultObject();
+    Result->SetStringField(TEXT("nodeId"), NewNode->NodeGuid.ToString());
+    Result->SetStringField(TEXT("nodeName"), NewNode->GetName());
+    Result->SetStringField(TEXT("nodeClass"), NodeClass->GetName());
+    McpHandlerUtils::AddVerification(Result, Context.Blueprint);
+    Context.SendResponse(TEXT("Node created."), Result);
     return true;
 }
 }

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersSpecialNodes.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersSpecialNodes.cpp
@@ -227,6 +227,37 @@ bool TryCreateConstructObjectNode(
         return false;
     }
 
+    // Resolve an optional construct/spawn class up front, before mutating the
+    // graph. A classless node is valid (and no longer crashes), but if the
+    // caller explicitly named a class we must not silently drop it — reject with
+    // CLASS_NOT_FOUND, matching the Cast branch above.
+    //
+    // Prefer `targetClass` (the spelling the rest of create_node uses) and fall
+    // back to the legacy spawnClass/actorClass/class spellings for backward
+    // compatibility. Resolve via the shared ResolveTargetClassFromString so
+    // /Game/... Blueprint asset paths load correctly — ResolveUClass only does
+    // native/name lookups and returns CLASS_NOT_FOUND for /Game/ paths.
+    FString RequestedClassName;
+    UClass* DesiredClass = nullptr;
+    const bool bHasRequestedClass =
+        Context.Payload->TryGetStringField(TEXT("targetClass"), RequestedClassName) ||
+        Context.Payload->TryGetStringField(TEXT("spawnClass"), RequestedClassName) ||
+        Context.Payload->TryGetStringField(TEXT("actorClass"), RequestedClassName) ||
+        Context.Payload->TryGetStringField(TEXT("class"), RequestedClassName);
+    if (bHasRequestedClass)
+    {
+        DesiredClass = ResolveTargetClassFromString(RequestedClassName);
+        if (!DesiredClass)
+        {
+            Context.SendError(
+                FString::Printf(
+                    TEXT("Class '%s' not found"),
+                    *RequestedClassName),
+                TEXT("CLASS_NOT_FOUND"));
+            return true;
+        }
+    }
+
     UEdGraphNode* NewNode =
         NewObject<UEdGraphNode>(Context.TargetGraph, NodeClass);
     if (!NewNode)
@@ -251,34 +282,20 @@ bool TryCreateConstructObjectNode(
     NewNode->AllocateDefaultPins();
     NewNode->PostPlacedNewNode();
 
-    // Optional: apply a construct/spawn class so the expose-on-spawn pins are
-    // generated. Prefer `targetClass` (the spelling the rest of create_node
-    // uses) and fall back to the legacy spawnClass/actorClass/class spellings
-    // for backward compatibility. A classless node is still valid (and no
-    // longer crashes), so silently skip when absent or unresolved.
-    FString SpawnClassName;
-    if (Context.Payload->TryGetStringField(TEXT("targetClass"), SpawnClassName) ||
-        Context.Payload->TryGetStringField(TEXT("spawnClass"), SpawnClassName) ||
-        Context.Payload->TryGetStringField(TEXT("actorClass"), SpawnClassName) ||
-        Context.Payload->TryGetStringField(TEXT("class"), SpawnClassName))
+    // Apply the requested construct/spawn class (already resolved above) so the
+    // expose-on-spawn pins are generated. Mirror how the engine itself seeds the
+    // class (ExpandNode): set DefaultObject, clear the textual default, then
+    // rebuild pins. Pins already exist here, so ReconstructNode is safe.
+    if (DesiredClass)
     {
-        // Resolve via the shared resolver so /Game/... Blueprint asset paths
-        // load correctly (ResolveUClass only handles native/name lookups and
-        // returns CLASS_NOT_FOUND for /Game/ paths).
-        if (UClass* DesiredClass = ResolveTargetClassFromString(SpawnClassName))
+        if (UK2Node_ConstructObjectFromClass* ConstructNode =
+                Cast<UK2Node_ConstructObjectFromClass>(NewNode))
         {
-            if (UK2Node_ConstructObjectFromClass* ConstructNode =
-                    Cast<UK2Node_ConstructObjectFromClass>(NewNode))
+            if (UEdGraphPin* ClassPin = ConstructNode->GetClassPin())
             {
-                if (UEdGraphPin* ClassPin = ConstructNode->GetClassPin())
-                {
-                    // Mirror how the engine itself seeds the class (ExpandNode):
-                    // set DefaultObject, clear the textual default, then rebuild
-                    // pins. Pins already exist here, so ReconstructNode is safe.
-                    ClassPin->DefaultObject = DesiredClass;
-                    ClassPin->DefaultValue.Reset();
-                    NewNode->ReconstructNode();
-                }
+                ClassPin->DefaultObject = DesiredClass;
+                ClassPin->DefaultValue.Reset();
+                NewNode->ReconstructNode();
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes #499 — `manage_blueprint` → `create_node` hard-crashes the editor for
`K2Node_SpawnActorFromClass` (and the rest of the `UK2Node_ConstructObjectFromClass`
family: `ConstructObjectFromClass`, `CreateWidget`, …).

## Root cause (corrected vs. the issue)

The issue blamed `AllocateDefaultPins()` + `FindPinChecked` and suggested `FGraphNodeCreator`.
That attribution is off by one call — and `FGraphNodeCreator` would **not** have fixed it (its
`Finalize()` runs the same fatal order). The real culprit is **`PostPlacedNewNode()`**:

```cpp
void UK2Node_SpawnActorFromClass::PostPlacedNewNode() {
    UEdGraphPin* const ScaleMethodPin = GetScaleMethodPin(); // FindPinChecked(TransformScaleMethod)
    ScaleMethodPin->DefaultValue = ...;                      // check(Result) fires — pin doesn't exist yet
}
```

`CreateDynamicNode` calls `PostPlacedNewNode()` while `Pins.Num() == 0`, so the checked pin
accessor asserts and the editor dies. The engine's own palette spawn survives because the cached
**template** node already carries pins by the time `PostPlacedNewNode` runs on the placed copy.

## Fix

Add `TryCreateConstructObjectNode()` (in `…SpecialNodes.cpp`), dispatched from `CreateDynamicNode`
right after the existing `TryCreateEnhancedInputNode` check. It:

- gates on `NodeClass->IsChildOf(UK2Node_ConstructObjectFromClass::StaticClass())` — covers the
  whole family in one place;
- **allocates default pins _before_ `PostPlacedNewNode()`** (the core fix), mirroring the
  production-proven `TryCreateEnhancedInputNode` path (`Modify`, `ForceVisualizationCacheClear`,
  `NotifyGraphChanged`, throttled save);
- optionally seeds a class from a `spawnClass` / `actorClass` / `class` payload field
  (`ClassPin->DefaultObject` + `ReconstructNode()`) so the expose-on-spawn pins are generated — a
  classless node is still valid and no longer crashes;
- leaves the generic `NewObject` path and its `FunctionResult` double-pin guard untouched.

## Files

- `…/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersSpecialNodes.cpp` — new helper + `#include "K2Node_ConstructObjectFromClass.h"`
- `…/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersPrivate.h` — declaration
- `…/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersNodeCreation.cpp` — wire into dispatch

No `.Build.cs` change (BlueprintGraph already a private dependency). No TS-bridge change required;
forwarding the optional class field through the bridge schema is a possible follow-up.

## Testing

- [ ] `create_node nodeType=K2Node_SpawnActorFromClass` → node created, editor stays alive (was 2/2 crash on UE 5.6).
- [ ] With a `spawnClass` payload → expose-on-spawn pins appear; `connect_pins` works; blueprint compiles.
- [ ] No regression: `K2Node_FunctionResult` still yields a single execute pin; simple nodes (get/set, math) unaffected.
- [ ] Sibling family sanity: `ConstructObjectFromClass`, `CreateWidget`.

Root cause verified against UE5 source and a working reference plugin (allocates pins first, skips
`PostPlacedNewNode` entirely); the order-swap is class-scoped and low-risk. I haven't been able to
run a full UE 5.6 editor build on my end — happy to iterate if your CI/build surfaces anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
