### PR TITLE
fix: resolve C4800 enum-to-bool implicit conversion in   IsStructureValid

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/AssetWorkflow/DataTables/LifecycleDataTables.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/AssetWorkflow/DataTables/LifecycleDataTables.cpp
@@ -244,7 +244,7 @@ bool HandleDataTableAction(
         if (!S) { OutResult = McpDataTableMakeError(TEXT("ASSET_NOT_FOUND"), nullptr); return true; }
 
         FString ValidityMsg;
-        if (!FStructureEditorUtils::IsStructureValid(S, nullptr, &ValidityMsg))
+        if (FStructureEditorUtils::IsStructureValid(S, nullptr, &ValidityMsg) != FStructureEditorUtils::EStructureError::Ok)
         {
             OutResult = McpDataTableMakeError(TEXT("INVALID_OPERATION"), *ValidityMsg);
             return true;

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/AssetWorkflow/Structs/McpAutomationBridge_AssetWorkflowStructsLifecycle.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/AssetWorkflow/Structs/McpAutomationBridge_AssetWorkflowStructsLifecycle.cpp
@@ -205,7 +205,7 @@ bool HandleStructLifecycleActions(UMcpAutomationBridgeSubsystem& Bridge, const F
             }
 
             FString ValidityMsg;
-            const bool bValid = FStructureEditorUtils::IsStructureValid(S, nullptr, &ValidityMsg);
+            const bool bValid = (FStructureEditorUtils::IsStructureValid(S, nullptr, &ValidityMsg) == FStructureEditorUtils::EStructureError::Ok);
 
             TSharedPtr<FJsonObject> Result = McpHandlerUtils::CreateResultObject();
             Result->SetStringField(TEXT("assetPath"), StructPath);


### PR DESCRIPTION
FStructureEditorUtils::IsStructureValid returns
  EStructureError (an enum), not bool. Two call sites
  implicitly converted that enum to bool, which MSVC
  rejects under /permissive- with error C4800, failing
  the whole plugin build on UE 5.7 and preventing the
  plugin from loading.

  Compare the result against EStructureError::Ok
  explicitly instead:
  -
  McpAutomationBridge_AssetWorkflowStructsLifecycle.cpp:
  bValid = (result == Ok)
  - LifecycleDataTables.cpp: if (result != Ok)

  Fixes #542

  ## Summary

  `FStructureEditorUtils::IsStructureValid()` returns
  `EStructureError` (an enum), not `bool`. Two call sites
  relied on an implicit enum→bool conversion, which MSVC
  rejects under `/permissive-` with `error C4800`. This
  failed the entire plugin build on UE 5.7, so the plugin
  could not be compiled or loaded. This PR makes the
  conversion explicit by comparing against
  `EStructureError::Ok` (the "valid" sentinel, enumerator
  value 0), leaving behavior unchanged.

  ## Changes

  - `McpAutomationBridge_AssetWorkflowStructsLifecycle.cp
  p:208`: `const bool bValid =
  (FStructureEditorUtils::IsStructureValid(...) ==
  FStructureEditorUtils::EStructureError::Ok);`
  - `LifecycleDataTables.cpp:247`: `if
  (FStructureEditorUtils::IsStructureValid(...) !=
  FStructureEditorUtils::EStructureError::Ok)` (was `if
  (!FStructureEditorUtils::IsStructureValid(...))`)

  ## Related Issues

  Fixes #542

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an
  issue)

  ## Testing

  Built `McpAutomationBridge` against UE 5.7.4
  (Changelist 51494982) on Windows with MSVC
  `/permissive-`. Before the fix: `error C4800` and
  `Result: Failed (OtherCompilationError)`. After the
  fix: zero errors, `Result: Succeeded`, plugin DLL links
  cleanly (UnrealEditor-McpAutomationBridge.dll, ~14
  MB).

  - [x] Tested with Unreal Engine (version: 5.7.4)
  - [ ] Tested MCP client integration (client: ___)
  - [ ] Added/updated tests

  ## Pre-Merge Checklist

  - [x] Code follows project style guidelines
  - [x] Self-reviewed the code
  - [x] Updated relevant documentation (if needed)
  - [x] Added/updated tests (if applicable)
  - [ ] CI passes