### PR TITLE
fix(effect): add the default emitter to the implicit Niagara authoring system

### DIFF
--- a/src/tools/handlers/effect/effect-handler-state.ts
+++ b/src/tools/handlers/effect/effect-handler-state.ts
@@ -127,6 +127,25 @@ export async function ensureDefaultNiagaraAuthoringAssets(tools: ITools): Promis
         ? emitterPayload.emitterPath
         : makeGameObjectPath(DEFAULT_EFFECT_SAVE_PATH, DEFAULT_NIAGARA_AUTHORING_EMITTER_ASSET_NAME);
 
+      // BUG-6b79a9 / BUG-f59b2c: the emitter asset above is created STANDALONE and was never added to the
+      // system, so the implicit default authoring system had 0 emitter handles → every add_*_module /
+      // add_*_renderer call failed EMITTER_NOT_FOUND ("The system has 0 emitter(s)"). Add the emitter to the
+      // system under the well-known handle name (DEFAULT_NIAGARA_EMITTER_NAME = 'DefaultEmitter'), which is
+      // exactly the name the authoring actions default to, so the module/renderer handlers resolve it.
+      const addEmitterResult = await executeAutomationRequest(tools, 'manage_niagara_authoring', {
+        // Direct dispatch bypasses effect-argument-normalization (which copies action→subAction), so the C++
+        // handler's required `subAction` must be set explicitly here.
+        action: 'add_emitter_to_system',
+        subAction: 'add_emitter_to_system',
+        systemPath,
+        emitterPath,
+        emitterName: DEFAULT_NIAGARA_EMITTER_NAME,
+        save: false,
+      }) as Record<string, unknown>;
+      if (addEmitterResult.success === false) {
+        throw new Error(`Failed to add default emitter to authoring system: ${String(addEmitterResult.message || addEmitterResult.error || 'unknown error')}`);
+      }
+
       return {
         systemPath,
         emitterPath,


### PR DESCRIPTION
## Problem
When an effect authoring action (`add_spawn_rate_module`, `add_sprite_renderer_module`, …) is called without an explicit `systemPath`, `ensureDefaultNiagaraAuthoringAssets` creates a default system and a standalone emitter asset — but never adds the emitter to the system. The system therefore has **0 emitter handles**, and every module/renderer call fails `EMITTER_NOT_FOUND` ("The system has 0 emitter(s)").

## Fix
After creating the default assets, call `add_emitter_to_system` under the well-known handle name (`DefaultEmitter`) that the authoring actions default to, so the module/renderer handlers resolve it. A direct dispatch bypasses the argument normalization that copies `action`→`subAction`, so `subAction` is set explicitly.

## Verification
Live-tested against a running UE 5.8 editor: nameless `add_spawn_rate_module` and `add_sprite_renderer_module` now succeed on the implicit default system where they previously returned `EMITTER_NOT_FOUND`.