### PR TITLE
fix(material): create_material auto-creates missing parent folders

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/MaterialAuthoring/Creation/McpAutomationBridge_MaterialAuthoringHandlersCreateMaterial.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/MaterialAuthoring/Creation/McpAutomationBridge_MaterialAuthoringHandlersCreateMaterial.cpp
@@ -65,11 +65,22 @@ bool HandleCreateMaterial(UMcpAutomationBridgeSubsystem* Bridge, const FString& 
     IAssetRegistry& AssetRegistry = AssetRegistryModule.Get();
 
     FString ParentFolderPath = FPackageName::GetLongPackagePath(ValidatedPath);
+    bool bParentFolderCreated = false;
     if (!AssetRegistry.PathExists(FName(*ParentFolderPath))) {
-      Bridge->SendAutomationError(Socket, RequestId,
-                          FString::Printf(TEXT("Parent folder does not exist: %s. Create the folder first or use an existing path."), *ParentFolderPath),
-                          TEXT("PARENT_FOLDER_NOT_FOUND"));
-      return true;
+      // Auto-create the parent chain instead of failing: the path already passed sanitization and
+      // IsValidLongPackageName above, and create_folder creates parents recursively — creating an
+      // asset in a fresh folder should not require a separate call. The old error remains the
+      // fallback for when directory creation itself fails.
+      // PathExists (asset registry) can lag a folder that already exists on disk; check the
+      // directory itself so parentFolderCreated stays truthful (MakeDirectory is idempotent).
+      const bool bAlreadyOnDisk = UEditorAssetLibrary::DoesDirectoryExist(ParentFolderPath);
+      if (!UEditorAssetLibrary::MakeDirectory(ParentFolderPath)) {
+        Bridge->SendAutomationError(Socket, RequestId,
+                            FString::Printf(TEXT("Parent folder does not exist: %s. Create the folder first or use an existing path."), *ParentFolderPath),
+                            TEXT("PARENT_FOLDER_NOT_FOUND"));
+        return true;
+      }
+      bParentFolderCreated = !bAlreadyOnDisk;
     }
 
     // Check for existing asset collision to prevent UE crash
@@ -238,6 +249,9 @@ bool HandleCreateMaterial(UMcpAutomationBridgeSubsystem* Bridge, const FString& 
 
     TSharedPtr<FJsonObject> Result = McpHandlerUtils::CreateResultObject();
     McpHandlerUtils::AddVerification(Result, NewMaterial);
+    if (bParentFolderCreated) {
+      Result->SetBoolField(TEXT("parentFolderCreated"), true);
+    }
     Bridge->SendAutomationResponse(Socket, RequestId, true,
                            FString::Printf(TEXT("Material '%s' created."), *Name),
                            Result);


### PR DESCRIPTION
## Problem
`manage_asset.create_material` hard-fails with `PARENT_FOLDER_NOT_FOUND` when the target folder does not exist yet, while `create_folder` happily creates parent chains recursively — so creating an asset in a fresh folder needs an extra round-trip that agents routinely forget.

## Fix
When the asset-registry `PathExists` check fails, create the parent chain via `UEditorAssetLibrary::MakeDirectory` (the path has already passed sanitization and `IsValidLongPackageName`, so this grants no new authority) and report `parentFolderCreated:true` — truthfully, gated on an on-disk `DoesDirectoryExist` check since the registry can lag a folder that already exists. The old `PARENT_FOLDER_NOT_FOUND` remains the fallback when directory creation itself fails.

## Verification (live editor, UE 5.8)
- `create_material name:M_Deep path:/Game/…/NewParent/NewChild` (neither folder existing) → `success:true, parentFolderCreated:true, existsAfter:true` (previously the hard failure).
- Existing-folder create → unchanged, no `parentFolderCreated` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)