### PR TITLE
fix(build): UE 5.8 SetEnums signature + missing Async include

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Core/Compatibility/McpVersionCompatibility.h
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Core/Compatibility/McpVersionCompatibility.h
@@ -421,3 +421,28 @@
 #else
 #define MCP_ASSET_DATA_GET_OBJECT_PATH(AssetData) (AssetData).ObjectPath.ToString()
 #endif
+
+// =============================================================================
+// UUserDefinedEnum::SetEnums Compatibility (UE 5.8 signature change)
+// =============================================================================
+// UE 5.8: UUserDefinedEnum overrides SetEnums with a 5-parameter signature
+//         (Names, CppForm, UnderlyingType, Flags, AddMaxKeyIfMissing). The
+//         2/4-argument UEnum overload is deprecated AND final, and the override
+//         hides it, so a 2-argument call no longer compiles.
+// UE 5.0-5.7: the 2-argument UEnum::SetEnums(Names, CppForm) is the way.
+//
+// On 5.8 the underlying type is read back with GetUnderlyingType() so the
+// enum keeps its own type. Note this is deliberately NOT what the deprecated
+// 2-argument overload does -- that one forwards EUnderlyingType::int64
+// unconditionally. Reading the type back matches Engine's own
+// FEnumEditorUtils, which is the behaviour you want when editing an existing
+// user-defined enum (creating one uses uint8, so int64 would rewrite it).
+
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8
+  #define MCP_SET_ENUMS(EnumPtr, Names, CppForm)                                \
+    (EnumPtr)->SetEnums((Names), (CppForm), (EnumPtr)->GetUnderlyingType(),     \
+                        EEnumFlags::None, UEnum::EAddMaxKeyIfMissing::Yes)
+#else
+  #define MCP_SET_ENUMS(EnumPtr, Names, CppForm)                                \
+    (EnumPtr)->SetEnums((Names), (CppForm))
+#endif

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/AssetWorkflow/Enums/LifecycleEnums.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/AssetWorkflow/Enums/LifecycleEnums.cpp
@@ -1,4 +1,5 @@
 #include "Domains/AssetWorkflow/Enums/Shared.h"
+#include "Async/Async.h"
 #include "Kismet2/EnumEditorUtils.h"
 #include "Misc/ScopedEvent.h"
 #include "ObjectTools.h"
@@ -115,7 +116,7 @@ bool HandleEnumLifecycleActions(
             {
                 Names[i].Value = i;
             }
-            Enum->SetEnums(Names, Enum->GetCppForm());
+            MCP_SET_ENUMS(Enum, Names, Enum->GetCppForm());
         }
 
         Package->MarkPackageDirty();

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/AssetWorkflow/Enums/Values.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/AssetWorkflow/Enums/Values.cpp
@@ -50,7 +50,7 @@ bool HandleEnumValueActions(
         const FString FullNameStr = Enum->GenerateFullEnumName(*ValueName);
         Names.Emplace(*FullNameStr, 0);
         for (int32 i = 0; i < Names.Num(); ++i) { Names[i].Value = i; }
-        Enum->SetEnums(Names, Enum->GetCppForm());
+        MCP_SET_ENUMS(Enum, Names, Enum->GetCppForm());
         FinalizeEnum(Enum, GetPayloadBool(Params, TEXT("save"), false));
 
         TSharedPtr<FJsonObject> Result = McpHandlerUtils::CreateResultObject();
@@ -82,7 +82,7 @@ bool HandleEnumValueActions(
             return true;
         }
         for (int32 i = 0; i < Names.Num(); ++i) { Names[i].Value = i; }
-        Enum->SetEnums(Names, Enum->GetCppForm());
+        MCP_SET_ENUMS(Enum, Names, Enum->GetCppForm());
         FinalizeEnum(Enum, GetPayloadBool(Params, TEXT("save"), false));
 
         TSharedPtr<FJsonObject> Result = McpHandlerUtils::CreateResultObject();
@@ -122,7 +122,7 @@ bool HandleEnumValueActions(
             return true;
         }
         for (int32 i = 0; i < Names.Num(); ++i) { Names[i].Value = i; }
-        Enum->SetEnums(Names, Enum->GetCppForm());
+        MCP_SET_ENUMS(Enum, Names, Enum->GetCppForm());
         FinalizeEnum(Enum, GetPayloadBool(Params, TEXT("save"), false));
 
         TSharedPtr<FJsonObject> Result = McpHandlerUtils::CreateResultObject();
@@ -183,7 +183,7 @@ bool HandleEnumValueActions(
         }
 
         for (int32 i = 0; i < NewNames.Num(); ++i) { NewNames[i].Value = i; }
-        Enum->SetEnums(NewNames, Enum->GetCppForm());
+        MCP_SET_ENUMS(Enum, NewNames, Enum->GetCppForm());
         FinalizeEnum(Enum, GetPayloadBool(Params, TEXT("save"), false));
 
         TSharedPtr<FJsonObject> Result = McpHandlerUtils::CreateResultObject();
@@ -255,7 +255,7 @@ bool HandleEnumValueActions(
         {
             NewNames.Emplace(*NewEnum->GenerateFullEnumName(*KeepShortNames[i]), static_cast<int64>(i));
         }
-        NewEnum->SetEnums(NewNames, NewEnum->GetCppForm());
+        MCP_SET_ENUMS(NewEnum, NewNames, NewEnum->GetCppForm());
         FinalizeEnum(NewEnum, GetPayloadBool(Params, TEXT("save"), false));
         FAssetRegistryModule::AssetCreated(NewEnum);
 


### PR DESCRIPTION
### What changed since this PR was opened

This started as a broad set of UE 5.8 build fixes. Since then most of them have landed on `dev` independently — the facade includes in the three domain `Shared.h` files, the `Async/Async.h` includes in the struct asset-ops files, the `ProjectPaths.h` include in `McpAutomationBridgeHelpersAssetCreation.h`, and the `AddVariable.cpp` includes (the `MCP_PC_Int` usage there is gone entirely now).

So this PR has been rebased onto current `dev` and **cut down to only what is still broken**: 3 files, ~27 added lines.

### 1. `UUserDefinedEnum::SetEnums` does not compile on UE 5.8

In 5.8 `UUserDefinedEnum` overrides `SetEnums` with a 5-parameter signature:

```cpp
virtual bool SetEnums(TArray<TPair<FName, int64>>& InNames, ECppForm InCppForm,
                      UEnum::EUnderlyingType InUnderlyingType, EEnumFlags InFlags,
                      EAddMaxKeyIfMissing bAddMaxKeyIfMissing) override;
```

That override **hides** the base `UEnum` 2/4-argument overload — which is itself deprecated and `final` in 5.8 — so the six existing 2-argument calls fail to compile:

- `Domains/AssetWorkflow/Enums/Values.cpp` (5 call sites)
- `Domains/AssetWorkflow/Enums/LifecycleEnums.cpp` (1 call site)

Added `MCP_SET_ENUMS(EnumPtr, Names, CppForm)` to `McpVersionCompatibility.h`, next to the existing compatibility macros: on 5.8+ it expands to the 5-argument form, and on 5.0–5.7 it stays the plain 2-argument call.

**One behaviour note worth your attention:** on 5.8 the macro passes `GetUnderlyingType()`, which is deliberately *not* what the deprecated 2-argument overload does — that one forwards `EUnderlyingType::int64` unconditionally:

```cpp
// Engine/Source/Runtime/CoreUObject/Private/UObject/Enum.cpp
bool UEnum::SetEnums(TArray<TPair<FName, int64>>& InNames, ECppForm InCppForm, EEnumFlags InFlags, bool bAddMaxKeyIfMissing)
{
    return SetEnums(InNames, InCppForm, UEnum::EUnderlyingType::int64, InFlags, ...);
}
```

Reading the type back instead is what Engine's own `FEnumEditorUtils` does when editing an existing user-defined enum, and it avoids rewriting the underlying type of enums that were created as `uint8`. If you would rather this branch stay bug-compatible with the old path, say the word and I will hard-code `int64` instead — it is a one-token change.

**Deliberately left alone:** `Private/Tests/McpPropertyReflectionImportTests.cpp:27` also calls the 2-argument overload, but on a plain `UEnum` (created via `UEnum::StaticClass()`), where the base overload is not hidden. It still compiles on 5.8 — it only emits the deprecation warning — so I kept it out to keep this diff to what actually breaks the build. Happy to fold it in if you want the warning gone too.

### 2. `LifecycleEnums.cpp` calls `AsyncTask` without including it

The file uses `AsyncTask(ENamedThreads::GameThread, ...)` but pulls in no `Async` header; it was relying on a neighbour through the unity blob. Added `#include "Async/Async.h"`.

### Verification

The same macro and the same six call-site conversions were compiled and exercised on UE 5.8 in an editor-closed full build (1099 files, 0 errors) and at runtime — `create_enum` succeeds, which goes through `SetEnums`. Only UE 5.8 was built here; the 5.0–5.7 branch of the macro is the pre-existing call, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
