### PR TITLE
fix(inspect): route get_components to inspect_cdo for a Blueprint target

### DIFF
--- a/src/tools/handlers/inspect/inspect-components.ts
+++ b/src/tools/handlers/inspect/inspect-components.ts
@@ -101,7 +101,29 @@ export async function resolveComponentObjectPathFromArgs(args: HandlerArgs, tool
 
 export async function handleGetComponents(context: InspectHandlerContext): Promise<Record<string, unknown>> {
   const actorName = await resolveObjectPath(context.args, context.tools, { pathKeys: [], actorKeys: ['actorName', 'name', 'objectPath'] });
-  if (!actorName) throw new Error('Invalid actorName');
+  if (!actorName) {
+    // Blueprint/CDO shape (mirrors handleGetComponentDetails): callers with a Blueprint but no spawned actor
+    // pass a blueprintPath here. Instead of failing, list the Blueprint's DEFAULT components via inspect_cdo
+    // (no actor spawn). Closes the get_components TOOL_EXECUTION_FAILED for Blueprint targets.
+    const blueprintPath = context.inspectArgs.blueprintPath
+      || (typeof context.normalizedArgs.blueprintPath === 'string' ? context.normalizedArgs.blueprintPath : '')
+      || (typeof context.normalizedArgs.assetPath === 'string' ? context.normalizedArgs.assetPath : '');
+    if (blueprintPath) {
+      const cdoResult = await executeAutomationRequest(context.tools, 'inspect', {
+        ...context.normalizedArgs,
+        action: 'inspect_cdo',
+        blueprintPath
+      }) as Record<string, unknown>;
+      return cleanObject({
+        ...cdoResult,
+        note: 'get_components inspects world actors; the blueprintPath argument was routed to inspect_cdo (Blueprint default/CDO components).'
+      }) as Record<string, unknown>;
+    }
+    throw new Error(
+      'Invalid actorName: get_components inspects WORLD actors (pass actorName). ' +
+      'For a Blueprint\'s default components, pass blueprintPath (routed to inspect_cdo).'
+    );
+  }
 
   return cleanObject(await executeAutomationRequest(
     context.tools,

--- a/src/tools/handlers/inspect/inspect-components.ts
+++ b/src/tools/handlers/inspect/inspect-components.ts
@@ -105,9 +105,10 @@ export async function handleGetComponents(context: InspectHandlerContext): Promi
     // Blueprint/CDO shape (mirrors handleGetComponentDetails): callers with a Blueprint but no spawned actor
     // pass a blueprintPath here. Instead of failing, list the Blueprint's DEFAULT components via inspect_cdo
     // (no actor spawn). Closes the get_components TOOL_EXECUTION_FAILED for Blueprint targets.
+    // Only a Blueprint path routes to inspect_cdo (which is Blueprint-only); a generic assetPath is NOT accepted
+    // here so non-Blueprint assets stay out of the CDO path.
     const blueprintPath = context.inspectArgs.blueprintPath
-      || (typeof context.normalizedArgs.blueprintPath === 'string' ? context.normalizedArgs.blueprintPath : '')
-      || (typeof context.normalizedArgs.assetPath === 'string' ? context.normalizedArgs.assetPath : '');
+      || (typeof context.normalizedArgs.blueprintPath === 'string' ? context.normalizedArgs.blueprintPath : '');
     if (blueprintPath) {
       const cdoResult = await executeAutomationRequest(context.tools, 'inspect', {
         ...context.normalizedArgs,


### PR DESCRIPTION
## Problem
`get_components` resolves a world actor and throws `Invalid actorName` when called against a Blueprint (a `blueprintPath` with no spawned actor) — `TOOL_EXECUTION_FAILED`.

## Fix
Mirror the existing `get_component_details` fallback: when no world actor resolves but a `blueprintPath` is supplied, delegate to `inspect_cdo`, which returns the Blueprint's default (CDO) components without spawning an actor. Single-file change in `inspect-components.ts`.

## Verification
Live-tested against a running UE 5.8 editor: `get_components` with a `blueprintPath` now returns the CDO component list (7 components on a GAS character Blueprint) instead of failing.