### PR TITLE
fix(blueprint): support enabling/disabling a node in set_node_property

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersNodeMutations.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersNodeMutations.cpp
@@ -183,6 +183,10 @@ static bool SetNodeProperty(FActionContext& Context)
                            ? ENodeEnabledState::Disabled
                            : ENodeEnabledState::Enabled;
         }
+        else if (Value.Equals(TEXT("Enabled"), ESearchCase::IgnoreCase))
+        {
+            NewState = ENodeEnabledState::Enabled;
+        }
         else if (Value.Equals(TEXT("Disabled"), ESearchCase::IgnoreCase))
         {
             NewState = ENodeEnabledState::Disabled;
@@ -192,6 +196,17 @@ static bool SetNodeProperty(FActionContext& Context)
                      ESearchCase::IgnoreCase))
         {
             NewState = ENodeEnabledState::DevelopmentOnly;
+        }
+        else
+        {
+            // Reject an unrecognized EnabledState string instead of silently treating it as Enabled, so a typo
+            // (e.g. "Disable") is reported rather than leaving the node in the wrong state under a success reply.
+            Context.SendError(
+                FString::Printf(
+                    TEXT("Invalid EnabledState '%s' (expected Enabled, Disabled, or DevelopmentOnly)"),
+                    *Value),
+                TEXT("INVALID_ARGUMENT"));
+            return true;
         }
         TargetNode->SetEnabledState(NewState);
         bHandled = true;

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersNodeMutations.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersNodeMutations.cpp
@@ -170,6 +170,32 @@ static bool SetNodeProperty(FActionContext& Context)
         TargetNode->bCommentBubblePinned = Value.ToBool();
         bHandled = true;
     }
+    else if (
+        PropertyName.Equals(TEXT("EnabledState"), ESearchCase::IgnoreCase) ||
+        PropertyName.Equals(TEXT("bDisabled"), ESearchCase::IgnoreCase))
+    {
+        // Enable/disable a node (BUG-d870cf: the set was previously comment/position-only). "bDisabled" takes a
+        // bool; "EnabledState" also accepts the enum names Enabled / Disabled / DevelopmentOnly.
+        ENodeEnabledState NewState = ENodeEnabledState::Enabled;
+        if (PropertyName.Equals(TEXT("bDisabled"), ESearchCase::IgnoreCase))
+        {
+            NewState = Value.ToBool()
+                           ? ENodeEnabledState::Disabled
+                           : ENodeEnabledState::Enabled;
+        }
+        else if (Value.Equals(TEXT("Disabled"), ESearchCase::IgnoreCase))
+        {
+            NewState = ENodeEnabledState::Disabled;
+        }
+        else if (Value.Equals(
+                     TEXT("DevelopmentOnly"),
+                     ESearchCase::IgnoreCase))
+        {
+            NewState = ENodeEnabledState::DevelopmentOnly;
+        }
+        TargetNode->SetEnabledState(NewState);
+        bHandled = true;
+    }
 
     if (!bHandled)
     {


### PR DESCRIPTION
## Problem
`set_node_property` supported only comment and node-position fields; every other property (including enabling/disabling a node) returned `PROPERTY_NOT_SUPPORTED`.

## Fix
Add two properties, both mapped to `UEdGraphNode::SetEnabledState`:
- `bDisabled` (bool) — disable/enable the node.
- `EnabledState` (string) — accepts `Enabled` / `Disabled` / `DevelopmentOnly`.

## Verification
Live-tested (Live Coding, running UE 5.8 editor): `set_node_property` with `bDisabled=true` returned `Node property updated` on a real graph node where it previously returned `PROPERTY_NOT_SUPPORTED`; the node was restored afterwards.