### PR TITLE
fix(blueprint): FindNode accepts an unambiguous GUID prefix

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersContext.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersContext.cpp
@@ -69,6 +69,39 @@ UEdGraphNode* FActionContext::FindNode(const FString& Id) const
             return Node;
         }
     }
+
+    // QoL: callers often quote a shortened GUID. Accept an UNAMBIGUOUS
+    // GUID-prefix of at least 8 hex chars; anything ambiguous stays
+    // not-found (the full 32-hex id is always available via
+    // get_graph_details). Non-hex ids keep exact-name-only semantics.
+    if (Id.Len() >= 8 && Id.Len() < 32)
+    {
+        bool bHexLike = true;
+        for (const TCHAR C : Id)
+        {
+            if (!FChar::IsHexDigit(C))
+            {
+                bHexLike = false;
+                break;
+            }
+        }
+        if (bHexLike)
+        {
+            UEdGraphNode* UniqueMatch = nullptr;
+            for (UEdGraphNode* Node : TargetGraph->Nodes)
+            {
+                if (Node && Node->NodeGuid.ToString().StartsWith(Id, ESearchCase::IgnoreCase))
+                {
+                    if (UniqueMatch)
+                    {
+                        return nullptr;
+                    }
+                    UniqueMatch = Node;
+                }
+            }
+            return UniqueMatch;
+        }
+    }
     return nullptr;
 }
 


### PR DESCRIPTION
### Problem
`FActionContext::FindNode` accepted only a full 32-hex GUID or an exact node name. Callers frequently pass a shortened id, which fell through to `NODE_NOT_FOUND`.

### Fix
After the exact-match pass misses, if the input is hex-like and 8–31 characters, match node GUIDs case-insensitively by `StartsWith` — returning **only** on a unique match. Ambiguous or missing → `nullptr` (`NODE_NOT_FOUND` preserved). Non-hex inputs keep their name semantics; the exact path is unchanged. This is the central lookup, so `get_node_details` / `set_node_property` / `delete_node` all benefit.

> An ambiguous prefix deliberately returns `NODE_NOT_FOUND` rather than silently selecting one match — this lookup backs destructive-capable actions.

### Verification (UE 5.8)
8-hex prefix → success; full 32-hex → success; fake `00000000` → `NODE_NOT_FOUND`; 4-char input → `NODE_NOT_FOUND` (threshold preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
