### PR TITLE
fix(control_editor): simulate_input mouse_click never triggers Slate widgets (missing EffectingButton)

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/ControlEditor/McpAutomationBridge_ControlEditorInputRouting.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/ControlEditor/McpAutomationBridge_ControlEditorInputRouting.cpp
@@ -188,15 +188,22 @@ void SimulateEditorInputForMcp(const FString &InputType, const FString &Key,
     TSet<FKey> PressedButtons;
     PressedButtons.Add(MouseButtonKey);
 
-    FPointerEvent MouseDownEvent(0, Position, Position, FVector2D(0.0f, 0.0f),
-                                 PressedButtons, FModifierKeysState());
-    SlateApp.ProcessMouseButtonDownEvent(nullptr, MouseDownEvent);
+    // Slate widgets (SButton, SComboBox, ...) gate clicks on
+    // GetEffectingButton(); the EffectingButton-less FPointerEvent
+    // constructor leaves it as an invalid FKey, so synthetic clicks never
+    // trigger any editor UI. Use the EffectingButton-aware constructor and
+    // mirror platform behaviour: down carries the button in PressedButtons,
+    // up carries an empty set.
+    FPointerEvent MouseDownEvent(0, Position, Position, PressedButtons,
+                                 MouseButtonKey, 0.0f, FModifierKeysState());
+    const bool bDownHandled =
+        SlateApp.ProcessMouseButtonDownEvent(nullptr, MouseDownEvent);
 
     TSet<FKey> ReleasedButtons;
-    FPointerEvent MouseUpEvent(0, Position, Position, FVector2D(0.0f, 0.0f),
-                               ReleasedButtons, FModifierKeysState());
-    SlateApp.ProcessMouseButtonUpEvent(MouseUpEvent);
-    bHandledBySlate = true;
+    FPointerEvent MouseUpEvent(0, Position, Position, ReleasedButtons,
+                               MouseButtonKey, 0.0f, FModifierKeysState());
+    const bool bUpHandled = SlateApp.ProcessMouseButtonUpEvent(MouseUpEvent);
+    bHandledBySlate = bDownHandled || bUpHandled;
     bSuccess = true;
     Message = FString::Printf(TEXT("Mouse click at (%f, %f)"), X, Y);
   } else if (InputType == TEXT("mouse_move") || InputType == TEXT("move")) {


### PR DESCRIPTION
## Problem

`control_editor` → `simulate_input` with `type: "mouse_click"` reports `success: true` and `handledBySlate: true`, but no Slate widget in the editor UI is ever actually triggered — synthetic clicks are a silent no-op on any `SButton`, `SComboBox`, dock tab, etc.

**Root cause** (`McpAutomationBridge_ControlEditorInputRouting.cpp`, `mouse_click` branch):

1. The down/up `FPointerEvent`s are built with the constructor that has **no EffectingButton parameter**, so `MouseEvent.GetEffectingButton()` returns an invalid `FKey()`. Slate widgets gate clicks on `GetEffectingButton() == EKeys::LeftMouseButton` (e.g. `SButton::OnMouseButtonDown/Up`), so they reject the event.
2. `bHandledBySlate` was hardcoded to `true`, masking the failure — callers are told "click handled" while nothing happened.

## Fix

- Use the EffectingButton-aware `FPointerEvent` constructor and mirror platform behaviour: the **down** event carries the button in `PressedButtons`, the **up** event carries an empty pressed set — both with the proper `EffectingButton`.
- Feed `bHandledBySlate` from the real return values of `ProcessMouseButtonDownEvent` / `ProcessMouseButtonUpEvent`.

The PIE key-input path (`InputKey` route) and `mouse_move` are untouched.

## Verification

Verified on UE 5.8 (Windows, live editor, before/after on the same coordinates):

- **Before:** `simulate_input` clicks on editor UI elements (status-bar buttons, dock tabs) did nothing, while the response still claimed `handledBySlate: true`.
- **After:** the same click genuinely activates Slate widgets — e.g. clicking the "World Settings" dock tab actually switches the panel — and `handledBySlate` now reflects the real Slate processing result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
