### PR TITLE
fix(inspect): route blueprintPath in get_component_property to the CDO component template

### DIFF
--- a/src/tools/handlers/inspect/inspect-components.ts
+++ b/src/tools/handlers/inspect/inspect-components.ts
@@ -140,7 +140,60 @@ export async function handleGetComponentProperty(context: InspectHandlerContext)
     { key: 'componentName', required: true },
     { key: 'propertyName', aliases: ['propertyPath'], required: true }
   ]);
-  if (!actorName) throw new Error('Invalid actorName: required to resolve componentName');
+  if (!actorName) {
+    // Blueprint/CDO shape (mirrors handleGetComponents): callers with a Blueprint but no spawned actor
+    // pass a blueprintPath here. Route to inspect_cdo and pick the requested property off the CDO
+    // component template instead of failing. Only a Blueprint path routes to inspect_cdo.
+    const blueprintPath = context.inspectArgs.blueprintPath
+      || (typeof context.normalizedArgs.blueprintPath === 'string' ? context.normalizedArgs.blueprintPath : '');
+    if (blueprintPath) {
+      const componentName = extractString(params, 'componentName');
+      const propertyName = extractString(params, 'propertyName');
+      const note = 'get_component_property inspects world actors; the blueprintPath argument was routed to inspect_cdo (CDO component template property).';
+      const cdoResult = await executeAutomationRequest(context.tools, 'inspect', {
+        ...context.normalizedArgs,
+        action: 'inspect_cdo',
+        blueprintPath,
+        componentName
+      }) as Record<string, unknown>;
+      const resultData = cdoResult.result as Record<string, unknown> | undefined;
+      const rawProperties = (resultData && resultData.properties) ?? cdoResult.properties;
+      const properties = (typeof rawProperties === 'object' && rawProperties !== null)
+        ? rawProperties as Record<string, unknown>
+        : undefined;
+      if (!properties) {
+        // No property map (e.g. BLUEPRINT_NOT_FOUND / COMPONENT_NOT_FOUND) — surface the CDO result as-is.
+        return cleanObject({ ...cdoResult, note }) as Record<string, unknown>;
+      }
+      // Intentional shape divergence from the world-actor path below: the CDO branch returns a
+      // normalized {success, blueprintPath, componentName, propertyName, value, note} envelope,
+      // while the actor path forwards the raw control_actor response (best-effort, sibling-handler style).
+      const matchedKey = Object.keys(properties).find(k => k.toLowerCase() === propertyName.toLowerCase());
+      if (matchedKey === undefined) {
+        return cleanObject({
+          success: false,
+          error: 'PROPERTY_NOT_FOUND',
+          message: `Property not found on CDO component template: ${propertyName}`,
+          blueprintPath,
+          componentName,
+          availableProperties: Object.keys(properties),
+          note
+        }) as Record<string, unknown>;
+      }
+      return cleanObject({
+        success: true,
+        blueprintPath,
+        componentName,
+        propertyName: matchedKey,
+        value: properties[matchedKey],
+        note
+      }) as Record<string, unknown>;
+    }
+    throw new Error(
+      'Invalid actorName: get_component_property inspects WORLD actors (pass actorName). ' +
+      'For a Blueprint component default, pass blueprintPath (routed to inspect_cdo).'
+    );
+  }
 
   return cleanObject(await executeAutomationRequest(context.tools, 'control_actor', {
     action: 'get_component_property',


### PR DESCRIPTION
## Problem
`inspect.get_component_property` hard-failed with `Invalid actorName: required to resolve componentName` when called with a `blueprintPath` and no spawned world actor — even though `get_components` (and `get_component_details`) already route a Blueprint target to `inspect_cdo`.

## Fix
Apply the same route in `handleGetComponentProperty`: with no resolvable actor and a `blueprintPath` present, call `inspect_cdo` with the component name and pick the requested property off the CDO component template (case-insensitive match; the canonical property key is echoed back). An unknown property returns `PROPERTY_NOT_FOUND` with `availableProperties[]`; CDO-level errors (`BLUEPRINT_NOT_FOUND`/`COMPONENT_NOT_FOUND`) surface as-is with a routing note. The world-actor path is unchanged, and the no-blueprintPath error message now explains both options.

## Verification (live editor, UE 5.8)
- `blueprintPath:/Game/SplineBP componentName:DefaultSceneRoot propertyName:Mobility` → `success:true, value:"Movable"` + routing note (previously the hard failure above).
- Unknown property → `PROPERTY_NOT_FOUND` + available names; unknown component → `COMPONENT_NOT_FOUND`.
- Regression: world-actor call (`Floor`/`StaticMeshComponent0`/`Mobility`) unchanged → `Movable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)