### PR TITLE
fix(metasound): set_metasound_default reports missing input and expected data type

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/AudioAuthoring/McpAutomationBridge_AudioAuthoringHandlersMetaSoundInterfaces.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/AudioAuthoring/McpAutomationBridge_AudioAuthoringHandlersMetaSoundInterfaces.cpp
@@ -185,9 +185,40 @@ TSharedPtr<FJsonObject> HandleMetaSoundInterfaceActions(const FString& SubAction
 		else
 		{
 			Response->SetBoolField(TEXT("success"), false);
+#if MCP_HAS_METASOUND_FRONTEND_V2
+			// Distinguish "no such graph input" from a genuine set failure and list
+			// the available inputs so the caller can self-correct.
+			const FMetasoundFrontendClassInput* GraphInput = Builder.FindGraphInput(FName(*InputName));
+			if (!GraphInput)
+			{
+				Response->SetStringField(TEXT("error"), FString::Printf(TEXT("Graph input '%s' not found"), *InputName));
+				Response->SetStringField(TEXT("errorCode"), TEXT("INPUT_NOT_FOUND"));
+				Response->SetStringField(TEXT("code"), TEXT("INPUT_NOT_FOUND"));
+				TArray<TSharedPtr<FJsonValue>> InputArray;
+				const FMetasoundFrontendDocument& Doc = Builder.GetConstDocumentChecked();
+				for (const FMetasoundFrontendClassInput& Input : Doc.RootGraph.GetDefaultInterface().Inputs)
+				{
+					TSharedPtr<FJsonObject> InputObj = McpHandlerUtils::CreateResultObject();
+					InputObj->SetStringField(TEXT("inputName"), Input.Name.ToString());
+					InputObj->SetStringField(TEXT("dataType"), Input.TypeName.ToString());
+					InputArray.Add(MakeShared<FJsonValueObject>(InputObj));
+				}
+				// Always emit availableInputs (even when empty) so INPUT_NOT_FOUND has a
+				// consistent shape — an empty array means "this graph has no inputs".
+				Response->SetArrayField(TEXT("availableInputs"), InputArray);
+			}
+			else
+			{
+				Response->SetStringField(TEXT("error"), FString::Printf(TEXT("Failed to set default for input '%s' - value could not be applied (likely a data-type mismatch; expected '%s')"), *InputName, *GraphInput->TypeName.ToString()));
+				Response->SetStringField(TEXT("errorCode"), TEXT("SET_DEFAULT_FAILED"));
+				Response->SetStringField(TEXT("code"), TEXT("SET_DEFAULT_FAILED"));
+				Response->SetStringField(TEXT("expectedDataType"), GraphInput->TypeName.ToString());
+			}
+#else
 			Response->SetStringField(TEXT("error"), FString::Printf(TEXT("Failed to set default for input '%s'"), *InputName));
 			Response->SetStringField(TEXT("errorCode"), TEXT("SET_DEFAULT_FAILED"));
 			Response->SetStringField(TEXT("code"), TEXT("SET_DEFAULT_FAILED"));
+#endif
 		}
 
 #if MCP_HAS_METASOUND_FRONTEND_V2


### PR DESCRIPTION
### Problem
When `SetGraphInputDefault` failed, `set_metasound_default` returned an opaque `SET_DEFAULT_FAILED` — callers couldn't distinguish "no such input" from a data-type mismatch.

### Fix (V2-guarded)
On failure, look up `Builder.FindGraphInput(name)`:
- not found → `INPUT_NOT_FOUND` + `availableInputs[{inputName, dataType}]` (from `RootGraph.GetDefaultInterface().Inputs`);
- found → `SET_DEFAULT_FAILED` + `expectedDataType` (the message notes this is the *likely* cause, since the builder can return false for other reasons).

The write path and non-V2 behavior are unchanged.

> Note: verified on **UE 5.8** only. `GetDefaultInterface()` was not compile-checked on the lower end of the 5.5–5.7 guard range — worth a quick spot-compile there before merge.

### Verification (UE 5.8)
missing `Frequency` → `INPUT_NOT_FOUND` + `[UE.Source.OnPlay(Trigger), Volume(Float)]`; `Volume` floatValue → success; boolValue on a Trigger input → `SET_DEFAULT_FAILED` + `expectedDataType:Trigger`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
