### PR TITLE
fix(metasound): connect_metasound_nodes resolves node names and surfaces available nodes

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/AudioAuthoring/McpAutomationBridge_AudioAuthoringHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/AudioAuthoring/McpAutomationBridge_AudioAuthoringHandlers.cpp
@@ -59,7 +59,31 @@ bool UMcpAutomationBridgeSubsystem::HandleManageAudioAuthoringAction(
 		else
 		{
 			FString ErrorMsg = Response->HasField(TEXT("error")) ? GetJsonStringField(Response, TEXT("error")) : Message.Len() > 0 ? Message : TEXT("Unknown error");
-			SendAutomationError(RequestingSocket, RequestId, ErrorMsg, ErrorCode);
+			// Preserve diagnostic payload fields handlers attach to failures
+			// (e.g. availableNodes/availableInputs); SendAutomationError would
+			// discard the whole response object. Envelope fields keep the same
+			// shape: message = human text, error = code.
+			TSharedPtr<FJsonObject> Details = MakeShared<FJsonObject>();
+			for (const auto& Pair : Response->Values)
+			{
+				const FString Key(Pair.Key.Len(), *Pair.Key);
+				if (Key == TEXT("success") || Key == TEXT("error") || Key == TEXT("errorCode") ||
+					Key == TEXT("code") || Key == TEXT("message") || Key == TEXT("type") ||
+					Key == TEXT("requestId") || Key == TEXT("data") || Key == TEXT("result"))
+				{
+					continue;
+				}
+				Details->SetField(Key, Pair.Value);
+			}
+			if (Details->Values.Num() > 0)
+			{
+				SendAutomationResponse(RequestingSocket, RequestId, false, ErrorMsg, Details,
+					ErrorCode.IsEmpty() ? TEXT("AUTOMATION_ERROR") : ErrorCode);
+			}
+			else
+			{
+				SendAutomationError(RequestingSocket, RequestId, ErrorMsg, ErrorCode);
+			}
 		}
 	}
 	else

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/AudioAuthoring/McpAutomationBridge_AudioAuthoringHandlersMetaSoundNodes.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/AudioAuthoring/McpAutomationBridge_AudioAuthoringHandlersMetaSoundNodes.cpp
@@ -152,10 +152,132 @@ TSharedPtr<FJsonObject> HandleMetaSoundNodeActions(const FString& SubAction, con
 
 		FGuid SourceGuid;
 		FGuid TargetGuid;
+#if MCP_HAS_METASOUND_FRONTEND_V2
+		// Snapshot the graph's nodes once: used to resolve node references given
+		// by name instead of GUID, and to enrich failure responses so the caller
+		// can self-correct (callers commonly pass node names or wrong pin names).
+		struct FMcpNodeSnapshot
+		{
+			FGuid Id;
+			FString Name;
+			FString ClassName;
+			TArray<FString> Inputs;
+			TArray<FString> Outputs;
+		};
+		TArray<FMcpNodeSnapshot> GraphNodes;
+		{
+			const FMetasoundFrontendDocument& Doc = Builder.GetConstDocumentChecked();
+			Doc.RootGraph.IterateGraphPages([&GraphNodes, &Doc](const FMetasoundFrontendGraph& GraphPage)
+			{
+				for (const FMetasoundFrontendNode& Node : GraphPage.Nodes)
+				{
+					FMcpNodeSnapshot Snapshot;
+					Snapshot.Id = Node.GetID();
+					Snapshot.Name = Node.Name.ToString();
+					if (const FMetasoundFrontendClass* NodeClass = Doc.Dependencies.FindByPredicate(
+						[&Node](const FMetasoundFrontendClass& Dependency) { return Dependency.ID == Node.ClassID; }))
+					{
+						Snapshot.ClassName = NodeClass->Metadata.GetClassName().ToString();
+					}
+					for (const FMetasoundFrontendVertex& Input : Node.Interface.Inputs)
+					{
+						Snapshot.Inputs.Add(FString::Printf(TEXT("%s (%s)"), *Input.Name.ToString(), *Input.TypeName.ToString()));
+					}
+					for (const FMetasoundFrontendVertex& Output : Node.Interface.Outputs)
+					{
+						Snapshot.Outputs.Add(FString::Printf(TEXT("%s (%s)"), *Output.Name.ToString(), *Output.TypeName.ToString()));
+					}
+					GraphNodes.Add(MoveTemp(Snapshot));
+				}
+			});
+		}
+
+		auto BuildAvailableNodesArray = [&GraphNodes]()
+		{
+			TArray<TSharedPtr<FJsonValue>> NodeArray;
+			for (const FMcpNodeSnapshot& Snapshot : GraphNodes)
+			{
+				TSharedPtr<FJsonObject> NodeObj = McpHandlerUtils::CreateResultObject();
+				NodeObj->SetStringField(TEXT("nodeId"), Snapshot.Id.ToString());
+				NodeObj->SetStringField(TEXT("name"), Snapshot.Name);
+				if (!Snapshot.ClassName.IsEmpty())
+				{
+					NodeObj->SetStringField(TEXT("className"), Snapshot.ClassName);
+				}
+				TArray<TSharedPtr<FJsonValue>> InputArray;
+				for (const FString& Input : Snapshot.Inputs) { InputArray.Add(MakeShared<FJsonValueString>(Input)); }
+				NodeObj->SetArrayField(TEXT("inputs"), InputArray);
+				TArray<TSharedPtr<FJsonValue>> OutputArray;
+				for (const FString& Output : Snapshot.Outputs) { OutputArray.Add(MakeShared<FJsonValueString>(Output)); }
+				NodeObj->SetArrayField(TEXT("outputs"), OutputArray);
+				NodeArray.Add(MakeShared<FJsonValueObject>(NodeObj));
+			}
+			return NodeArray;
+		};
+
+		// Resolve a node reference: GUID first, then a unique (case-insensitive)
+		// match on node name or full class name.
+		auto ResolveNodeReference = [&GraphNodes](const FString& NodeRef, FGuid& OutGuid, FString& OutFailReason) -> bool
+		{
+			// A well-formed GUID must still name a node that exists in this graph;
+			// otherwise fall through to the INVALID_GUID + availableNodes diagnostic
+			// instead of failing later with a generic edge error.
+			FGuid ParsedGuid;
+			if (FGuid::Parse(NodeRef, ParsedGuid))
+			{
+				if (GraphNodes.ContainsByPredicate([&ParsedGuid](const FMcpNodeSnapshot& Snapshot) { return Snapshot.Id == ParsedGuid; }))
+				{
+					OutGuid = ParsedGuid;
+					return true;
+				}
+				OutFailReason = FString::Printf(TEXT("'%s' does not match any node in this graph"), *NodeRef);
+				return false;
+			}
+			int32 MatchCount = 0;
+			for (const FMcpNodeSnapshot& Snapshot : GraphNodes)
+			{
+				if (Snapshot.Name.Equals(NodeRef, ESearchCase::IgnoreCase) ||
+					Snapshot.ClassName.Equals(NodeRef, ESearchCase::IgnoreCase))
+				{
+					OutGuid = Snapshot.Id;
+					++MatchCount;
+				}
+			}
+			if (MatchCount == 1)
+			{
+				return true;
+			}
+			OutFailReason = MatchCount > 1
+				? FString::Printf(TEXT("'%s' matches %d nodes - use the node GUID"), *NodeRef, MatchCount)
+				: FString::Printf(TEXT("'%s' is not a GUID and does not match any node name"), *NodeRef);
+			return false;
+		};
+
+		FString SourceFailReason;
+		FString TargetFailReason;
+		const bool bSourceResolved = ResolveNodeReference(SourceNodeId, SourceGuid, SourceFailReason);
+		const bool bTargetResolved = ResolveNodeReference(TargetNodeId, TargetGuid, TargetFailReason);
+		if (!bSourceResolved || !bTargetResolved)
+		{
+			TArray<FString> Reasons;
+			if (!SourceFailReason.IsEmpty()) { Reasons.Add(FString::Printf(TEXT("sourceNodeId: %s"), *SourceFailReason)); }
+			if (!TargetFailReason.IsEmpty()) { Reasons.Add(FString::Printf(TEXT("targetNodeId: %s"), *TargetFailReason)); }
+			TSharedPtr<FJsonObject> ErrorResponse = McpHandlerUtils::BuildErrorResponse(
+				TEXT("INVALID_GUID"),
+				FString::Printf(TEXT("Invalid node reference - %s"), *FString::Join(Reasons, TEXT("; "))));
+			TArray<TSharedPtr<FJsonValue>> NodeArray = BuildAvailableNodesArray();
+			if (NodeArray.Num() > 0)
+			{
+				ErrorResponse->SetArrayField(TEXT("availableNodes"), NodeArray);
+			}
+			return ErrorResponse;
+		}
+#else
 		if (!FGuid::Parse(SourceNodeId, SourceGuid) || !FGuid::Parse(TargetNodeId, TargetGuid))
 		{
 			return McpHandlerUtils::BuildErrorResponse(TEXT("INVALID_GUID"), TEXT("Invalid node ID format - must be valid GUID"));
 		}
+#endif
 
 		Metasound::Frontend::FNamedEdge NamedEdge{SourceGuid, FName(*SourceOutputName), TargetGuid, FName(*TargetInputName)};
 		TSet<Metasound::Frontend::FNamedEdge> Edges;
@@ -169,32 +291,24 @@ TSharedPtr<FJsonObject> HandleMetaSoundNodeActions(const FString& SubAction, con
 			Response->SetBoolField(TEXT("success"), true);
 			Response->SetStringField(TEXT("message"), TEXT("MetaSound nodes connected"));
 			Response->SetNumberField(TEXT("edgesCreated"), CreatedEdges.Num());
+			// Echo the resolved GUIDs so name-based callers learn the canonical IDs.
+			Response->SetStringField(TEXT("sourceNodeId"), SourceGuid.ToString());
+			Response->SetStringField(TEXT("targetNodeId"), TargetGuid.ToString());
 			McpHandlerUtils::AddVerification(Response, MetaSound);
 		}
 		else
 		{
 			Response->SetBoolField(TEXT("success"), false);
-			Response->SetStringField(TEXT("error"), TEXT("Failed to create edge connection"));
+			Response->SetStringField(TEXT("error"), TEXT("Failed to create edge connection - check pin names against availableNodes inputs/outputs"));
 			Response->SetStringField(TEXT("errorCode"), TEXT("EDGE_FAILED"));
 			Response->SetStringField(TEXT("code"), TEXT("EDGE_FAILED"));
-			TArray<TSharedPtr<FJsonValue>> NodeIdArray;
 #if MCP_HAS_METASOUND_FRONTEND_V2
-			const FMetasoundFrontendDocument& Doc = Builder.GetConstDocumentChecked();
-			Doc.RootGraph.IterateGraphPages([&NodeIdArray](const FMetasoundFrontendGraph& GraphPage)
-			{
-				for (const FMetasoundFrontendNode& Node : GraphPage.Nodes)
-				{
-					TSharedPtr<FJsonObject> NodeObj = McpHandlerUtils::CreateResultObject();
-					NodeObj->SetStringField(TEXT("nodeId"), Node.GetID().ToString());
-					NodeObj->SetStringField(TEXT("name"), Node.Name.ToString());
-					NodeIdArray.Add(MakeShared<FJsonValueObject>(NodeObj));
-				}
-			});
-#endif
+			TArray<TSharedPtr<FJsonValue>> NodeIdArray = BuildAvailableNodesArray();
 			if (NodeIdArray.Num() > 0)
 			{
 				Response->SetArrayField(TEXT("availableNodes"), NodeIdArray);
 			}
+#endif
 		}
 
 #if MCP_HAS_METASOUND_FRONTEND_V2


### PR DESCRIPTION
### Problem
`connect_metasound_nodes` rejected any node reference that wasn't a raw `FGuid` with `INVALID_GUID`, so a caller passing a node **name** or class name had no working path. Separately, when a connection failed the handler's diagnostic payload (e.g. the available-nodes list) never reached the wire.

### Fix
- Snapshot the graph nodes once (id / name / className / input+output pin names+types).
- If the id isn't a parseable GUID, resolve it by a **unique** case-insensitive name or className match; ambiguous or missing → `INVALID_GUID` with a reason and `availableNodes[]`.
- `EDGE_FAILED` now includes `availableNodes[]` with pin names; on success the resolved GUIDs are echoed (`sourceNodeId`/`targetNodeId`).
- Also fixes the audio dispatcher failure branch: it called `SendAutomationError(msg, code)`, which dropped the handler's `Response` object. Non-envelope diagnostic fields are now preserved (envelope keys `success/error/errorCode/code/message/type/requestId/data/result` excluded); when there are none, the previous path is unchanged.

Guarded for the V2 MetaSound builder (UE 5.5+); non-V2 behavior is unchanged.

### Verification (UE 5.8)
name + wrong pin → `EDGE_FAILED` with pin-listed dump; name + correct pin → success + `edgesCreated:1` + GUID echo; missing name → `INVALID_GUID` + reason + dump; raw GUID → success (regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
