### PR TITLE
fix(environment): default a landscape name when none is provided

### DIFF
--- a/src/tools/handlers/environment/environment-landscape-actions.ts
+++ b/src/tools/handlers/environment/environment-landscape-actions.ts
@@ -14,8 +14,12 @@ export async function handleEnvironmentLandscapeAction(
       const componentCount = argsTyped.componentCount;
       const componentsX = typeof componentCount === 'object' ? componentCount.x : undefined;
       const componentsY = typeof componentCount === 'object' ? componentCount.y : undefined;
+      // Default a plain actor name when omitted (mirrors the procedural handler): the C++ requires a non-empty,
+      // path-char-free name and otherwise fails INVALID_ARGUMENT — an empty `name` was the common failure.
+      const rawName = typeof argsTyped.name === 'string' ? argsTyped.name.trim() : '';
+      const landscapeName = rawName || `Landscape_${Date.now()}`;
       return cleanObject(await executeAutomationRequest(tools, 'create_landscape', {
-        name: argsTyped.name ?? '',
+        name: landscapeName,
         location: vec3ToArray(argsTyped.location),
         sizeX: argsRecord.sizeX as number | undefined,
         sizeY: argsRecord.sizeY as number | undefined,


### PR DESCRIPTION
## Problem
`create_landscape` requires a non-empty, path-character-free `name` and otherwise fails `INVALID_ARGUMENT`. The handler forwarded `name: argsTyped.name ?? ''`, so omitting the name sent an empty string and every nameless `create_landscape` call failed.

## Fix
Mirror the sibling procedural-terrain handler: trim the provided name and fall back to a generated `Landscape_<timestamp>` when empty. Single-file change in `environment-landscape-actions.ts`.

## Verification
Live-tested against a running UE 5.8 editor: `create_landscape` with no `name` now succeeds (`Landscape_<ts>`) where it previously returned `INVALID_ARGUMENT`.