### PR TITLE
fix(gas): get_gas_info accepts blueprintPath and states gasType None explicitly

### DIFF
--- a/src/tools/handlers/gas/gas-handlers.ts
+++ b/src/tools/handlers/gas/gas-handlers.ts
@@ -20,6 +20,15 @@ export async function handleGASTools(
     };
   }
 
+  if (action === 'get_gas_info' && typeof context.argsRecord.assetPath !== 'string') {
+    // get_gas_info inspects ANY GAS-relevant asset, so it takes the generic assetPath — but callers
+    // coming from the blueprint/inspect tools naturally pass blueprintPath (or path). Alias them
+    // instead of failing validation on a naming difference.
+    const alias = [context.argsRecord.blueprintPath, context.argsRecord.path]
+      .find((v): v is string => typeof v === 'string' && v.trim().length > 0);
+    if (alias) context.argsRecord.assetPath = alias.trim();
+  }
+
   validateGASRequiredFields(context.argsRecord, route.requiredFields);
 
   if (route.kind === 'create_gameplay_effect') {
@@ -29,5 +38,21 @@ export async function handleGASTools(
     return await handleAddTagToAsset(context);
   }
 
-  return await sendGASRequest(context, action, route.blueprintPathParam);
+  const response = await sendGASRequest(context, action, route.blueprintPathParam);
+
+  if (action === 'get_gas_info' && response && response.success === true) {
+    // Make "no GAS here" explicit: a successful inspection of a non-GAS asset returns no gasType,
+    // which reads as an incomplete answer. State it instead of leaving the field absent.
+    const resultData = response.result as Record<string, unknown> | undefined;
+    if (resultData && typeof resultData === 'object' && typeof resultData.gasType !== 'string') {
+      try {
+        resultData.gasType = 'None';
+        resultData.gasNote = 'No GAS parent class detected (not a GameplayAbility/GameplayEffect/AttributeSet/GameplayCue derivative and no AbilitySystemComponent found).';
+      } catch {
+        // Best-effort clarity only — a frozen/sealed result must not turn a successful inspection into a failure.
+      }
+    }
+  }
+
+  return response;
 }

--- a/src/tools/handlers/gas/gas-handlers.ts
+++ b/src/tools/handlers/gas/gas-handlers.ts
@@ -20,10 +20,13 @@ export async function handleGASTools(
     };
   }
 
-  if (action === 'get_gas_info' && typeof context.argsRecord.assetPath !== 'string') {
+  const existingAssetPath = context.argsRecord.assetPath;
+  const assetPathMissing = typeof existingAssetPath !== 'string' || existingAssetPath.trim().length === 0;
+  if (action === 'get_gas_info' && assetPathMissing) {
     // get_gas_info inspects ANY GAS-relevant asset, so it takes the generic assetPath — but callers
     // coming from the blueprint/inspect tools naturally pass blueprintPath (or path). Alias them
-    // instead of failing validation on a naming difference.
+    // instead of failing validation on a naming difference. Treat an empty/whitespace assetPath as
+    // missing too, so a supplied blueprintPath still gets used.
     const alias = [context.argsRecord.blueprintPath, context.argsRecord.path]
       .find((v): v is string => typeof v === 'string' && v.trim().length > 0);
     if (alias) context.argsRecord.assetPath = alias.trim();
@@ -47,7 +50,7 @@ export async function handleGASTools(
     if (resultData && typeof resultData === 'object' && typeof resultData.gasType !== 'string') {
       try {
         resultData.gasType = 'None';
-        resultData.gasNote = 'No GAS parent class detected (not a GameplayAbility/GameplayEffect/AttributeSet/GameplayCue derivative and no AbilitySystemComponent found).';
+        resultData.gasNote = 'No GAS parent class detected (not a GameplayAbility/GameplayEffect/AttributeSet/GameplayCue derivative).';
       } catch {
         // Best-effort clarity only — a frozen/sealed result must not turn a successful inspection into a failure.
       }


### PR DESCRIPTION
## Problem
Two argument-DX gaps in `manage_gas.get_gas_info`:
1. The route only accepts `assetPath`; callers coming from the blueprint/inspect tools naturally pass `blueprintPath` (or `path`) and get `Missing required parameter: assetPath`.
2. A successful inspection of a non-GAS asset returns no `gasType` field at all, which reads as an incomplete answer rather than a clear "no GAS here".

## Fix
- Pre-validation alias for `get_gas_info` only: `blueprintPath`/`path` → `assetPath` (trimmed; existing `assetPath` callers unchanged).
- A successful result without a `gasType` now states `gasType:"None"` plus a `gasNote` explaining that no GAS parent class was detected. The enrichment is best-effort (`try/catch`) so it can never turn a successful inspection into a failure.

## Verification (live editor, UE 5.8)
- `blueprintPath` on a GameplayAbility Blueprint → `success:true, gasType:GameplayAbility` (+policies) — previously the missing-parameter failure.
- Non-GAS Blueprint → `gasType:"None"` + note.
- Regression: `assetPath` on a GameplayEffect Blueprint → unchanged (`gasType:GameplayEffect`, `modifierCount` etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)