### PR TITLE
feat(asset): manage_asset list opt-in disk metadata (size/modified) with a stat cap

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/AssetWorkflow/Operations/McpAutomationBridge_AssetWorkflowListing.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/AssetWorkflow/Operations/McpAutomationBridge_AssetWorkflowListing.cpp
@@ -8,6 +8,8 @@
 
 #if WITH_EDITOR
 #include "AssetRegistry/AssetRegistryModule.h"
+#include "HAL/FileManager.h"
+#include "Misc/PackageName.h"
 #endif
 
 bool UMcpAutomationBridgeSubsystem::HandleListAssets(
@@ -39,6 +41,11 @@ bool UMcpAutomationBridgeSubsystem::HandleListAssets(
 
   bool bRecursive = true;
   Payload->TryGetBoolField(TEXT("recursive"), bRecursive);
+
+  // Opt-in per-asset disk metadata (size + modified date). Off by default:
+  // it costs one file stat per listed asset and grows the response.
+  bool bIncludeMetadata = false;
+  Payload->TryGetBoolField(TEXT("includeMetadata"), bIncludeMetadata);
 
   // Parse pagination
   int32 Offset = 0;
@@ -212,6 +219,14 @@ bool UMcpAutomationBridgeSubsystem::HandleListAssets(
     // immediate subfolders of the requested path.
   }
 
+  // File stats below are synchronous game-thread IO. Bound how many assets we
+  // stat so an unbounded recursive listing (no pagination limit) cannot stall
+  // the editor. Assets past the cap are still listed, just without disk
+  // metadata; the caller is told via metadataTruncated.
+  const int32 MetadataStatCap = 256;
+  int32 MetadataStatBudget = bIncludeMetadata ? MetadataStatCap : 0;
+  bool bMetadataTruncated = false;
+
   TArray<TSharedPtr<FJsonValue>> AssetsArray;
   for (const FAssetData &Asset : AssetList) {
     TSharedPtr<FJsonObject> AssetObj = McpHandlerUtils::CreateResultObject();
@@ -232,6 +247,28 @@ bool UMcpAutomationBridgeSubsystem::HandleListAssets(
     }
     AssetObj->SetArrayField(TEXT("tags"), Tags);
 
+    if (bIncludeMetadata) {
+      if (MetadataStatBudget > 0) {
+        --MetadataStatBudget;
+        FString PackageFilename;
+        if (FPackageName::DoesPackageExist(Asset.PackageName.ToString(),
+                                           &PackageFilename)) {
+          IFileManager &FileManager = IFileManager::Get();
+          const int64 FileSize = FileManager.FileSize(*PackageFilename);
+          if (FileSize >= 0) {
+            AssetObj->SetNumberField(TEXT("diskSizeBytes"),
+                                     static_cast<double>(FileSize));
+          }
+          const FDateTime Stamp = FileManager.GetTimeStamp(*PackageFilename);
+          if (Stamp != FDateTime::MinValue()) {
+            AssetObj->SetStringField(TEXT("modifiedAt"), Stamp.ToIso8601());
+          }
+        }
+      } else {
+        bMetadataTruncated = true;
+      }
+    }
+
     AssetsArray.Add(MakeShared<FJsonValueObject>(AssetObj));
   }
 
@@ -247,6 +284,9 @@ bool UMcpAutomationBridgeSubsystem::HandleListAssets(
   Resp->SetNumberField(TEXT("totalCount"), TotalCount);
   Resp->SetNumberField(TEXT("count"), AssetsArray.Num());
   Resp->SetNumberField(TEXT("offset"), Offset);
+  if (bIncludeMetadata) {
+    Resp->SetBoolField(TEXT("metadataTruncated"), bMetadataTruncated);
+  }
 
   SendAutomationResponse(Socket, RequestId, true, TEXT("Assets listed"), Resp,
                          FString());

--- a/src/tools/handlers/asset/asset-basic-actions.ts
+++ b/src/tools/handlers/asset/asset-basic-actions.ts
@@ -31,16 +31,19 @@ export async function handleListAssets(context: AssetHandlerContext): Promise<Re
     { key: 'path', aliases: ['directory', 'directoryPath', 'assetPath'], default: '/Game' },
     { key: 'limit', default: 50 },
     { key: 'recursive', aliases: ['recursivePaths'], default: false },
-    { key: 'depth', default: undefined }
+    { key: 'depth', default: undefined },
+    { key: 'includeMetadata', aliases: ['withMetadata'], default: undefined }
   ]);
   const path = normalizeAndSanitizeAssetPath(extractOptionalString(params, 'path') ?? '/Game');
   const limit = extractOptionalNumber(params, 'limit') ?? 50;
   const recursive = extractOptionalBoolean(params, 'recursive') ?? false;
   const depth = extractOptionalNumber(params, 'depth');
+  const includeMetadata = extractOptionalBoolean(params, 'includeMetadata');
   const res = await executeAutomationRequest(context.tools, 'list', {
     path,
     recursive: recursive === true || (depth !== undefined && depth > 0),
-    depth
+    depth,
+    includeMetadata
   }) as AssetListResponse;
   const assets: AssetListItem[] = Array.isArray(res.assets)
     ? res.assets
@@ -61,11 +64,14 @@ export async function handleListAssets(context: AssetHandlerContext): Promise<Re
   }
   if (remaining > 0) message += `... and ${remaining} others`;
 
+  const rawTruncated = res.metadataTruncated ??
+    (Array.isArray(res.result) ? undefined : (res.result as Record<string, unknown> | undefined)?.metadataTruncated);
   return ResponseFactory.success({
     assets: limitedAssets,
     folders,
     totalCount: assets.length,
-    count: limitedAssets.length
+    count: limitedAssets.length,
+    ...(typeof rawTruncated === 'boolean' ? { metadataTruncated: rawTruncated } : {})
   }, message);
 }
 


### PR DESCRIPTION
### Problem
`manage_asset` list returned only name / path / class / packagePath / tag names — no size or timestamp.

### Fix (opt-in; default response shape unchanged)
New `includeMetadata` boolean (alias `withMetadata`). When true, each asset gains `diskSizeBytes` (`FPackageName::DoesPackageExist` + `IFileManager::FileSize`) and `modifiedAt` (ISO-8601 file timestamp).

The per-asset stat runs on the game thread, so the loop is bounded by `MetadataStatCap = 256`: beyond the cap, assets remain listed **without** metadata and the response sets `metadataTruncated:true` (no silent truncation). The TS handler passes the flag through.

### Verification (UE 5.8)
888-asset recursive folder → success + `metadataTruncated:true` (no timeout); small folder → 5/5 metadata + `metadataTruncated:false`; without the flag → key set identical to before (no leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
