### PR TITLE
fix(inspect): measure the PIE world in get_performance_stats

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Environment/Inspection/McpAutomationBridge_EnvironmentHandlersInspectSettings.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Environment/Inspection/McpAutomationBridge_EnvironmentHandlersInspectSettings.cpp
@@ -182,7 +182,28 @@ bool HandleInspectSettingsAction(
         // ---------------------------------------------------------------------
         else if (LowerSubAction.Equals(TEXT("get_performance_stats")))
         {
-            const double DeltaSeconds = FApp::GetDeltaTime();
+            // BUG-e85282: when a PIE/play session is active, measure THAT world (actor count + frame delta), not
+            // the editor world. GEditor->PlayWorld is the active PIE world (nullptr outside PIE). The thread
+            // timers below are process-global (they reflect whatever the engine is ticking) — flagged as such.
+            double DeltaSeconds = FApp::GetDeltaTime();
+            UWorld* StatWorld = nullptr;
+            FString WorldType = TEXT("None");
+            if (GEditor && GEditor->PlayWorld)
+            {
+                StatWorld = GEditor->PlayWorld;
+                WorldType = TEXT("PIE");
+                const double PieDelta = StatWorld->GetDeltaSeconds();
+                if (PieDelta > 0.0)
+                {
+                    DeltaSeconds = PieDelta;
+                }
+            }
+            else if (GEditor && GEditor->GetEditorWorldContext().World())
+            {
+                StatWorld = GEditor->GetEditorWorldContext().World();
+                WorldType = TEXT("Editor");
+            }
+
             const double FrameTimeMs = DeltaSeconds > 0.0 ? DeltaSeconds * 1000.0 : 0.0;
             const double EstimatedFps = DeltaSeconds > 0.0 ? 1.0 / DeltaSeconds : 0.0;
             const double GameThreadMs = FPlatformTime::ToMilliseconds(GGameThreadTime);
@@ -191,16 +212,17 @@ bool HandleInspectSettingsAction(
             const double GPUFrameMs = FPlatformTime::ToMilliseconds(RHIGetGPUFrameCycles());
 
             int32 ActorCount = 0;
-            if (GEditor && GEditor->GetEditorWorldContext().World())
+            if (StatWorld)
             {
-                UWorld* World = GEditor->GetEditorWorldContext().World();
-                for (TActorIterator<AActor> It(World); It; ++It)
+                for (TActorIterator<AActor> It(StatWorld); It; ++It)
                 {
                     ActorCount++;
                 }
             }
 
             Resp->SetBoolField(TEXT("success"), true);
+            Resp->SetStringField(TEXT("worldType"), WorldType);
+            Resp->SetBoolField(TEXT("threadTimersAreProcessGlobal"), true);
             Resp->SetNumberField(TEXT("deltaSeconds"), DeltaSeconds);
             Resp->SetNumberField(TEXT("frameTimeMs"), FrameTimeMs);
             Resp->SetNumberField(TEXT("estimatedFps"), EstimatedFps);


### PR DESCRIPTION
## Problem
`get_performance_stats` always measured the editor world: actor count came from `GetEditorWorldContext().World()` and frame timing from `FApp::GetDeltaTime()`. During a play session it therefore reported the editor loop (e.g. the ~3 FPS editor background throttle) and the editor world's actors, not the game.

## Fix
When a PIE session is active (`GEditor->PlayWorld`), select that world for the actor count and frame delta. Add a `worldType` field (`PIE`/`Editor`) and a `threadTimersAreProcessGlobal` flag (the thread timers are process-global and unchanged).

## Verification
Live-tested (Live Coding, running UE 5.8 editor): `get_performance_stats` now reports `worldType` and, outside PIE, `Editor`; the world-selection + new fields are live.