### PR TITLE
fix(actor): set_component_property assigns a mesh the actor never renders

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/ControlActor/McpAutomationBridge_ControlActorComponentProperties.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/ControlActor/McpAutomationBridge_ControlActorComponentProperties.cpp
@@ -1,5 +1,9 @@
 #include "Domains/ControlActor/McpAutomationBridge_ControlActorSupport.h"
 
+#if WITH_EDITOR
+#include "ComponentReregisterContext.h"
+#endif
+
 bool UMcpAutomationBridgeSubsystem::HandleControlActorSetComponentProperties(
     const FString &RequestId, const TSharedPtr<FJsonObject> &Payload,
     TSharedPtr<FMcpBridgeWebSocket> Socket) {
@@ -119,6 +123,38 @@ bool UMcpAutomationBridgeSubsystem::HandleControlActorSetComponentProperties(
       }
     }
 
+    // A mesh asset has to go through the engine setter, never raw reflection.
+    // UStaticMeshComponent::ShouldCreateRenderState() returns false while the
+    // mesh is null, so a component that registered empty has NO render state at
+    // all -- and MarkRenderStateDirty() only flags an existing one, so it does
+    // nothing here. SetStaticMesh() is what notices that case and calls
+    // RecreateRenderState_Concurrent(); it also runs the bookkeeping a raw write
+    // skips (NotifyIfStaticMeshChanged, physics/nav/streaming state, bounds).
+    // Writing the property directly leaves an actor that reports correct bounds
+    // and a correct StaticMesh but is never drawn.
+    if (PropertyName.Equals(TEXT("StaticMesh"), ESearchCase::IgnoreCase)) {
+      if (UStaticMeshComponent *MeshComp =
+              Cast<UStaticMeshComponent>(TargetComponent)) {
+        FString MeshPath;
+        const bool bClearMesh = Pair.Value->Type == EJson::Null;
+        if (bClearMesh || Pair.Value->TryGetString(MeshPath)) {
+          UStaticMesh *NewMesh = nullptr;
+          if (!MeshPath.IsEmpty()) {
+            NewMesh = LoadObject<UStaticMesh>(nullptr, *MeshPath);
+            if (!NewMesh) {
+              PropertyWarnings.Add(FString::Printf(
+                  TEXT("Failed to set %s: no static mesh could be loaded from %s"),
+                  *PropertyName, *MeshPath));
+              continue;
+            }
+          }
+          MeshComp->SetStaticMesh(NewMesh);
+          AppliedProperties.Add(PropertyName);
+          continue;
+        }
+      }
+    }
+
     FProperty *Property = ComponentClass->FindPropertyByName(*PropertyName);
     if (!Property) {
       PropertyWarnings.Add(
@@ -134,14 +170,34 @@ bool UMcpAutomationBridgeSubsystem::HandleControlActorSetComponentProperties(
                                            *PropertyName, *ApplyError));
   }
 
+  // Whether a component can render at all is decided at registration time, and
+  // some properties change that answer. A component that had nothing to draw
+  // when it registered carries no render state, and MarkRenderStateDirty() is a
+  // documented no-op while bRenderStateCreated is false -- precisely the state
+  // the write above may have just invalidated. ShouldCreateRenderState() is
+  // protected, so ask the engine the same question the way it asks itself: a
+  // re-register re-runs the check and creates the state if it is now warranted.
+  if (TargetComponent->IsRegistered() &&
+      !TargetComponent->IsRenderStateCreated()) {
+    FComponentReregisterContext ReregisterContext(TargetComponent);
+  } else {
+    TargetComponent->MarkRenderStateDirty();
+  }
   if (USceneComponent *SceneComponent =
           Cast<USceneComponent>(TargetComponent)) {
-    SceneComponent->MarkRenderStateDirty();
     SceneComponent->UpdateComponentToWorld();
   }
   TargetComponent->MarkPackageDirty();
 
   TSharedPtr<FJsonObject> Data = McpHandlerUtils::CreateResultObject();
+  // Report whether the component ended up with a render state. Without this the
+  // response cannot distinguish "property written" from "component will draw",
+  // which is the exact gap that let a mesh assignment look successful while the
+  // actor stayed invisible.
+  if (Cast<UPrimitiveComponent>(TargetComponent)) {
+    Data->SetBoolField(TEXT("renderStateCreated"),
+                       TargetComponent->IsRenderStateCreated());
+  }
   if (AppliedProperties.Num() > 0) {
     TArray<TSharedPtr<FJsonValue>> PropsArray;
     for (const FString &PropName : AppliedProperties)


### PR DESCRIPTION
## Symptom

`control_actor set_component_property` can assign a static mesh to an actor that then **never renders** — while every response says the operation succeeded.

```
control_actor spawn { classPath: "/Script/Engine.StaticMeshActor", actorName: "X", location: {...} }
control_actor set_component_property { actorName: "X", componentName: "StaticMeshComponent0",
                                       propertyName: "StaticMesh", value: "/Engine/BasicShapes/Cube.Cube" }
  -> applied: ["StaticMesh"]
control_actor get_actor_bounds { actorName: "X" }
  -> origin [0,-500,200], extent [50,50,50]        # correct cube bounds
control_editor focus_actor / screenshot
  -> camera is on the actor, and nothing is drawn
```

A stock `/Engine/BasicShapes/Cube` is invisible, so this is not about any particular asset. The mesh really is assigned: `get_component_property` reads it back, and it survives a save — reopening the level makes the actor appear. Only the in-session render state is missing.

## Cause

The handler writes every property through raw reflection (`ApplyJsonValueToProperty` → `FObjectProperty::SetObjectPropertyValue_InContainer`) and then calls `MarkRenderStateDirty()`. For `StaticMesh` that combination cannot work:

1. `UStaticMeshComponent::ShouldCreateRenderState()` returns **false while the mesh is null** (`StaticMeshComponent.cpp`, the `"ShouldCreateRenderState returned false … (StaticMesh is null)"` branch). An `AStaticMeshActor` spawned without a mesh therefore registers with **no render state at all** — `bRenderStateCreated == false`, no primitive in the scene.
2. `UActorComponent::MarkRenderStateDirty()` is guarded by `if (IsRegistered() && bRenderStateCreated && …)`. With no render state it is a **no-op**, so nothing ever creates one.

The engine's own setter handles exactly this case:

```cpp
// UStaticMeshComponent::SetStaticMesh
if (IsRenderStateCreated())        { MarkRenderStateDirty(); }
else if (ShouldCreateRenderState()) { RecreateRenderState_Concurrent(); }
```

The raw write skips that branch — and with it `NotifyIfStaticMeshChanged()` (the `KnownStaticMesh` bookkeeping whose mismatch trips an `ensure` in editor builds), `RecreatePhysicsState()`, navigation/streaming updates, PSO precaching and `UpdateBounds()`.

Bounds still look right because `UStaticMeshComponent::CalcBounds` only transforms the mesh's own bounds and needs no render state. That is why every diagnostic reads green while the viewport stays empty.

## Fix

1. **`StaticMesh` goes through `SetStaticMesh()`** instead of raw reflection. A path that does not resolve to a `UStaticMesh` now produces a warning rather than a silent write, and a JSON `null` clears the mesh.
2. **General render-state repair**, written as a rule rather than for this one property: after the writes, if the component is registered but has no render state, re-register it. `ShouldCreateRenderState()` is `protected`, so this asks the engine the same way `USceneComponent::SetMobility` does — `FComponentReregisterContext` re-runs the engine's own check and creates the state when it is now warranted. Otherwise the previous `MarkRenderStateDirty()` path is unchanged.
3. **The response reports `renderStateCreated`** for primitive components — the difference between "the property was written" and "this will actually draw". Purely additive.

Existing behaviour for every other property and component type is untouched.

## Verification

Live on UE 5.8 (editor, `Development`), one session, flipping between the pre-fix and fixed code with Live Coding so the only variable is the patch:

| | pre-fix | with this patch |
|---|---|---|
| `applied` | `["StaticMesh"]` | `["StaticMesh"]` |
| `renderStateCreated` | *(field absent)* | `true` |
| `get_actor_bounds` | `extent [50,50,50]` | `extent [50,50,50]` |
| screenshot `cameraLocation` | matches `focus_actor` exactly | matches `focus_actor` exactly |
| **actor drawn** | **no** | **yes** |

Both runs used the same actor class, the same stock cube and the same camera coordinates; re-issuing the identical call after the patch also rescues an actor that the pre-fix run had already left invisible.

Compile-verified and behaviour-verified on **UE 5.8 only**. The APIs used are long-standing and not 5.8-specific — `UStaticMeshComponent::SetStaticMesh`, the public `UActorComponent::IsRegistered()`/`IsRenderStateCreated()`, and `FComponentReregisterContext` from `ComponentReregisterContext.h` — but a spot compile on 5.5–5.7 would be worth doing before merge if you support those.

## Known adjacent gap (not addressed here)

Skeletal mesh assets have the same shape: `USkeletalMeshComponent::SkeletalMeshAsset` declares `Setter = SetSkeletalMeshAsset`, which raw reflection ignores. The re-register in (2) restores visibility, but the setter's own bookkeeping is still skipped. Left alone deliberately — routing it correctly needs a version-safe path across the engine versions this plugin targets, and I have not measured it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
