### PR TITLE
feat(bridge): expose the in-flight automation action for external monitoring

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Core/Requests/McpAutomationBridge_ProcessRequest.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Core/Requests/McpAutomationBridge_ProcessRequest.cpp
@@ -10,6 +10,26 @@
 #include "Misc/ScopeLock.h"
 #include "Framework/Application/SlateApplication.h" // active-modal pre-flight (Slate is an editor dep)
 
+// Publish the currently-executing automation action so external tooling (e.g. an off-thread watchdog) can attribute
+// a game-thread stall to the tool that was in flight. The lock is held ONLY for the brief set/get — never during
+// the handler — so a reader can observe the action off-thread even while a handler blocks the game thread. The
+// getter is exported so another module can link it.
+namespace McpAutomationBridge
+{
+    static FCriticalSection GInFlightActionCS;
+    static FString GInFlightAction;
+    static void SetInFlightAction(const FString& InAction)
+    {
+        FScopeLock Lock(&GInFlightActionCS);
+        GInFlightAction = InAction;
+    }
+    MCPAUTOMATIONBRIDGE_API FString GetInFlightAction()
+    {
+        FScopeLock Lock(&GInFlightActionCS);
+        return GInFlightAction;
+    }
+}
+
 void UMcpAutomationBridgeSubsystem::ProcessAutomationRequest(
     const FString &RequestId, const FString &Action,
     const TSharedPtr<FJsonObject> &Payload,
@@ -98,6 +118,9 @@ void UMcpAutomationBridgeSubsystem::ProcessAutomationRequest(
   // (the witnessed force-kill / data-loss class). RAII-restored on every function-scope exit (incl. the early
   // returns and the exception paths below). Non-differential stability fix.
   TGuardValue<bool> UnattendedScriptGuard(GIsRunningUnattendedScript, true);
+  // B11/K2b: record which action is now executing (cleared in the ON_SCOPE_EXIT below) so the off-thread watchdog
+  // can name it if this handler freezes the game thread.
+  McpAutomationBridge::SetInFlightAction(Action);
   bool bDispatchHandled = false;
   bool bErrorCaptureStarted = false;
   FString ConsumedHandlerLabel = TEXT("unknown-handler");
@@ -141,6 +164,7 @@ void UMcpAutomationBridgeSubsystem::ProcessAutomationRequest(
       }
 
       bProcessingAutomationRequest = false;
+      McpAutomationBridge::SetInFlightAction(FString()); // clear the in-flight action on every exit path
       CurrentRequestOrigin = ERequestOrigin::WebSocket;
       const double DispatchEndSeconds = FPlatformTime::Seconds();
       const double DurationMs =

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Core/Requests/McpAutomationBridge_ProcessRequest.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Core/Requests/McpAutomationBridge_ProcessRequest.cpp
@@ -13,7 +13,7 @@
 // Publish the currently-executing automation action so external tooling (e.g. an off-thread watchdog) can attribute
 // a game-thread stall to the tool that was in flight. The lock is held ONLY for the brief set/get — never during
 // the handler — so a reader can observe the action off-thread even while a handler blocks the game thread. The
-// getter is exported so another module can link it.
+// getter is declared in the public McpAutomationBridgeSubsystem.h so other modules can call it.
 namespace McpAutomationBridge
 {
     static FCriticalSection GInFlightActionCS;

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Public/McpAutomationBridgeSubsystem.h
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Public/McpAutomationBridgeSubsystem.h
@@ -31,6 +31,14 @@ bool DispatchFallbackAutomationRequest(
     FString& OutConsumedHandlerLabel);
 }
 
+namespace McpAutomationBridge
+{
+// Returns the automation action currently executing on the bridge (empty when idle). Thread-safe; readable
+// off-thread even while a handler blocks the game thread, so external tooling (e.g. a watchdog) can attribute
+// a stall to the tool in flight. Publisher lives in Core/Requests/McpAutomationBridge_ProcessRequest.cpp.
+MCPAUTOMATIONBRIDGE_API FString GetInFlightAction();
+}
+
 #define MCP_DECLARE_ACTION_HANDLER(Name) bool Name(const FString& RequestId, const FString& Action, const TSharedPtr<FJsonObject>& Payload, TSharedPtr<FMcpBridgeWebSocket> RequestingSocket)
 #define MCP_DECLARE_PAYLOAD_HANDLER(Name) bool Name(const FString& RequestId, const TSharedPtr<FJsonObject>& Payload, TSharedPtr<FMcpBridgeWebSocket> RequestingSocket)
 #include "McpAutomationBridgeSubsystemActionRoutingDeclarations.h"


### PR DESCRIPTION
## What

Adds a thread-safe accessor, `McpAutomationBridge::GetInFlightAction()`, that reports which automation action `ProcessAutomationRequest` is currently executing.

## Why

Automation handlers run synchronously on the game thread. If a handler blocks it (a modal, or a long synchronous editor op), external tooling — e.g. an off-thread watchdog — can detect that the game thread stalled, but has no way to know **which tool** caused it. This accessor closes that gap: it lets a stall be attributed to the specific in-flight action.

## How

The action is stored in a `namespace`-scoped `FString` guarded by an `FCriticalSection`. It is set right before dispatch and cleared on every exit path (including early returns and exceptions). The lock is held **only** for the brief set/get, **never** during the handler, so a reader can observe the action off-thread even while a handler is blocking the game thread — which is exactly when attribution matters most.

The getter is exported (`MCPAUTOMATIONBRIDGE_API`) for cross-module use. No behavior changes for existing callers; the setter/getter are additive.

## Verification

Built against UE 5.8 (`Result: Succeeded`, 0 errors) and smoke-tested live: an off-thread watchdog reading `GetInFlightAction()` correctly named the in-flight tool while a handler was deliberately blocking the game thread.