### PR TITLE
fix: make execute_python fatal crashes diagnosable (#525)

### DIFF
--- a/plugins/McpAutomationBridge/README.md
+++ b/plugins/McpAutomationBridge/README.md
@@ -266,6 +266,24 @@ The plugin uses `PCHUsageMode.NoPCHs` to prevent memory issues during compilatio
 3. Regenerate project files
 4. Rebuild
 
+### Python Execution Crash Recovery
+
+`execute_python` writes temporary artifacts to `<Project>/Saved/Temp/MCP_Python/` before each run:
+
+- `mcp_exec_<executionId>.py` — generated wrapper script
+- `code_<executionId>.py` — user-provided code (inline `code` parameter only)
+- `output_<executionId>.txt`, `error_<executionId>.txt`, `status_<executionId>.txt` — captured streams
+
+On success these files are cleaned up automatically. If the editor is terminated by a fatal error during Python execution (e.g. an Engine-side assertion or access violation in native code called from Python), the cleanup does not run and the temp files remain on disk.
+
+To identify the script that was active when a crash occurred, check the editor log for the `execute_python begin:` line emitted **before** native execution:
+
+```
+LogMcpAutomationBridgeSubsystem: execute_python begin: executionId=<guid> requestId=<id> origin=WebSocket mode=ExecuteFile scope=Private codeSha256=<sha256> codePath=<path> wrapperPath=<path>
+```
+
+The `executionId` matches the suffix of the leftover `mcp_exec_<executionId>.py` / `code_<executionId>.py` files. The `codeSha256` is the SHA-256 of the executed code bytes, so the active script is identifiable without logging raw source. Crash-leftover temp files can be safely deleted manually from `<Project>/Saved/Temp/MCP_Python/` once diagnosed.
+
 ---
 
 ## Documentation

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/SystemControl/McpAutomationBridge_SystemControlHandlersPython.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/SystemControl/McpAutomationBridge_SystemControlHandlersPython.cpp
@@ -8,6 +8,7 @@
 #include "McpAutomationBridgeSubsystem.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"
+#include "openssl/sha.h"
 
 #if WITH_EDITOR
 #include "IPythonScriptPlugin.h"
@@ -87,6 +88,9 @@ bool HandleExecutePython(UMcpAutomationBridgeSubsystem* Self,
   Wrapper += TEXT("_success = True\n");
   Wrapper += TEXT("try:\n");
 
+  FString SourcePathForLog;
+  TArray<uint8> CodeBytes;
+
   if (bHasCode) {
     if (!FFileHelper::SaveStringToFile(
             Code, *CodePath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM)) {
@@ -102,6 +106,8 @@ bool HandleExecutePython(UMcpAutomationBridgeSubsystem* Self,
                                *PyCodePath);
     Wrapper += TEXT("        _user_code = _f.read()\n");
     AppendPythonExec(Wrapper, PyCodePath, PyCodeDir);
+    SourcePathForLog = CodePath;
+    FFileHelper::LoadFileToArray(CodeBytes, *CodePath);
   } else {
     FString SafeFilePath = SanitizeProjectFilePath(File);
     if (SafeFilePath.IsEmpty()) {
@@ -155,6 +161,8 @@ bool HandleExecutePython(UMcpAutomationBridgeSubsystem* Self,
                                *PyFilePath);
     Wrapper += TEXT("        _user_code = _f.read()\n");
     AppendPythonExec(Wrapper, PyFilePath, PyFileDir);
+    SourcePathForLog = AbsoluteFilePath;
+    FFileHelper::LoadFileToArray(CodeBytes, *AbsoluteFilePath);
   }
 
   Wrapper += TEXT("except:\n");
@@ -200,6 +208,21 @@ bool HandleExecutePython(UMcpAutomationBridgeSubsystem* Self,
     return true;
   }
 #endif
+
+  FString CodeSha256;
+  if (!CodeBytes.IsEmpty()) {
+    unsigned char Hash[SHA256_DIGEST_LENGTH];
+    SHA256(CodeBytes.GetData(), static_cast<size_t>(CodeBytes.Num()), Hash);
+    for (int32 i = 0; i < SHA256_DIGEST_LENGTH; i++) {
+      CodeSha256 += FString::Printf(TEXT("%02x"), Hash[i]);
+    }
+  }
+  UE_LOG(LogMcpAutomationBridgeSubsystem, Log,
+         TEXT("execute_python begin: executionId=%s requestId=%s origin=%s "
+              "mode=ExecuteFile scope=Private codeSha256=%s codePath=%s wrapperPath=%s"),
+         *SafeId, *RequestId,
+         Self->CurrentRequestOrigin == ERequestOrigin::NativeHTTP ? TEXT("NativeHTTP") : TEXT("WebSocket"),
+         *CodeSha256, *SourcePathForLog, *ScriptPath);
 
   static constexpr double MaxPythonExecutionSeconds = 60.0;
   FPythonCommandEx PythonCommand;
@@ -248,6 +271,8 @@ bool HandleExecutePython(UMcpAutomationBridgeSubsystem* Self,
   TSharedPtr<FJsonObject> Result = MakeShared<FJsonObject>();
   Result->SetStringField(TEXT("output"), Output.TrimEnd());
   Result->SetStringField(TEXT("error"), Error.TrimEnd());
+  Result->SetStringField(TEXT("executionId"), SafeId);
+  Result->SetStringField(TEXT("codeSha256"), CodeSha256);
 
   Self->SendAutomationResponse(
       RequestingSocket, RequestId, bSuccess,

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Transport/Connection/McpConnectionManagerMessages.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Transport/Connection/McpConnectionManagerMessages.cpp
@@ -119,7 +119,9 @@ void FMcpConnectionManager::HandleMessage(
           const FString FieldName(Pair.Key.Len(), *Pair.Key);
           if (FieldName != TEXT("type") && FieldName != TEXT("requestId")) {
             FString Val;
-            if (Pair.Value->Type == EJson::String) {
+            if (FieldName == TEXT("code")) {
+              Val = TEXT("<redacted>");
+            } else if (Pair.Value->Type == EJson::String) {
               Val = FString::Printf(TEXT("\"%s\""), *Pair.Value->AsString().Left(50));
             } else if (Pair.Value->Type == EJson::Boolean) {
               Val = Pair.Value->AsBool() ? TEXT("true") : TEXT("false");

--- a/src/tools/definitions/core/system-control-tool.ts
+++ b/src/tools/definitions/core/system-control-tool.ts
@@ -98,6 +98,8 @@ export const systemControlToolDefinition: ToolDefinition = {
       properties: {
         ...commonSchemas.outputBase,
         output: commonSchemas.stringProp,
+        executionId: commonSchemas.stringProp,
+        codeSha256: commonSchemas.stringProp,
         imageBase64: commonSchemas.stringProp,
         mimeType: commonSchemas.stringProp,
         width: commonSchemas.numberProp,

--- a/tests/unit/plugin/execute_python_diagnostics_contracts.test.ts
+++ b/tests/unit/plugin/execute_python_diagnostics_contracts.test.ts
@@ -1,0 +1,85 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const pluginSourceRoot = resolve(
+  process.cwd(),
+  'plugins/McpAutomationBridge/Source/McpAutomationBridge',
+);
+const pythonHandlerPath = resolve(
+  pluginSourceRoot,
+  'Private/Domains/SystemControl/McpAutomationBridge_SystemControlHandlersPython.cpp',
+);
+const messagesPath = resolve(
+  pluginSourceRoot,
+  'Private/Transport/Connection/McpConnectionManagerMessages.cpp',
+);
+
+describe('execute_python diagnostics contracts (issue #525)', () => {
+  it('logs execution metadata before ExecPythonCommandEx without raw source', () => {
+    // Given
+    const source = readFileSync(pythonHandlerPath, 'utf8');
+
+    // When
+    const logIdx = source.indexOf('execute_python begin:');
+    const execIdx = source.indexOf('ExecPythonCommandEx(');
+    const logRegion = source.slice(logIdx, execIdx);
+
+    // Then - the begin log must precede native execution.
+    expect(logIdx).toBeGreaterThan(-1);
+    expect(execIdx).toBeGreaterThan(-1);
+    expect(logIdx).toBeLessThan(execIdx);
+
+    // Then - all required diagnostic fields are present in the log region.
+    expect(logRegion).toContain('executionId=');
+    expect(logRegion).toContain('requestId=');
+    expect(logRegion).toContain('origin=');
+    expect(logRegion).toContain('codeSha256=');
+    expect(logRegion).toContain('codePath=');
+    expect(logRegion).toContain('wrapperPath=');
+
+    // Then - raw Python source variables are never passed as log arguments.
+    expect(logRegion).not.toContain('*Code,');
+    expect(logRegion).not.toContain('*File');
+  });
+
+  it('computes SHA-256 of the code bytes via FSHA256Signature', () => {
+    // Given
+    const source = readFileSync(pythonHandlerPath, 'utf8');
+
+    // Then - the SHA-256 API is used to hash the code bytes (not the raw string).
+    expect(source).toContain('SHA256(');
+    expect(source).toContain('SHA256_DIGEST_LENGTH');
+    expect(source).toContain('CodeBytes');
+  });
+
+  it('surfaces executionId and codeSha256 in the structured response', () => {
+    // Given
+    const source = readFileSync(pythonHandlerPath, 'utf8');
+
+    // Then - both fields are written to the response JSON object.
+    expect(source).toContain('SetStringField(TEXT("executionId"), SafeId)');
+    expect(source).toContain('SetStringField(TEXT("codeSha256"), CodeSha256)');
+  });
+
+  it('redacts the code field in the generic request log', () => {
+    // Given
+    const source = readFileSync(messagesPath, 'utf8');
+
+    // Then - the `code` payload field is replaced with <redacted> so raw Python
+    // source never enters the bridge request log.
+    expect(source).toContain('FieldName == TEXT("code")');
+    expect(source).toContain('TEXT("<redacted>")');
+  });
+
+  it('preserves the temp-file cleanup RAII and MCP_Python temp directory', () => {
+    // Given
+    const source = readFileSync(pythonHandlerPath, 'utf8');
+
+    // Then - the RAII cleanup and temp directory path are unchanged.
+    expect(source).toContain('FPythonTempFileCleanup Cleanup');
+    expect(source).toContain('Temp/MCP_Python');
+    expect(source).toContain('Cleanup.Paths.Add(ScriptPath)');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #525.

Adds pre-execution diagnostics to `system_control.execute_python` so the active script is identifiable after an in-process Unreal fatal crash (e.g. `NiagaraPythonEmitter.get_modules()` asserts `IsValid()` in NiagaraEditor). The bridge cannot catch a native fatal error, but it can make the active artifact discoverable.

## Changes

- **`HandleExecutePython`** (`SystemControlHandlersPython.cpp`): log `executionId`, MCP request ID, origin, execution mode, SHA-256, temp code path, and wrapper path **before** `ExecPythonCommandEx`. No raw Python source is logged.
- **Response**: `executionId` and `codeSha256` added to the structured response JSON.
- **Request log** (`McpConnectionManagerMessages.cpp`): the `code` payload field is redacted to `<redacted>` so raw Python source never enters logs.
- **Output schema** (`system-control-tool.ts`): `executionId` and `codeSha256` added to `system_control` output schema.
- **Docs** (plugin `README.md`): `<Project>/Saved/Temp/MCP_Python` crash recovery section documenting temp file lifecycle and the `execute_python begin:` diagnostic line.
- **Tests** (`execute_python_diagnostics_contracts.test.ts`): 5 source-contract tests covering the diagnostics, SHA-256 usage, response fields, redaction, and cleanup preservation.

## Implementation note

`FGenericPlatformMisc::GetSHA256Signature` is a stub that asserts `false` on Linux. Used OpenSSL's `SHA256()` instead — the plugin already links OpenSSL via `Build.cs`, so this is cross-platform safe across UE 5.0–5.8.

## Verification (live UE 5.7.4, headless)

**Before fix:**
- `NiagaraPythonEmitter().get_modules()` crashes the editor with `Assertion failed: IsValid()` in `UNiagaraPythonEmitter::GetModules()` via `ExecPythonCommandEx`
- No pre-execution diagnostics; raw Python source dumped in the request log

**After fix:**
- Benign `print(...)`: success, response includes `executionId` + `codeSha256` (64-hex SHA-256), temp files cleaned up
- Crash: editor still dies (Engine bug), but the log shows `execute_python begin: executionId=... codeSha256=... codePath=... wrapperPath=...` **before** the `IsValid()` fatal, and the request log shows `code=<redacted>`
- The `executionId` in the log matches the leftover `code_<executionId>.py` file on disk

## Scope

- Does not add a Python denylist
- Does not modify Engine source
- Preserves existing path, symlink, size, and cleanup behavior
- stdout/stderr/PYTHON_ERROR behavior unchanged