### PR TITLE
fix(inspect): delete_object hints at manage_asset when given an asset path

### DIFF
--- a/src/tools/handlers/inspect/inspect-actor-actions.ts
+++ b/src/tools/handlers/inspect/inspect-actor-actions.ts
@@ -10,6 +10,18 @@ async function cleanControlActorAction(
   return cleanObject(await executeAutomationRequest(context.tools, 'control_actor', payload) as Record<string, unknown>);
 }
 
+function assetPathGuidance(actorName: string | undefined): string | undefined {
+  // delete_object deletes WORLD actors by name; a content path (/Game/..., /Engine/...) is an ASSET
+  // reference and will never match an actor. Point the caller at the right tool instead of leaving an
+  // ambiguous NOT_FOUND (no silent cross-routing: deletion is destructive, the caller must re-target).
+  // The ':' subobject delimiter marks a world OBJECT path (/Game/Map.Map:PersistentLevel.Actor_1) —
+  // a legitimate actor reference, not an asset — so it must not get the asset hint.
+  if (actorName && /^\/(Game|Engine)\//i.test(actorName) && !actorName.includes(':')) {
+    return 'delete_object deletes WORLD actors by name; this looks like an ASSET path. To delete an asset, use manage_asset with action:delete.';
+  }
+  return undefined;
+}
+
 function handledNotFoundResponse(res: InspectResponse, actorName: string): Record<string, unknown> | undefined {
   if (res.success !== false) return undefined;
   const message = String(res.message || res.error || '');
@@ -21,7 +33,8 @@ function handledNotFoundResponse(res: InspectResponse, actorName: string): Recor
       handled: true,
       message,
       deleted: actorName,
-      notFound: true
+      notFound: true,
+      hint: assetPathGuidance(actorName)
     });
   }
   return cleanObject({ ...res, handled: true, notFound: lower.includes('not found') });
@@ -46,7 +59,8 @@ async function handleDeleteObject(context: InspectHandlerContext): Promise<Recor
         handled: true,
         message,
         deleted: actorName,
-        notFound: true
+        notFound: true,
+        hint: assetPathGuidance(actorName)
       });
     }
     throw error;


### PR DESCRIPTION
## Problem
`inspect.delete_object` deletes WORLD actors, but callers frequently pass an asset content path (`/Game/...`). The path is looked up as an actor name, the call returns a bare `NOT_FOUND` ("Actors not found"), and the asset stays on disk — which reads like a broken delete rather than a re-targeting problem.

## Fix
When the NOT_FOUND paths fire and the target is package-path-shaped (`/Game/…`, `/Engine/…`), the response now carries a `hint`: *"delete_object deletes WORLD actors by name; this looks like an ASSET path. To delete an asset, use manage_asset with action:delete."* Deliberately no silent cross-routing — deletion is destructive, the caller must re-target. `:`-delimited world OBJECT paths (`/Game/Map.Map:PersistentLevel.Actor`) are legitimate actor references and do not get the hint; plain actor-name responses keep their exact shape (the undefined hint is stripped).

## Verification (live editor, UE 5.8)
- Asset path target → `NOT_FOUND` + hint.
- `:` object-path target → `NOT_FOUND`, no hint.
- Plain actor name → `NOT_FOUND`, no hint (shape unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)