### PR TITLE
fix(bridge): guard synchronous handler dispatch against blocking modals

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Core/Requests/McpAutomationBridge_ProcessRequest.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Core/Requests/McpAutomationBridge_ProcessRequest.cpp
@@ -8,6 +8,7 @@
 #include "McpConnectionManager.h"
 #include "Misc/ScopeExit.h"
 #include "Misc/ScopeLock.h"
+#include "Framework/Application/SlateApplication.h" // active-modal pre-flight (Slate is an editor dep)
 
 void UMcpAutomationBridgeSubsystem::ProcessAutomationRequest(
     const FString &RequestId, const FString &Action,
@@ -66,8 +67,29 @@ void UMcpAutomationBridgeSubsystem::ProcessAutomationRequest(
     return;
   }
 
+  // if the editor is ALREADY blocked on a modal window, do NOT stack another handler on top of it — reply
+  // with a clear signal instead of piling onto the freeze. Defensive: the primary K1 fix is the unattended-guard
+  // below, which stops handlers from opening a blocking modal in the first place.
+  if (FSlateApplication::IsInitialized() &&
+      FSlateApplication::Get().GetActiveModalWindow().IsValid()) {
+    UE_LOG(LogMcpAutomationBridgeSubsystem, Warning,
+           TEXT("ProcessAutomationRequest: refusing dispatch while a modal window is active "
+                "RequestId=%s action='%s'"),
+           *RequestId, *Action);
+    SendAutomationError(
+        RequestingSocket, RequestId,
+        TEXT("Editor is waiting on a modal dialog; automation is paused until it is dismissed."),
+        TEXT("EDITOR_MODAL_ACTIVE"));
+    return;
+  }
+
   bProcessingAutomationRequest = true;
   CurrentRequestOrigin = Origin;
+  // force UE unattended-script mode for the duration of handler dispatch so any FMessageDialog / editor
+  // confirmation prompt AUTO-ANSWERS its default instead of opening a BLOCKING modal that freezes the game thread
+  // (the witnessed force-kill / data-loss class). RAII-restored on every function-scope exit (incl. the early
+  // returns and the exception paths below). Non-differential stability fix.
+  TGuardValue<bool> UnattendedScriptGuard(GIsRunningUnattendedScript, true);
   bool bDispatchHandled = false;
   bool bErrorCaptureStarted = false;
   FString ConsumedHandlerLabel = TEXT("unknown-handler");


### PR DESCRIPTION
## Problem

`UMcpAutomationBridgeSubsystem::ProcessAutomationRequest` runs each automation handler **fully synchronously on the game thread**. If a handler opens a blocking modal (an `FMessageDialog` / editor confirmation prompt) or otherwise waits on the UI, the game thread blocks until it is dismissed. In an automated / headless context there is no user to dismiss it, so the editor appears to **hang** and every downstream automation request times out until the process is force-killed.

## Fix

Two guards around the handler dispatch, both editor-only and behavior-preserving on the normal (non-modal) path:

1. **Unattended-script guard** — wrap the dispatch in `TGuardValue<bool>(GIsRunningUnattendedScript, true)` so any `FMessageDialog` / prompt **auto-answers its default** instead of opening a blocking modal. RAII-restored on every exit path (early returns + exceptions).
2. **Modal pre-flight** — if a modal window is already active when a request arrives, reply with a clear `EDITOR_MODAL_ACTIVE` error instead of stacking another handler behind it.

`Slate` is already a private module dependency, so no new dependency is introduced. Handlers that never prompt see no API or response-shape change.

## Verification

Built against UE 5.8 (`Result: Succeeded`, 0 errors) and smoke-tested live: after the change, `ue_ext_ping`, asset queries, and `execute_python` all dispatch normally with no regression; the guard is active around every handler for the duration of its execution.