### PR TITLE
fix(material): set_scalar_parameter_value updates the parameter default on a base material

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/MaterialAuthoring/Parameters/McpAutomationBridge_MaterialAuthoringHandlersSetScalarParameterValue.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/MaterialAuthoring/Parameters/McpAutomationBridge_MaterialAuthoringHandlersSetScalarParameterValue.cpp
@@ -44,7 +44,7 @@ bool HandleSetScalarParameterValue(UMcpAutomationBridgeSubsystem* Bridge, const 
         const FName ParamFName(*ParamName);
         // Note: with duplicate-named ScalarParameter expressions (a graph authoring error), the last
         // match wins — same ambiguity UE itself has for duplicate parameter names.
-        for (UMaterialExpression *Expr : BaseMaterial->GetExpressions()) {
+        for (UMaterialExpression *Expr : MCP_GET_MATERIAL_EXPRESSIONS(BaseMaterial)) {
           if (UMaterialExpressionScalarParameter *Scalar =
                   Cast<UMaterialExpressionScalarParameter>(Expr)) {
             AvailableParams.Add(Scalar->ParameterName.ToString());

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/MaterialAuthoring/Parameters/McpAutomationBridge_MaterialAuthoringHandlersSetScalarParameterValue.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/MaterialAuthoring/Parameters/McpAutomationBridge_MaterialAuthoringHandlersSetScalarParameterValue.cpp
@@ -35,8 +35,54 @@ bool HandleSetScalarParameterValue(UMcpAutomationBridgeSubsystem* Bridge, const 
     UMaterialInstanceConstant *Instance =
         LoadObject<UMaterialInstanceConstant>(nullptr, *AssetPath);
     if (!Instance) {
+      // Fallback: a BASE UMaterial. Setting a "parameter value" on a base material means updating
+      // the named ScalarParameter expression's DefaultValue — do that instead of failing with a
+      // misleading ASSET_NOT_FOUND (the asset exists; it just isn't an instance).
+      if (UMaterial *BaseMaterial = LoadObject<UMaterial>(nullptr, *AssetPath)) {
+        UMaterialExpressionScalarParameter *Param = nullptr;
+        TArray<FString> AvailableParams;
+        const FName ParamFName(*ParamName);
+        // Note: with duplicate-named ScalarParameter expressions (a graph authoring error), the last
+        // match wins — same ambiguity UE itself has for duplicate parameter names.
+        for (UMaterialExpression *Expr : BaseMaterial->GetExpressions()) {
+          if (UMaterialExpressionScalarParameter *Scalar =
+                  Cast<UMaterialExpressionScalarParameter>(Expr)) {
+            AvailableParams.Add(Scalar->ParameterName.ToString());
+            if (Scalar->ParameterName == ParamFName) {
+              Param = Scalar;
+            }
+          }
+        }
+        if (!Param) {
+          Bridge->SendAutomationError(Socket, RequestId,
+                              FString::Printf(TEXT("Scalar parameter '%s' not found on base material. Available: [%s]"),
+                                              *ParamName, *FString::Join(AvailableParams, TEXT(", "))),
+                              TEXT("PARAMETER_NOT_FOUND"));
+          return true;
+        }
+        Param->DefaultValue = Value;
+        BaseMaterial->PostEditChange();
+        BaseMaterial->MarkPackageDirty();
+
+        bool bSaveBase = true;
+        Payload->TryGetBoolField(TEXT("save"), bSaveBase);
+        if (bSaveBase) {
+          SaveMaterialAsset(BaseMaterial);
+        }
+
+        TSharedPtr<FJsonObject> BaseResult = McpHandlerUtils::CreateResultObject();
+        McpHandlerUtils::AddVerification(BaseResult, BaseMaterial);
+        BaseResult->SetStringField(TEXT("parameterName"), ParamName);
+        BaseResult->SetNumberField(TEXT("value"), Value);
+        BaseResult->SetStringField(TEXT("note"), TEXT("Base material (not an instance): the ScalarParameter expression's DefaultValue was updated."));
+        Bridge->SendAutomationResponse(
+            Socket, RequestId, true,
+            FString::Printf(TEXT("Scalar parameter '%s' default set to %f on base material."),
+                            *ParamName, Value), BaseResult);
+        return true;
+      }
       Bridge->SendAutomationError(Socket, RequestId,
-                          TEXT("Could not load material instance."),
+                          TEXT("Could not load a material instance or material at this path."),
                           TEXT("ASSET_NOT_FOUND"));
       return true;
     }


### PR DESCRIPTION
## Problem
`manage_asset.set_scalar_parameter_value` only loads `UMaterialInstanceConstant`, so pointing it at a base `UMaterial` returns a misleading `ASSET_NOT_FOUND` ("Could not load material instance") even though the asset exists.

## Fix
When the instance load fails, fall back to `LoadObject<UMaterial>`: update the named `ScalarParameter` expression's `DefaultValue` (+`PostEditChange`, mark dirty, optional save) and return a success with an explanatory note that the base material's parameter default was updated. An unknown parameter returns `PARAMETER_NOT_FOUND` listing the available scalar parameter names. If neither an instance nor a material loads, the error message now says so explicitly. The instance path is untouched. (Note: with duplicate-named ScalarParameter expressions — a graph authoring error — the last match wins, same ambiguity UE itself has.)

## Verification (live editor, UE 5.8)
- Base material + existing parameter → `success:true, value:0.77` + note (previously `ASSET_NOT_FOUND`).
- Unknown parameter → `PARAMETER_NOT_FOUND` + available names.
- Regression: material instance path unchanged (override set to 0.25 verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)