### PR TITLE
fix(inspect): resolve bare short class names in inspect_class (game-module classes)

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Environment/Inspection/McpAutomationBridge_EnvironmentHandlersInspectSearch.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Environment/Inspection/McpAutomationBridge_EnvironmentHandlersInspectSearch.cpp
@@ -122,6 +122,26 @@ bool HandleInspectSearchAction(
                     // Try with /Script/Engine prefix for common classes
                     TargetClass = FindObject<UClass>(nullptr, *FString::Printf(TEXT("/Script/Engine.%s"), *ClassName));
                 }
+                if (!TargetClass && !ClassName.Contains(TEXT(".")) && !ClassName.Contains(TEXT("/")))
+                {
+                    // Bare short name: UE5 removed the ANY_PACKAGE lookup, so FindObject with a null outer
+                    // resolves only full /Script/ paths, and the /Script/Engine fallback above only covers
+                    // engine classes — every game-module class (e.g. "TDMCharacter") came back
+                    // CLASS_NOT_FOUND. Scan all loaded classes by object name instead, and tolerate the
+                    // conventional A/U code prefix (reflected class object names carry no prefix:
+                    // ATDMCharacter's UClass is named "TDMCharacter"). If two loaded classes share the
+                    // short name, first-found wins (best-effort read-only fallback; the full
+                    // /Script/<Module>.<Class> path stays the deterministic route).
+                    TargetClass = FindFirstObject<UClass>(*ClassName, EFindFirstObjectOptions::None);
+                    if (!TargetClass && ClassName.Len() >= 2)
+                    {
+                        const TCHAR Prefix = ClassName[0];
+                        if ((Prefix == TEXT('A') || Prefix == TEXT('U')) && FChar::IsUpper(ClassName[1]))
+                        {
+                            TargetClass = FindFirstObject<UClass>(*ClassName.Mid(1), EFindFirstObjectOptions::None);
+                        }
+                    }
+                }
                 if (TargetClass)
                 {
                     Resp->SetStringField(TEXT("className"), TargetClass->GetName());

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Environment/Inspection/McpAutomationBridge_EnvironmentHandlersInspectSearch.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Environment/Inspection/McpAutomationBridge_EnvironmentHandlersInspectSearch.cpp
@@ -132,13 +132,23 @@ bool HandleInspectSearchAction(
                     // ATDMCharacter's UClass is named "TDMCharacter"). If two loaded classes share the
                     // short name, first-found wins (best-effort read-only fallback; the full
                     // /Script/<Module>.<Class> path stays the deterministic route).
+                    // FindFirstObject is UE 5.1+; pre-5.1 falls back to ResolveClassByName
+                    // (ANY_PACKAGE-era lookup) — same guard as MontageNotifyBlend.cpp.
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 1
                     TargetClass = FindFirstObject<UClass>(*ClassName, EFindFirstObjectOptions::None);
+#else
+                    TargetClass = ResolveClassByName(ClassName);
+#endif
                     if (!TargetClass && ClassName.Len() >= 2)
                     {
                         const TCHAR Prefix = ClassName[0];
                         if ((Prefix == TEXT('A') || Prefix == TEXT('U')) && FChar::IsUpper(ClassName[1]))
                         {
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 1
                             TargetClass = FindFirstObject<UClass>(*ClassName.Mid(1), EFindFirstObjectOptions::None);
+#else
+                            TargetClass = ResolveClassByName(ClassName.Mid(1));
+#endif
                         }
                     }
                 }


### PR DESCRIPTION
## Problem

`inspect_class` returns `CLASS_NOT_FOUND` for every game-module C++ class when called with the natural short-name shape:

```json
{ "action": "inspect_class", "className": "TDMCharacter" }
```

Root cause: UE5 removed the `ANY_PACKAGE` lookup, so `FindObject<UClass>(nullptr, *ClassName)` only resolves a **full object path**. The handler's single fallback tries `/Script/Engine.<name>`, which covers engine classes only — so any class living in a game or plugin module can never be resolved by short name, even though that's the form an LLM (or a human) naturally passes after seeing the class name in other tool output (e.g. a Blueprint's `parentClass`).

## Fix

In `HandleInspectSearchAction` (`inspect_class` branch), when the name contains no `.` or `/` and both existing lookups missed:

1. Fall back to `FindFirstObject<UClass>(*ClassName, EFindFirstObjectOptions::None)` — the same idiom the AnimationAuthoring handlers already use for notify classes — which scans loaded classes by object name.
2. Tolerate the conventional `A`/`U` code prefix: reflected `UClass` object names carry no prefix (`ATDMCharacter`'s class object is named `TDMCharacter`), so a caller passing the C++ identifier still resolves. The strip only runs after the unstripped lookup missed, and only for `A`/`U` followed by an uppercase letter.

If two loaded classes share a short name, first-found wins (best-effort, read-only inspection fallback; noted in a comment). Full-path behavior — `/Script/<Module>.<Class>`, `classPath` — is completely unchanged.

## Verification

Live on UE 5.8 (editor build Succeeded):
- Before: `inspect_class {"className":"TDMCharacter"}` → `CLASS_NOT_FOUND`
- After: same call → `success:true`, `classPath: /Script/TopDownMulti.TDMCharacter`, correct parent chain
- Full-path calls (`classPath: "/Script/TopDownMulti.TDMCharacter"`, `/Script/Engine.Actor`) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)