### PR TITLE
fix(build): UE 5.8 FJsonObject shared-string keys

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Execute/McpNativeGatewayIdempotency.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Execute/McpNativeGatewayIdempotency.cpp
@@ -15,8 +15,14 @@ void AppendCanonical(FString& Out, const TSharedPtr<FJsonValue>& Value);
 
 void AppendCanonicalObject(FString& Out, const TSharedPtr<FJsonObject>& Object)
 {
+	// FJsonObject's key type is FString before UE 5.8 and UE::FSharedString from
+	// 5.8 on, so the keys are copied out rather than read into a TArray<FString>.
 	TArray<FString> Keys;
-	Object->Values.GetKeys(Keys);
+	Keys.Reserve(Object->Values.Num());
+	for (const auto& Pair : Object->Values)
+	{
+		Keys.Add(FString(*Pair.Key));
+	}
 	// Sorting the keys is what makes the digest order-independent: two payloads
 	// that differ only in key order produce the same fingerprint.
 	Keys.Sort();
@@ -34,7 +40,7 @@ void AppendCanonicalObject(FString& Out, const TSharedPtr<FJsonObject>& Object)
 		KeyWriter->Close();
 		Out += EncodedKey;
 		Out += TEXT(":");
-		AppendCanonical(Out, Object->Values[Keys[Index]]);
+		AppendCanonical(Out, Object->Values.FindChecked(*Keys[Index]));
 	}
 	Out += TEXT("}");
 }

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Execute/McpNativeGatewayValidation.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Execute/McpNativeGatewayValidation.cpp
@@ -200,7 +200,7 @@ TSharedPtr<FJsonObject> McpProjectCanonicalOutput(
 	const TSharedPtr<FJsonObject>* Payload = nullptr;
 	const bool bHasPayload = Result->TryGetObjectField(TEXT("data"), Payload) && Payload;
 	TSharedPtr<FJsonObject> Projected = MakeShared<FJsonObject>();
-	for (const TPair<FString, TSharedPtr<FJsonValue>>& Property : (*Properties)->Values)
+	for (const auto& Property : (*Properties)->Values)
 	{
 		if (const TSharedPtr<FJsonValue>* Field = Result->Values.Find(Property.Key))
 		{

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Execute/McpNativeReceiptRedaction.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Execute/McpNativeReceiptRedaction.cpp
@@ -163,13 +163,13 @@ void MaskSecretsDeepInternal(const TSharedPtr<FJsonObject>& Object, int32 Depth)
 	{
 		return;
 	}
-	for (TPair<FString, TSharedPtr<FJsonValue>>& Pair : Object->Values)
+	for (auto& Pair : Object->Values)
 	{
 		// A secret-named KEY masks its ENTIRE value whatever the value's shape:
 		// an object, an array and a number can each carry a credential just as
 		// well as a string, and recursing would only find leaves that no longer
 		// carry the keyword context the string masker needs.
-		if (McpIsSecretKey(Pair.Key))
+		if (McpIsSecretKey(FString(*Pair.Key)))
 		{
 			Pair.Value = MakeShared<FJsonValueString>(TEXT("[REDACTED]"));
 			continue;

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Gateway/McpNativeGatewayCanonicalJson.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Gateway/McpNativeGatewayCanonicalJson.cpp
@@ -53,23 +53,27 @@ bool AppendObject(const TSharedPtr<FJsonObject>& Object, FString& Out)
 		Out.Append(TEXT("{}"));
 		return true;
 	}
-	TArray<FString> Keys;
-	Keys.Reserve(Object->Values.Num());
+	// Carry the value along with the key: FJsonObject's key type is FString before
+	// UE 5.8 and UE::FSharedString from 5.8 on, so a TArray<FString> of keys can no
+	// longer be used to index back into the map.
+	TArray<TPair<FString, TSharedPtr<FJsonValue>>> Entries;
+	Entries.Reserve(Object->Values.Num());
 	for (const auto& Pair : Object->Values)
 	{
-		Keys.Add(Pair.Key);
+		Entries.Emplace(FString(*Pair.Key), Pair.Value);
 	}
 	// UE FString relational operators are case-INsensitive; discovery output is
 	// diffed against JSON.stringify key order, which is by code unit.
-	Keys.Sort([](const FString& L, const FString& R) { return L.Compare(R, ESearchCase::CaseSensitive) < 0; });
+	Entries.Sort([](const TPair<FString, TSharedPtr<FJsonValue>>& L, const TPair<FString, TSharedPtr<FJsonValue>>& R)
+		{ return L.Key.Compare(R.Key, ESearchCase::CaseSensitive) < 0; });
 
 	Out.AppendChar(TEXT('{'));
-	for (int32 Index = 0; Index < Keys.Num(); ++Index)
+	for (int32 Index = 0; Index < Entries.Num(); ++Index)
 	{
 		if (Index > 0) Out.AppendChar(TEXT(','));
-		AppendEscaped(Keys[Index], Out);
+		AppendEscaped(Entries[Index].Key, Out);
 		Out.AppendChar(TEXT(':'));
-		if (!AppendValue(Object->Values[Keys[Index]], Out)) return false;
+		if (!AppendValue(Entries[Index].Value, Out)) return false;
 	}
 	Out.AppendChar(TEXT('}'));
 	return true;

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Gateway/McpNativeGatewayDescribe.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Gateway/McpNativeGatewayDescribe.cpp
@@ -44,9 +44,12 @@ TArray<FString> ParameterNames(const TSharedPtr<FJsonObject>& Schema)
 	TArray<FString> Names;
 	for (const auto& Pair : SchemaProperties(Schema)->Values)
 	{
-		if (Pair.Key.Equals(TEXT("action"), ESearchCase::CaseSensitive)) continue;
-		if (Pair.Key.Equals(TEXT("subAction"), ESearchCase::CaseSensitive)) continue;
-		Names.Add(Pair.Key);
+		// Both key types dereference to a null-terminated TCHAR buffer, so a view
+		// compares without allocating on every supported engine version.
+		const FStringView KeyView(*Pair.Key);
+		if (KeyView.Equals(TEXT("action"), ESearchCase::CaseSensitive)) continue;
+		if (KeyView.Equals(TEXT("subAction"), ESearchCase::CaseSensitive)) continue;
+		Names.Add(FString(*Pair.Key));
 	}
 	Names.Sort([](const FString& L, const FString& R) { return L.Compare(R, ESearchCase::CaseSensitive) < 0; });
 	return Names;

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Gateway/McpNativeGatewayDirectCallMigration.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Gateway/McpNativeGatewayDirectCallMigration.cpp
@@ -20,7 +20,7 @@ TSharedPtr<FJsonObject> MigratedParams(const TSharedPtr<FJsonObject>& Arguments)
 		{
 			Merged->Values = (*Nested)->Values;
 		}
-		for (const TPair<FString, TSharedPtr<FJsonValue>>& Field : Arguments->Values)
+		for (const auto& Field : Arguments->Values)
 		{
 			Merged->Values.Add(Field.Key, Field.Value);
 		}

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Tests/NativeProtocolCaptureTests.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Tests/NativeProtocolCaptureTests.cpp
@@ -127,7 +127,11 @@ bool FMcpTask38NativeProtocolCaptureTest::RunTest(const FString& Parameters)
 			{
 				bDataPresent = true;
 				TArray<FString> Keys;
-				(*DataObj)->Values.GetKeys(Keys);
+				Keys.Reserve((*DataObj)->Values.Num());
+				for (const auto& Pair : (*DataObj)->Values)
+				{
+					Keys.Add(FString(*Pair.Key));
+				}
 				Keys.Sort();
 				for (const FString& Key : Keys) { DataKeys.Add(MakeShared<FJsonValueString>(Key)); }
 			}


### PR DESCRIPTION
Closes the remaining half of the UE 5.8 build failure recorded in `docs/performance-and-evidence.md`. #565 fixed the `UUserDefinedEnum::SetEnums` half; this is the `FJsonObject` half.

## Problem

UE 5.8 changed `FJsonObject`'s key storage from `FString` to `UE::FSharedString` so recurring keys share one allocation. The accessor API moved to `FStringView` and absorbs `FString` transparently, so the overwhelming majority of call sites are unaffected — including the 38 existing `for (const auto& Pair : ...->Values)` loops, which need no change at all.

What breaks is code that touches `FJsonObject::Values` directly **and names `FString` explicitly**. On UE 5.8.0 that is **15 errors across 7 files**, in four shapes:

| Shape | Files |
| --- | --- |
| `TArray<FString>` populated from a key, or used to index back into `Values`; `Values.GetKeys(TArray<FString>&)` no longer resolves | `McpNativeGatewayCanonicalJson`, `McpNativeGatewayIdempotency`, `NativeProtocolCaptureTests` |
| `FString::Equals` called on a key | `McpNativeGatewayDescribe` |
| explicit `const TPair<FString, ...>&` loop variable whose key is passed to `Values.Find()` / `Values.Add()` | `McpNativeGatewayValidation`, `McpNativeGatewayDirectCallMigration` |
| non-const `TPair<FString, ...>&` loop variable | `McpNativeReceiptRedaction` |

Worth noting for review: in the third shape the **loop header itself compiles** — the const reference binds to a converted temporary — so the diagnostic surfaces later, at the `Find`/`Add` call, and reads as a `TMapBase::Find` overload failure rather than anything about the loop. The non-const case in the fourth shape cannot bind to that temporary and fails at the loop itself.

## Fix

Every change is version-agnostic — no `ENGINE_MINOR_VERSION` guards, and no new compat macro:

- Loop variables become `auto`, so the key keeps whatever type the map uses.
- Where an `FString` is genuinely required, the key is dereferenced: both `FString` and `UE::FSharedString` yield a null-terminated `TCHAR` buffer through `operator*`.
- Where a key comparison is all that's needed, an `FStringView` over that buffer compares without allocating.
- Where a key array was used to index back into the map, the value is carried alongside the key instead. That also drops a redundant hash lookup per key.

Behaviour is unchanged on every supported engine version, including the case-sensitive key ordering that canonical JSON and the idempotency digest depend on.

## Verification

UE 5.8.0, `UnrealBuildTool -Module=McpAutomationBridge` (compiles the module, no link step):

- before: 15 `error C....` across the 7 files above
- after: **exit 0, 0 errors**

Scope of that claim, stated precisely: this is a compile result for the whole module on 5.8, not a runtime or behavioural test — nothing here was exercised live. I have no 5.0–5.7 root available to re-confirm the older engines, but every construct used (`auto` loop variables, `operator*` on the key, `FStringView::Equals`) is valid on all of them, and no existing `#if` branch was touched.
