### PR TITLE
fix(pcg): actionable guidance when the PCG plugin is unavailable or disabled

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/PCG/McpAutomationBridge_PCGHandlers.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/PCG/McpAutomationBridge_PCGHandlers.cpp
@@ -14,7 +14,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManagePCGAction(
     SendAutomationError(Socket, RequestId, TEXT("manage_pcg requires an editor build."), TEXT("EDITOR_ONLY"));
     return true;
 #elif !MCP_HAS_PCG
-    SendAutomationError(Socket, RequestId, TEXT("PCG plugin support is not available in this build."), TEXT("PCG_PLUGIN_NOT_AVAILABLE"));
+    SendAutomationError(Socket, RequestId, TEXT("PCG plugin support is not available in this build. Enable the 'Procedural Content Generation Framework (PCG)' plugin (Edit > Plugins), restart the editor, then rebuild this automation plugin so PCG support is compiled in."), TEXT("PCG_PLUGIN_NOT_AVAILABLE"));
     return true;
 #else
     if (!Payload.IsValid())
@@ -26,7 +26,7 @@ bool UMcpAutomationBridgeSubsystem::HandleManagePCGAction(
     if (!FModuleManager::Get().IsModuleLoaded(TEXT("PCG")) &&
         (!FModuleManager::Get().ModuleExists(TEXT("PCG")) || !FModuleManager::Get().LoadModulePtr<IModuleInterface>(TEXT("PCG"))))
     {
-        SendAutomationError(Socket, RequestId, TEXT("PCG plugin is not enabled in this project."), TEXT("PCG_PLUGIN_NOT_ENABLED"));
+        SendAutomationError(Socket, RequestId, TEXT("PCG plugin is not enabled in this project. Enable the 'Procedural Content Generation Framework (PCG)' plugin (Edit > Plugins) and restart the editor."), TEXT("PCG_PLUGIN_NOT_ENABLED"));
         return true;
     }
 


### PR DESCRIPTION
### Problem
Both PCG error modes were correct but not actionable — the caller wasn't told how to resolve them.

### Fix (message strings only — no control-flow change)
- `PCG_PLUGIN_NOT_AVAILABLE` (compile-time, `MCP_HAS_PCG=0` — the bridge was built without PCG headers) and
- `PCG_PLUGIN_NOT_ENABLED` (runtime, module not loaded)

now instruct the user to enable the **Procedural Content Generation Framework (PCG)** plugin and restart the editor (and, for `NOT_AVAILABLE`, rebuild the automation plugin).

### Verification (UE 5.8)
`create_pcg_graph` → `NOT_AVAILABLE` returned with the new guidance text. (The `NOT_ENABLED` branch can't be triggered in a PCG-less build; string-only, low risk.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
