### PR TITLE
fix(inspect): make get_level_details return the level/world summary

### DIFF
--- a/src/tools/handlers/inspect/inspect-actions.ts
+++ b/src/tools/handlers/inspect/inspect-actions.ts
@@ -27,7 +27,9 @@ const INSPECT_ACTION_ALIASES: Record<string, string> = {
   get_texture_details: 'inspect_object',
   get_mesh_details: 'inspect_object',
   get_blueprint_details: 'inspect_object',
-  get_level_details: 'inspect_object',
+  // A level/world has no `objectPath`, so aliasing to inspect_object failed 'Invalid objectPath'. Route to
+  // get_world_settings, which returns the level summary (worldName/levelName/packageName/gravity/killZ/time).
+  get_level_details: 'get_world_settings',
   get_project_settings: 'get_project_settings',
   get_editor_settings: 'get_editor_settings',
   get_performance_stats: 'get_performance_stats',

--- a/src/tools/handlers/inspect/inspect-handlers.ts
+++ b/src/tools/handlers/inspect/inspect-handlers.ts
@@ -50,10 +50,14 @@ export async function handleInspectTools(action: string, args: HandlerArgs, tool
       const globalResult = await handleGlobalInspectAction(normalizedAction, context);
       if (globalResult) return globalResult;
 
+      // Forward the NORMALIZED action so an alias survives to the C++ layer (BUG-67fa5c: get_level_details is
+      // aliased to get_world_settings, which is handled C++-side; passing raw `args` kept action=
+      // get_level_details → the object-required path fired 'objectPath, actorName, or name required'). For every
+      // non-aliased action normalizedAction === args.action, so this is a no-op there.
       return cleanObject(await executeAutomationRequest(
         tools,
         'inspect',
-        args,
+        { ...args, action: normalizedAction },
         'Automation bridge not available for inspect operations'
       )) as Record<string, unknown>;
     }


### PR DESCRIPTION
## Problem
`get_level_details` was aliased to `inspect_object`, but a level/world has no `objectPath`, so the call failed `INVALID_ARGUMENT` ("objectPath, actorName, or name required").

## Fix
Two small changes:
1. Alias `get_level_details` → `get_world_settings`, which returns the level summary (worldName / levelName / packageName / gravity / killZ / time).
2. In `inspect-handlers`, the default-branch fallback now forwards `{ ...args, action: normalizedAction }` instead of raw `args`, so the alias survives to the native layer (`get_world_settings` is handled there, not in `GLOBAL_INSPECT_ACTIONS`; the old fallback kept `action=get_level_details`). For every non-aliased action `normalizedAction === args.action`, so this is a no-op.

## Verification
Live-tested against a running UE 5.8 editor: `get_level_details` now returns the world/level summary (worldName, levelName, gravity, killZ, …) where it previously failed.