### PR TITLE
fix(blueprint): set_default accepts variableName as an alias for propertyName

### DIFF
--- a/src/tools/handlers/blueprint/blueprint-core-actions.ts
+++ b/src/tools/handlers/blueprint/blueprint-core-actions.ts
@@ -24,7 +24,11 @@ export const blueprintCoreHandlers: Readonly<Record<string, BlueprintActionHandl
   set_default: async (context) => await executeBlueprintRequest(context, 'blueprint_set_default', {
     blueprintCandidates: blueprintCandidates(context),
     requestedPath: blueprintTarget(context),
-    propertyName: context.argsTyped.propertyName ?? '',
+    // set_default targets a Blueprint VARIABLE's default, so callers naturally say variableName —
+    // alias it instead of failing the C++ "propertyName required" check on a naming difference.
+    propertyName: context.argsTyped.propertyName
+      ?? optionalString(context.argsRecord.variableName)
+      ?? '',
     value: context.argsTyped.value !== undefined ? context.argsTyped.value : context.argsRecord.propertyValue
   }),
   compile: async (context) => await executeBlueprintRequest(context, 'blueprint_compile', {


### PR DESCRIPTION
## Problem
`manage_blueprint.set_default` sets a Blueprint VARIABLE's default value, so callers naturally pass `variableName` — but the TS dispatch only forwards `propertyName`, and the request dies on the handler's `propertyName required` check. The underlying write path is healthy (including struct arrays such as `TArray<FVector>` from a JSON array).

## Fix
Alias `variableName` → `propertyName` in the dispatch, only when `propertyName` is absent (existing callers byte-identical; reuses the file's `optionalString` guard so a non-string value safely falls through).

## Verification (live editor, UE 5.8)
- `set_default variableName:VecArr value:[{x,y,z}…]` on a `TArray<FVector>` variable → written and confirmed via `get` defaults readback (previously `INVALID_ARGUMENT`).
- Regression: the `propertyName` form unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)