### PR TITLE
fix(responses): give program output a larger summary budget with an explicit truncation notice

### DIFF
--- a/src/utils/responses/response-content.test.ts
+++ b/src/utils/responses/response-content.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { buildSummaryText } from './response-content.js';
+
+describe('buildSummaryText — output field budget', () => {
+  it('keeps a short output verbatim', () => {
+    const text = buildSummaryText('system_control', {
+      success: true,
+      result: { output: 'MONTAGE COUNT 3' },
+      message: 'Python executed successfully'
+    });
+
+    expect(text).toContain('output: MONTAGE COUNT 3');
+    expect(text).not.toContain('truncated');
+  });
+
+  it('keeps a multi-line output between 150 and 2000 chars intact (not clipped at 150)', () => {
+    const lines = Array.from({ length: 20 }, (_, i) => `/Game/Anims/AM_Attack_${String(i).padStart(2, '0')}`);
+    const output = lines.join('\n'); // ~500 chars — the execute_python listing shape
+    const text = buildSummaryText('system_control', { success: true, result: { output } });
+
+    expect(text).toContain('AM_Attack_19'); // the tail survives
+    expect(text).not.toContain('truncated');
+  });
+
+  it('announces truncation explicitly above 2000 chars — sizes + structuredContent pointer, no bare ellipsis', () => {
+    const output = 'X'.repeat(5000);
+    const text = buildSummaryText('system_control', { success: true, result: { output } });
+
+    expect(text).toContain('[output truncated: showing 2000 of 5000 chars — full text in structuredContent]');
+    expect(text).not.toContain('X'.repeat(2001)); // budget enforced
+    expect(text).toContain('X'.repeat(2000)); // budget delivered
+  });
+
+  it('other long string fields keep the compact 150-char summary behaviour', () => {
+    const long = 'Y'.repeat(500);
+    const text = buildSummaryText('some_tool', { success: true, detail: long });
+
+    expect(text).toContain(`detail: ${'Y'.repeat(150)}...`);
+    expect(text).not.toContain('Y'.repeat(151));
+  });
+
+  it('non-string output values fall through to the generic formatter', () => {
+    const text = buildSummaryText('some_tool', { success: true, output: ['a', 'b'] });
+
+    expect(text).toContain('output: [a, b] (2)');
+  });
+});

--- a/src/utils/responses/response-content.ts
+++ b/src/utils/responses/response-content.ts
@@ -50,6 +50,21 @@ function formatRecordListItem(record: Record<string, unknown>): string {
   return `{ ${entries.map(([key, value]) => `${key}=${formatNestedValue(value)}`).join(', ')}${suffix} }`;
 }
 
+/**
+ * Program output (`output` from execute_python / console commands) gets a larger summary budget than other
+ * string fields: it is the payload the caller explicitly asked the tool to produce, and clients that render
+ * only the text content (many MCP clients never surface structuredContent to the model) would otherwise see
+ * an unusable 150-char head and re-query in a loop. Truncation above this budget is announced explicitly —
+ * with the shown/total sizes and a pointer to structuredContent — never a bare '...'.
+ */
+const OUTPUT_SUMMARY_LIMIT = 2000;
+
+function formatOutputValue(val: unknown): string {
+  if (typeof val !== 'string') return formatValue(val);
+  if (val.length <= OUTPUT_SUMMARY_LIMIT) return val;
+  return `${val.slice(0, OUTPUT_SUMMARY_LIMIT)}... [output truncated: showing ${OUTPUT_SUMMARY_LIMIT} of ${val.length} chars — full text in structuredContent]`;
+}
+
 function formatValue(val: unknown): string {
   if (val === null || val === undefined) return '';
   if (typeof val === 'string') return val.length > 150 ? val.slice(0, 150) + '...' : val;
@@ -137,7 +152,7 @@ export function buildSummaryText(toolName: string, payload: unknown): string {
     if (Array.isArray(val) && val.length > 0) hasArrays = true;
     if ((key === 'count' || key === 'totalCount') && hasArrays) continue;
 
-    const formatted = formatValue(val);
+    const formatted = key === 'output' ? formatOutputValue(val) : formatValue(val);
     if (formatted) {
       parts.push(`${key}: ${formatted}`);
       addedKeys.add(key);


### PR DESCRIPTION
## Problem

`buildSummaryText` (src/utils/responses/response-content.ts) caps every string field at 150 chars. That is the right compact-summary default, but for `output` — the stdout of `execute_python` / console commands — it clips the exact payload the caller asked the tool to produce.

Clients that render only the text content (many MCP clients never surface `structuredContent` to the model) see an unusable 150-char head ending in a bare `...`. In a live agent session we measured the downstream cost: **~25 redundant tool round-trips in a single turn** — the model resorted to writing the output to a file and re-reading it through the same 150-char window, page by page.

## Change

- `output` gets a **2000-char summary budget**; all other string fields keep the compact 150-char behaviour.
- Truncation above the budget is **announced explicitly** — `... [output truncated: showing 2000 of N chars — full text in structuredContent]` — never a silent `...`, so a text-only client knows the data exists and where.
- Non-string `output` values fall through to the generic formatter unchanged.

## Tests

- New `src/utils/responses/response-content.test.ts` (vitest, co-located like `response-factory.test.ts`): short verbatim / mid-size intact / over-budget loud notice / other-fields-still-150 / non-string fallthrough — 5/5 green.
- `npm run test:unit`: no new failures (the 31 failures pre-existing at 663596e9 are unchanged in the same environment).
- `npm run type-check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
