### PR TITLE
fix(build): UE 5.8 compile fixes for Sequence/MovieRender/TakeRecorder + native transport

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Sequence/Cinematics/McpAutomationBridge_SequenceCinematicsShotSettings.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Sequence/Cinematics/McpAutomationBridge_SequenceCinematicsShotSettings.cpp
@@ -1,5 +1,7 @@
 #include "Domains/Sequence/Cinematics/McpAutomationBridge_SequenceCinematics.h"
 
+#include "Domains/Sequence/McpAutomationBridge_SequenceHandlersEditorSupport.h"
+
 #if WITH_EDITOR
 #include "MovieScene.h"
 #include "Sections/MovieSceneCinematicShotSection.h"

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Sequence/McpAutomationBridge_SequencePathSecurity.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Sequence/McpAutomationBridge_SequencePathSecurity.cpp
@@ -1,5 +1,6 @@
 #include "Domains/Sequence/McpAutomationBridge_SequencePathSecurity.h"
 
+#include "GenericPlatform/GenericPlatformFile.h"
 #include "HAL/PlatformFileManager.h"
 #include "Misc/PackageName.h"
 #include "Misc/Paths.h"

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Sequence/MovieRender/McpAutomationBridge_SequenceMovieRenderExecutor.h
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Sequence/MovieRender/McpAutomationBridge_SequenceMovieRenderExecutor.h
@@ -3,6 +3,7 @@
 #include "Core/Compatibility/McpVersionCompatibility.h"
 #include "CoreMinimal.h"
 #include "Dom/JsonObject.h"
+#include "Templates/SubclassOf.h"
 
 #if MCP_HAS_MOVIE_RENDER_PIPELINE
 

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Sequence/MovieRender/McpAutomationBridge_SequenceMovieRenderJobCreation.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Sequence/MovieRender/McpAutomationBridge_SequenceMovieRenderJobCreation.cpp
@@ -3,6 +3,7 @@
 #if MCP_HAS_MOVIE_RENDER_PIPELINE
 
 #include "Domains/Sequence/MovieRender/McpAutomationBridge_SequenceMovieRenderInternal.h"
+#include "Domains/Sequence/MovieRender/McpAutomationBridge_SequenceMovieRenderResourceLimits.h"
 
 #include "EditorAssetLibrary.h"
 #include "Engine/World.h"

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Sequence/MovieRender/McpAutomationBridge_SequenceMovieRenderOutput.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Sequence/MovieRender/McpAutomationBridge_SequenceMovieRenderOutput.cpp
@@ -5,6 +5,7 @@
 #include "Domains/Sequence/McpAutomationBridge_SequencePathSecurity.h"
 #include "Domains/Sequence/McpAutomationBridge_SequenceFrameRate.h"
 #include "Domains/Sequence/MovieRender/McpAutomationBridge_SequenceMovieRenderInternal.h"
+#include "Domains/Sequence/MovieRender/McpAutomationBridge_SequenceMovieRenderResourceLimits.h"
 
 #include "Foundation/HandlerUtils/McpHandlerUtils.h"
 #include "McpAutomationBridgeSubsystem.h"

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Sequence/MovieRender/McpAutomationBridge_SequenceMovieRenderOutputProof.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Sequence/MovieRender/McpAutomationBridge_SequenceMovieRenderOutputProof.cpp
@@ -164,7 +164,7 @@ void CaptureRenderOutputData(const FMoviePipelineOutputData &OutputData,
     for (const TPair<FMoviePipelinePassIdentifier,
                      FMoviePipelineRenderPassOutputData> &Pass :
          Shot.RenderPassData) {
-      State->ReportedRenderPasses.Add(Pass.Key.Name.ToString());
+      State->ReportedRenderPasses.Add(Pass.Key.Name);
       for (const FString &File : Pass.Value.FilePaths)
         State->ReportedOutputFiles.Add(File);
     }

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Sequence/RecordReplay/McpAutomationBridge_SequenceTakeRecorderResults.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Sequence/RecordReplay/McpAutomationBridge_SequenceTakeRecorderResults.cpp
@@ -1,5 +1,6 @@
 #include "Domains/Sequence/RecordReplay/McpAutomationBridge_SequenceTakeRecorderInternal.h"
 
+#include "Core/Compatibility/McpVersionCompatibility.h"
 #include "Containers/Ticker.h"
 #if MCP_HAS_MOVIE_SCENE_SHOT_METADATA
 #include "MetaData/MovieSceneShotMetaData.h"

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Transport/McpNativeTransportConnection.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Transport/McpNativeTransportConnection.cpp
@@ -220,7 +220,11 @@ void FMcpNativeTransport::HandleConnection(FSocket* ClientSocket)
 		{
 			TSharedRef<FInternetAddr> RemoteAddr =
 				ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM)->CreateInternetAddr();
-			if (ClientSocket->GetAddress(*RemoteAddr))
+			// FSocket::GetAddress is void as of UE 5.8 (was bool in earlier
+			// versions); it populates RemoteAddr unconditionally, so there is
+			// no success check to branch on anymore.
+			ClientSocket->GetAddress(*RemoteAddr);
+			if (RemoteAddr->IsValid())
 			{
 				ConnectionRemoteAddr = RemoteAddr->ToString(true);
 			}


### PR DESCRIPTION
## Problem
On UE 5.8 a full (non-unity / clean) build of the plugin fails with compile errors across the Sequence, MovieRender and TakeRecorder handlers, plus one in the native transport. Seven files relied on includes that only arrived transitively via unity-build blob adjacency, one file called a method that does not exist on the field's actual type, and one call site used a UE API whose signature changed in 5.8.

## Fix (all surgical, single-line or include-only)
- `SequenceCinematicsShotSettings.cpp` — include the editor-support header (carries `LevelSequence.h`); `ULevelSequence` was only forward-declared here while every sibling includes it.
- `SequencePathSecurity.cpp` — include `GenericPlatform/GenericPlatformFile.h` for the full `IPlatformFile`/`ESymlinkResult` definitions (`HAL/PlatformFileManager.h` only forward-declares).
- `SequenceMovieRenderExecutor.h` — include `Templates/SubclassOf.h` (`TSubclassOf` is not in CoreMinimal) in this public header.
- `SequenceMovieRenderJobCreation.cpp` + `SequenceMovieRenderOutput.cpp` — include the resource-limits header that declares `ValidateQueueResourceLimits`/`ValidateJobResourceLimits` (their siblings already do).
- `SequenceMovieRenderOutputProof.cpp` — remove a stray `.ToString()` on `FMoviePipelinePassIdentifier::Name`, which is already an `FString`.
- `SequenceTakeRecorderResults.cpp` — include the version-compatibility header that defines `MCP_HAS_MOVIE_SCENE_SHOT_METADATA`.
- `McpNativeTransportConnection.cpp` — `FSocket::GetAddress` is `void` in UE 5.8 (was `bool`); call unconditionally and check `RemoteAddr->IsValid()` instead.

## Verification
Full editor-target build on UE 5.8 (Development Editor, Win64): **Succeeded** — 98 Sequence/MovieRender/TakeRecorder/RecordReplay compile actions with 0 errors. Live check after the build: `manage_sequence` action surface registered and `list` returns project sequences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)