### PR TITLE
fix(inspect): route blueprintPath in get_component_details to inspect_cdo

### DIFF
--- a/src/tools/definitions/core/inspect-tool.ts
+++ b/src/tools/definitions/core/inspect-tool.ts
@@ -4,7 +4,7 @@ import type { ToolDefinition } from '../shared/tool-definition.js';
 export const inspectToolDefinition: ToolDefinition = {
     name: 'inspect',
     category: 'core',
-    description: 'Inspect any UObject: read/write properties, list components, export snapshots, and query class info. Actions: inspect_cdo (Blueprint CDO properties + all components without spawning an actor; use blueprintPath, optional detailed/componentName/propertyNames), inspect_class (class metadata), inspect_object (world actor), get_property/set_property, get_components, list_objects, find_by_class, find_by_tag, runtime_report.',
+    description: 'Inspect any UObject: read/write properties, list components, export snapshots, and query class info. Actions: inspect_cdo (Blueprint CDO properties + all components without spawning an actor; use blueprintPath, optional detailed/componentName/propertyNames), inspect_class (class metadata), inspect_object (world actor), get_property/set_property, get_components, get_component_details (WORLD actors: actorName+componentName; a blueprintPath is routed to inspect_cdo), list_objects, find_by_class, find_by_tag, runtime_report.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/tools/handlers/inspect/inspect-components.ts
+++ b/src/tools/handlers/inspect/inspect-components.ts
@@ -149,7 +149,30 @@ export async function handleSetComponentProperty(context: InspectHandlerContext)
 export async function handleGetComponentDetails(context: InspectHandlerContext): Promise<Record<string, unknown>> {
   const actorName = await resolveObjectPath(context.args, context.tools, { pathKeys: [], actorKeys: ['actorName', 'name', 'objectPath'] });
   const params = normalizeArgs(context.args, [{ key: 'componentName', required: true }]);
-  if (!actorName) throw new Error('Invalid actorName: required to resolve componentName');
+  if (!actorName) {
+    // Blueprint/CDO shape: callers coming from get_blueprint_details naturally pass a blueprintPath here,
+    // but this action inspects WORLD actors. Instead of failing, delegate to inspect_cdo (which reads a
+    // Blueprint's default components without spawning an actor) filtered to the requested component.
+    const blueprintPath = context.inspectArgs.blueprintPath
+      || (typeof context.normalizedArgs.blueprintPath === 'string' ? context.normalizedArgs.blueprintPath : '')
+      || (typeof context.normalizedArgs.assetPath === 'string' ? context.normalizedArgs.assetPath : '');
+    if (blueprintPath) {
+      const cdoResult = await executeAutomationRequest(context.tools, 'inspect', {
+        ...context.normalizedArgs,
+        action: 'inspect_cdo',
+        blueprintPath,
+        componentName: extractString(params, 'componentName')
+      }) as Record<string, unknown>;
+      return cleanObject({
+        ...cdoResult,
+        note: 'get_component_details inspects world actors; the blueprintPath argument was routed to inspect_cdo (Blueprint default/CDO components).'
+      }) as Record<string, unknown>;
+    }
+    throw new Error(
+      'Invalid actorName: get_component_details inspects WORLD actors (pass actorName). ' +
+      'For a Blueprint\'s default components, pass blueprintPath (routed to inspect_cdo) or call inspect_cdo with componentName.'
+    );
+  }
 
   const componentName = extractString(params, 'componentName');
   const res = await executeAutomationRequest(

--- a/src/tools/schemas/inspect-tool.ts
+++ b/src/tools/schemas/inspect-tool.ts
@@ -4,7 +4,7 @@ import type { ToolDefinition } from './core-tool-definition.js';
 export const inspectToolDefinition: ToolDefinition = {
   name: 'inspect',
   category: 'core',
-  description: 'Inspect any UObject: read/write properties, list components, export snapshots, and query class info. Actions: inspect_cdo (Blueprint CDO properties + all components without spawning an actor; use blueprintPath, optional detailed/componentName/propertyNames), inspect_class (class metadata), inspect_object (world actor), get_property/set_property, get_components, list_objects, find_by_class, find_by_tag, runtime_report.',
+  description: 'Inspect any UObject: read/write properties, list components, export snapshots, and query class info. Actions: inspect_cdo (Blueprint CDO properties + all components without spawning an actor; use blueprintPath, optional detailed/componentName/propertyNames), inspect_class (class metadata), inspect_object (world actor), get_property/set_property, get_components, get_component_details (WORLD actors: actorName+componentName; a blueprintPath is routed to inspect_cdo), list_objects, find_by_class, find_by_tag, runtime_report.',
   inputSchema: {
     type: 'object',
     properties: {


### PR DESCRIPTION
## Problem

`inspect` / `get_component_details` only supports **world actors**: the handler resolves `actorName` and delegates to `control_actor get_components`. But the call shape an LLM (or human) naturally produces right after `get_blueprint_details` is:

```json
{ "action": "get_component_details", "blueprintPath": "/Game/.../BP_GAS_Character", "componentName": "AbilitySystemComponent" }
```

which fails with a bare `Invalid actorName: required to resolve componentName` — even though `inspect_cdo` already carries exactly this capability (a Blueprint's default components + per-component detail, without spawning an actor).

## Fix (TS only, `inspect-components.ts` + tool description)

1. **Delegate:** when no actor resolves and a `blueprintPath`/`assetPath` is present, `handleGetComponentDetails` forwards to the `inspect_cdo` bridge action with the requested `componentName` (same delegation idiom the file family already uses). The result is passed through faithfully — `success:false` included — plus a `note` field so the routing is observable to the caller rather than a silent semantic swap.
2. **Guided error:** when neither target is given, the error names both routes: `actorName` for world actors, `blueprintPath` → `inspect_cdo` for Blueprint components.
3. **Description:** the `inspect` tool description now documents `get_component_details` as world-actor-focused with the `blueprintPath` routing (both definition copies, kept byte-identical).

## Verification

Live on UE 5.8 (fresh server against an open editor):
- `blueprintPath` + `componentName` → `success:true` with the component's CDO data + routing note (previously `Invalid actorName`)
- targetless call → loud error naming both routes
- world-actor path (`actorName`) → unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)