### PR TITLE
fix(control_editor): set_camera discards the requested position and still reports success

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/ControlEditor/McpAutomationBridge_ControlEditorCamera.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/ControlEditor/McpAutomationBridge_ControlEditorCamera.cpp
@@ -176,33 +176,85 @@ bool UMcpAutomationBridgeSubsystem::HandleControlEditorFocusActor(
   FString ActorName;
   Payload->TryGetStringField(TEXT("actorName"), ActorName);
   if (ActorName.IsEmpty()) {
+    Payload->TryGetStringField(TEXT("name"), ActorName);
+  }
+  if (ActorName.IsEmpty()) {
+    Payload->TryGetStringField(TEXT("objectPath"), ActorName);
+  }
+  if (ActorName.IsEmpty()) {
     SendStandardErrorResponse(this, Socket, RequestId, TEXT("INVALID_ARGUMENT"),
                               TEXT("actorName required"), nullptr);
     return true;
   }
 
+  if (!GEditor) {
+    SendStandardErrorResponse(this, Socket, RequestId,
+                              TEXT("EDITOR_NOT_AVAILABLE"),
+                              TEXT("Editor not available"), nullptr);
+    return true;
+  }
+
+  AActor *Target = nullptr;
   if (UEditorActorSubsystem *ActorSS =
           GEditor->GetEditorSubsystem<UEditorActorSubsystem>()) {
     TArray<AActor *> Actors = ActorSS->GetAllLevelActors();
     for (AActor *Actor : Actors) {
       if (!Actor)
         continue;
-      if (Actor->GetActorLabel().Equals(ActorName, ESearchCase::IgnoreCase)) {
-        GEditor->SelectNone(true, true, false);
-        GEditor->SelectActor(Actor, true, true, true);
-        GEditor->Exec(nullptr, TEXT("EDITORTEMPVIEWPORT"));
-        GEditor->MoveViewportCamerasToActor(*Actor, false);
-        SendAutomationResponse(Socket, RequestId, true,
-                               TEXT("Viewport focused on actor"), nullptr,
-                               FString());
-        return true;
+      if (Actor->GetActorLabel().Equals(ActorName, ESearchCase::IgnoreCase) ||
+          Actor->GetName().Equals(ActorName, ESearchCase::IgnoreCase)) {
+        Target = Actor;
+        break;
       }
     }
-    SendStandardErrorResponse(this, Socket, RequestId, TEXT("ACTOR_NOT_FOUND"),
-                              TEXT("Actor not found"), nullptr);
+  }
+
+  if (!Target) {
+    SendStandardErrorResponse(
+        this, Socket, RequestId, TEXT("ACTOR_NOT_FOUND"),
+        FString::Printf(TEXT("Actor not found: %s"), *ActorName), nullptr);
     return true;
   }
-  return false;
+
+  GEditor->SelectNone(true, true, false);
+  GEditor->SelectActor(Target, true, true, true);
+  GEditor->MoveViewportCamerasToActor(*Target, false);
+
+  // MoveViewportCamerasToActor ANIMATES the camera: it ends in FocusViewportOnBox,
+  // whose bInstant parameter defaults to false. A screenshot taken straight after
+  // this call therefore catches the camera in flight, and an automation client has
+  // no way to observe when the flight is over. Land the viewport we actually
+  // capture on the target immediately so "focus then screenshot" is deterministic.
+  FEditorViewportClient *ViewportClient = GetActiveEditorViewportClientForMcp();
+  const FBox FocusBox = Target->GetComponentsBoundingBox(true);
+  const bool bBoundsValid = FocusBox.IsValid != 0;
+  if (ViewportClient && bBoundsValid) {
+    ViewportClient->FocusViewportOnBox(FocusBox, /*bInstant=*/true);
+    ViewportClient->Invalidate();
+  }
+
+  TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
+  Resp->SetBoolField(TEXT("success"), true);
+  Resp->SetStringField(TEXT("actorName"), Target->GetActorLabel());
+  Resp->SetStringField(TEXT("actorPath"), Target->GetPathName());
+  Resp->SetBoolField(TEXT("boundsValid"), bBoundsValid);
+  Resp->SetBoolField(TEXT("focusedInstantly"), ViewportClient && bBoundsValid);
+  if (bBoundsValid) {
+    Resp->SetObjectField(TEXT("focusCenter"),
+                         MakeVectorObjectForMcp(FocusBox.GetCenter()));
+    Resp->SetObjectField(TEXT("focusExtent"),
+                         MakeVectorObjectForMcp(FocusBox.GetExtent()));
+  }
+  if (ViewportClient) {
+    Resp->SetObjectField(TEXT("cameraLocation"),
+                         MakeVectorObjectForMcp(ViewportClient->GetViewLocation()));
+    Resp->SetObjectField(TEXT("cameraRotation"),
+                         MakeRotatorObjectForMcp(ViewportClient->GetViewRotation()));
+  }
+
+  SendAutomationResponse(Socket, RequestId, true,
+                         TEXT("Viewport focused on actor"), Resp, FString());
+  return true;
 #else
   return false;
 #endif
@@ -212,47 +264,80 @@ bool UMcpAutomationBridgeSubsystem::HandleControlEditorSetCamera(
     const FString &RequestId, const TSharedPtr<FJsonObject> &Payload,
     TSharedPtr<FMcpBridgeWebSocket> Socket) {
 #if WITH_EDITOR
-  const TSharedPtr<FJsonObject> *Loc = nullptr;
-  FVector Location(0, 0, 0);
-  FRotator Rotation(0, 0, 0);
-  if (Payload->TryGetObjectField(TEXT("location"), Loc) && Loc &&
-      (*Loc).IsValid())
-    ReadVectorField(*Loc, TEXT(""), Location, Location);
-  if (Payload->TryGetObjectField(TEXT("rotation"), Loc) && Loc &&
-      (*Loc).IsValid())
-    ReadRotatorField(*Loc, TEXT(""), Rotation, Rotation);
+  // Move the SAME viewport client the screenshot handler captures. Routing the
+  // camera through UUnrealEditorSubsystem::SetLevelViewportCameraInfo used to
+  // target the first PERSPECTIVE client in GEditor->GetLevelViewportClients(),
+  // which is not necessarily the client that gets drawn and read back, so
+  // "set the camera, then take a picture" could address two different viewports.
+  FEditorViewportClient *ViewportClient = GetActiveEditorViewportClientForMcp();
+  if (!ViewportClient) {
+    SendStandardErrorResponse(
+        this, Socket, RequestId, TEXT("VIEWPORT_NOT_AVAILABLE"),
+        TEXT("No active level editor viewport to move the camera in"), nullptr);
+    return true;
+  }
 
-#if defined(MCP_HAS_UNREALEDITOR_SUBSYSTEM)
-  if (UUnrealEditorSubsystem *UES =
-          GEditor->GetEditorSubsystem<UUnrealEditorSubsystem>()) {
-    UES->SetLevelViewportCameraInfo(Location, Rotation);
-#if defined(MCP_HAS_LEVELEDITOR_SUBSYSTEM)
-    if (ULevelEditorSubsystem *LES =
-            GEditor->GetEditorSubsystem<ULevelEditorSubsystem>())
-      LES->EditorInvalidateViewports();
-#endif
-    TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
-    Resp->SetBoolField(TEXT("success"), true);
-    SendAutomationResponse(Socket, RequestId, true, TEXT("Camera set"), Resp,
-                           FString());
+  // The vector lives in a NAMED field of the payload, so it has to be read from
+  // the payload. Reading it out of the already-extracted sub-object under an
+  // EMPTY field name matched nothing and fell back to the default on every call,
+  // which parked the camera at the world origin whatever the caller asked for --
+  // and the handler still answered {"success":true}.
+  const bool bHasLocation = Payload->HasField(TEXT("location"));
+  const bool bHasRotation = Payload->HasField(TEXT("rotation"));
+  if (!bHasLocation && !bHasRotation) {
+    SendStandardErrorResponse(
+        this, Socket, RequestId, TEXT("INVALID_ARGUMENT"),
+        TEXT("location and/or rotation required (object {x,y,z} / {pitch,yaw,roll}, or a 3-number array)"),
+        nullptr);
     return true;
   }
-#endif
-  if (FEditorViewportClient *ViewportClient =
-          GEditor->GetActiveViewport()
-              ? (FEditorViewportClient *)GEditor->GetActiveViewport()
-                    ->GetClient()
-              : nullptr) {
-    ViewportClient->SetViewLocation(Location);
-    ViewportClient->SetViewRotation(Rotation);
-    ViewportClient->Invalidate();
-    TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
-    Resp->SetBoolField(TEXT("success"), true);
-    SendAutomationResponse(Socket, RequestId, true, TEXT("Camera set"), Resp,
-                           FString());
+
+  const FVector RequestedLocation = ExtractVectorField(
+      Payload, TEXT("location"), ViewportClient->GetViewLocation());
+  const FRotator RequestedRotation = ExtractRotatorField(
+      Payload, TEXT("rotation"), ViewportClient->GetViewRotation());
+
+  ViewportClient->SetViewLocation(RequestedLocation);
+  ViewportClient->SetViewRotation(RequestedRotation);
+  ViewportClient->Invalidate();
+
+  // Report where the camera ENDED UP rather than echoing the request. A viewport
+  // that refuses to move -- locked to an actor, piloting, orthographic -- is then
+  // visible to the caller instead of being reported as a success.
+  const FVector AppliedLocation = ViewportClient->GetViewLocation();
+  const FRotator AppliedRotation = ViewportClient->GetViewRotation();
+  const bool bLocationApplied = AppliedLocation.Equals(RequestedLocation, 1.0);
+  const bool bRotationApplied = AppliedRotation.Equals(RequestedRotation, 1.0);
+
+  TSharedPtr<FJsonObject> Resp = McpHandlerUtils::CreateResultObject();
+  Resp->SetBoolField(TEXT("success"), bLocationApplied && bRotationApplied);
+  Resp->SetObjectField(TEXT("requestedLocation"),
+                       MakeVectorObjectForMcp(RequestedLocation));
+  Resp->SetObjectField(TEXT("requestedRotation"),
+                       MakeRotatorObjectForMcp(RequestedRotation));
+  Resp->SetObjectField(TEXT("cameraLocation"),
+                       MakeVectorObjectForMcp(AppliedLocation));
+  Resp->SetObjectField(TEXT("cameraRotation"),
+                       MakeRotatorObjectForMcp(AppliedRotation));
+  Resp->SetBoolField(TEXT("locationApplied"), bLocationApplied);
+  Resp->SetBoolField(TEXT("rotationApplied"), bRotationApplied);
+  Resp->SetBoolField(TEXT("perspective"), ViewportClient->IsPerspective());
+
+  if (!bLocationApplied || !bRotationApplied) {
+    const FString Message =
+        TEXT("Viewport did not take the requested camera. It may be locked to an "
+             "actor, piloting, or orthographic; cameraLocation/cameraRotation "
+             "report where it actually is.");
+    Resp->SetStringField(TEXT("error"), Message);
+    Resp->SetStringField(TEXT("message"), Message);
+    SendAutomationResponse(Socket, RequestId, false, Message, Resp,
+                           TEXT("CAMERA_NOT_APPLIED"));
     return true;
   }
-  return false;
+
+  SendAutomationResponse(Socket, RequestId, true, TEXT("Camera set"), Resp,
+                         FString());
+  return true;
 #else
   return false;
 #endif

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/ControlEditor/McpAutomationBridge_ControlEditorScreenshot.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/ControlEditor/McpAutomationBridge_ControlEditorScreenshot.cpp
@@ -108,8 +108,18 @@ bool UMcpAutomationBridgeSubsystem::HandleControlEditorScreenshot(
   }
 
   FViewport* Viewport = nullptr;
+  FEditorViewportClient* CaptureClient = nullptr;
   if (GEditor->PlayWorld != nullptr && GEditor->GetPIEViewport() != nullptr) {
     Viewport = GEditor->GetPIEViewport();
+  }
+  if (!Viewport) {
+    // Resolve through the same helper the camera handlers use, so the viewport
+    // that gets moved is provably the viewport that gets photographed.
+    CaptureClient = GetActiveEditorViewportClientForMcp();
+    if (CaptureClient) {
+      Viewport = CaptureClient->Viewport;
+      CaptureClient->Invalidate();
+    }
   }
   if (!Viewport) {
     Viewport = GEditor->GetActiveViewport();
@@ -172,6 +182,15 @@ bool UMcpAutomationBridgeSubsystem::HandleControlEditorScreenshot(
   if (bSaved) {
     Resp->SetStringField(TEXT("path"), FullPath);
     Resp->SetStringField(TEXT("screenshotPath"), FullPath);
+  }
+  // Ship the camera with the picture. Without it a caller cannot tell a correct
+  // frame from a frame taken somewhere else entirely, which is exactly how a
+  // camera handler that silently ignored its arguments stayed hidden.
+  if (CaptureClient) {
+    Resp->SetObjectField(TEXT("cameraLocation"),
+                         MakeVectorObjectForMcp(CaptureClient->GetViewLocation()));
+    Resp->SetObjectField(TEXT("cameraRotation"),
+                         MakeRotatorObjectForMcp(CaptureClient->GetViewRotation()));
   }
   AddScreenshotMetadataForMcp(Resp, Payload);
 


### PR DESCRIPTION
Every `set_camera` / `set_viewport_camera` / `set_camera_position` call parks the editor camera at the world origin, whatever the caller asked for, and answers `{"success":true}`. An automation client aiming the viewport gets the same picture back no matter where it aims, because **the camera never moves.**

## Repro

```jsonc
// any two calls with different positions
{"action":"set_viewport_camera","location":{"x":-3000,"y":0,"z":400},"rotation":{"pitch":0,"yaw":0,"roll":0}}
{"action":"screenshot","mode":"editor_viewport"}

{"action":"set_viewport_camera","location":{"x":0,"y":0,"z":0},"rotation":{"pitch":0,"yaw":0,"roll":0}}
{"action":"screenshot","mode":"editor_viewport"}
```

Both screenshots show the same view (the view from the origin). Same for `pitch: -89` looking straight down — the rotation is dropped too.

## Cause

```cpp
// McpAutomationBridge_ControlEditorCamera.cpp
if (Payload->TryGetObjectField(TEXT("location"), Loc) && Loc && (*Loc).IsValid())
    ReadVectorField(*Loc, TEXT(""), Location, Location);
```

`ReadVectorField` looks the vector up as a **named field of** the object it is given:

```cpp
// McpAutomationBridgeHelpersJsonFields.h:22
if (Obj->TryGetObjectField(FieldName, FieldObj) && FieldObj && (*FieldObj).IsValid()) { ... }
```

The handler had already extracted the `location` object and then asked *that object* for a field called `""`. No such field, no array branch either, so it falls through to the default — and the default is the zero-initialised `FVector` declared two lines above. Identical story for the rotation.

## Measured (UE 5.8)

Mean absolute pixel difference between the two captured frames, on a 64×32 downsample:

| | mean difference |
|---|---|
| **before:** requested (-3000, 0, 400) vs requested (0, 0, 0) | **2.33** / 255 — temporal-AA noise, i.e. the same frame |
| reference: two genuinely different views | 32–42 |
| **after:** requested (-600, 0, 250) vs (0, 0, 3000) pitch −89 | **39.35** |

## Changes

Three, because the parse bug alone is not what kept this hidden for so long.

**1. Parse from the payload with the field name.** The default is now the viewport's *current* camera rather than zero, so a rotation-only request no longer teleports the caller to the origin. Neither field present is `INVALID_ARGUMENT`.

**2. Move the same viewport the screenshot captures.** `set_camera` went through `UUnrealEditorSubsystem::SetLevelViewportCameraInfo`, which returns the **first perspective client** of `GEditor->GetLevelViewportClients()` (`UnrealEditorSubsystem.cpp:132`), while `HandleControlEditorScreenshot` reads `GEditor->GetActiveViewport()`. Those are not guaranteed to be the same viewport, so "set the camera, then take a picture" could address two different cameras. Both now resolve through `GetActiveEditorViewportClientForMcp()` — the helper the rest of the ControlEditor domain already uses.

**3. Stop reporting success for a no-op.** The response no longer echoes the request; it reads the camera back out of the viewport and reports `cameraLocation`, `cameraRotation`, `locationApplied`, `rotationApplied`, `perspective`, and returns `CAMERA_NOT_APPLIED` when they disagree. A viewport that is locked to an actor, piloting, or orthographic is now visible to the caller instead of silently winning.

The `editor_viewport` screenshot response also carries `cameraLocation` / `cameraRotation` now. A picture that cannot say where it was taken from is not evidence — with that field present this bug would have been caught immediately instead of surviving until someone compared pixels. (It proved itself during verification: it reported a camera that was not the one just set, because a human was moving the viewport by hand between two calls.)

## focus_actor, same surface

- `MoveViewportCamerasToActor` ends in `FocusViewportOnBox`, whose `bInstant` parameter **defaults to false** (`EditorServer.cpp:5213` → `EditorViewportClient.cpp:1004`), so the camera **animates**. A screenshot taken straight after the call catches it mid-flight, and an automation client cannot observe when the flight ends. The captured viewport now lands instantly via `FocusViewportOnBox(Box, /*bInstant=*/true)`; the engine call is kept first so other viewports keep their normal behaviour.
- The response previously carried **no payload at all**, so a caller could not distinguish a successful focus from one that framed nothing. It now returns `actorName`, `actorPath`, `boundsValid`, `focusCenter`, `focusExtent` and the resulting camera.
- Actor lookup matched `GetActorLabel()` only; `GetName()` is now a fallback, and the requested name goes into the `ACTOR_NOT_FOUND` message.
- `GEditor->Exec(nullptr, TEXT("EDITORTEMPVIEWPORT"))` is removed — no such console command exists anywhere in the UE 5.8 engine source, so it was a silent no-op.

## Verification

Body-only, no new translation units. Verified live on **UE 5.8** through Live Coding (`"Live coding succeeded"`): `set_camera` echoes the requested position back *from the viewport*, `focus_actor` reports `focusedInstantly: true`, and the frame separation in the table above.

Not compile-checked on 5.5–5.7. Every API used is long-standing and public in `EditorViewportClient.h` (`GetViewLocation`, `GetViewRotation`, `SetViewLocation`, `SetViewRotation`, `IsPerspective`, `FocusViewportOnBox`, `Invalidate`, the public `Viewport` member) and `AActor::GetComponentsBoundingBox`, but a spot-compile on an older branch would be worth having before merge if you keep 5.5 support.
