### PR TITLE
fix(tests): repair the two dev suites that had never run in CI

### DIFF
--- a/tests/harness/native-discovery/ue-shim/CoreMinimal.h
+++ b/tests/harness/native-discovery/ue-shim/CoreMinimal.h
@@ -23,6 +23,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 using int32 = std::int32_t;
@@ -30,6 +31,10 @@ using int64 = std::int64_t;
 using uint8 = std::uint8_t;
 using uint32 = std::uint32_t;
 using TCHAR = wchar_t;
+
+// UE's "not found" sentinel. FString::FindLastChar below reports it on failure,
+// so it has to be declared before FString.
+constexpr int32 INDEX_NONE = -1;
 
 #define TEXT(x) L##x
 #define check(expr) assert(expr)
@@ -41,6 +46,29 @@ enum class ESearchCase : uint8 { CaseSensitive, IgnoreCase };
 template <typename T> using TFunctionRef = std::function<T>;
 template <typename T> constexpr T&& MoveTemp(T& value) { return static_cast<T&&>(value); }
 template <typename T> void Swap(T& a, T& b) { std::swap(a, b); }
+
+// UE's TPair spells its members `.Key` / `.Value`, not std::pair's `.first` /
+// `.second`, and the canonical-JSON writer carries key/value together in a
+// TArray<TPair<...>> because FJsonObject's key type changed in UE 5.8.
+//
+// The two-argument constructor forwards rather than taking `const&`, so an
+// rvalue key and an lvalue value bind in the same call. Being a TWO-parameter
+// template it can never hijack the one-parameter copy or move constructor.
+template <typename K, typename V>
+struct TPair
+{
+	K Key{};
+	V Value{};
+
+	TPair() = default;
+
+	template <typename InKeyType, typename InValueType>
+	TPair(InKeyType&& InKey, InValueType&& InValue)
+		: Key(std::forward<InKeyType>(InKey))
+		, Value(std::forward<InValueType>(InValue))
+	{
+	}
+};
 
 class FString
 {
@@ -86,6 +114,29 @@ public:
 	{
 		if (Case == ESearchCase::CaseSensitive) return Data == Other.Data;
 		return ToLower().Data == Other.ToLower().Data;
+	}
+
+	// UE reports INDEX_NONE in the out-parameter when the character is absent, so
+	// a caller that checks only the out-parameter behaves the same here.
+	bool FindLastChar(TCHAR Ch, int32& OutIndex) const
+	{
+		const size_t Found = Data.rfind(Ch);
+		if (Found == std::wstring::npos)
+		{
+			OutIndex = INDEX_NONE;
+			return false;
+		}
+		OutIndex = static_cast<int32>(Found);
+		return true;
+	}
+
+	// Drops the FIRST `Count` characters. UE clamps rather than throwing: a count
+	// at or past the end yields an empty string, a non-positive count the whole one.
+	FString RightChop(int32 Count) const
+	{
+		if (Count <= 0) return *this;
+		if (Count >= Len()) return FString();
+		return FString(Data.substr(static_cast<size_t>(Count)));
 	}
 
 	int32 Compare(const FString& Other, ESearchCase Case = ESearchCase::IgnoreCase) const
@@ -148,6 +199,15 @@ public:
 	void Empty() { Items.clear(); }
 	void Add(const T& Value) { Items.push_back(Value); }
 	void Add(T&& Value) { Items.push_back(std::move(Value)); }
+
+	// UE's TArray::Emplace constructs in place and returns the new INDEX (it is
+	// Emplace_GetRef that hands back a reference).
+	template <typename... ArgTypes>
+	int32 Emplace(ArgTypes&&... Args)
+	{
+		Items.emplace_back(std::forward<ArgTypes>(Args)...);
+		return static_cast<int32>(Items.size()) - 1;
+	}
 	void AddUnique(const T& Value) { if (!Contains(Value)) Items.push_back(Value); }
 	void SetNumUninitialized(int32 Count) { Items.resize(static_cast<size_t>(Count)); }
 	T& operator[](int32 Index) { return Items[static_cast<size_t>(Index)]; }

--- a/tests/unit/unrealagent-removal-contract.test.ts
+++ b/tests/unit/unrealagent-removal-contract.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 // ============================================================================
@@ -34,21 +34,46 @@ const UPLUGIN = `plugins/${UA}/${UA}.uplugin`;
 const isIntentionalStatement = (line: string): boolean =>
   line.includes(UA) && /removed/i.test(line) && /external consumer/i.test(line);
 
-// ripgrep needs an explicit path under `execFileSync` (the no-path form searches
-// nothing when stdin is not a TTY). `.` searches the repo root recursively; the
-// hidden `.omo` directory is skipped by default, mirroring the acceptance
-// command's `--glob '!.omo/**'` intent.
-const runRgRepoOwned = (): string => {
-  try {
-    return execFileSync(
-      'rg',
-      ['-n', PATTERN, '.'],
-      { encoding: 'utf8' },
-    ).trim();
-  } catch {
-    // rg exits non-zero when there are zero matches; treat that as empty.
-    return '';
+// "Repository-owned" is exactly the set of TRACKED files, so the scan enumerates
+// them with `git ls-files` and reads them in process. `.omo` is untracked, so it
+// is excluded for free — no glob needed.
+//
+// This replaced a `rg` shell-out that could never pass in CI. ripgrep is not
+// installed on GitHub runners and nothing in the workflow installs it, so
+// `execFileSync` threw ENOENT; the catch treated that exactly like ripgrep's
+// "no matches" exit code and returned an empty string. A MISSING TOOL therefore
+// reported as a MISSING MIGRATION STATEMENT, and the contract only passed on
+// machines that happened to have rg on PATH. Reading the files here removes the
+// external dependency, so the contract means the same thing everywhere.
+const isBinary = (contents: Buffer): boolean => contents.subarray(0, 8192).includes(0);
+
+const runRepoOwnedScan = (): string => {
+  const tracked = execFileSync('git', ['ls-files', '-z'], {
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  })
+    .split('\0')
+    .filter(Boolean);
+
+  const matcher = new RegExp(PATTERN);
+  const hits: string[] = [];
+  for (const file of tracked) {
+    let contents: Buffer;
+    try {
+      contents = readFileSync(file);
+    } catch {
+      // Listed but unreadable: a submodule entry, or deleted mid-scan.
+      continue;
+    }
+    if (isBinary(contents)) continue;
+    contents
+      .toString('utf8')
+      .split(/\r?\n/u)
+      .forEach((line, index) => {
+        if (matcher.test(line)) hits.push(`${file}:${index + 1}:${line}`);
+      });
   }
+  return hits.join('\n');
 };
 
 describe('Task 7 — ACP panel plugin removal contract', () => {
@@ -67,7 +92,7 @@ describe('Task 7 — ACP panel plugin removal contract', () => {
   });
 
   it('rg over repo-owned files returns only the intentional migration statement', () => {
-    const raw = runRgRepoOwned();
+    const raw = runRepoOwnedScan();
     const lines = raw.split('\n').filter(Boolean);
     expect(
       lines.length,


### PR DESCRIPTION
## Summary

Fixes two test failures on `dev` that had never run in CI. Both were introduced in July, after the last CI run on 2026-06-05, and surfaced for the first time when #587 enabled the gates on `dev`. Neither is a regression from any recent change — they have simply never been executed on a runner.

They are unrelated to each other and to #587; this PR exists so #587 can go green on a re-run without absorbing unrelated work.

## Changes

- **`unrealagent-removal-contract.test.ts`** failed with `expected exactly one residual match, found 0` — which reads as a missing migration statement. The statement was present; **ripgrep was not**. `rg` is not installed on GitHub runners and nothing in the workflow installs it, so `execFileSync` threw `ENOENT`. The `catch` was written for ripgrep's documented "no matches" exit code and swallowed the missing binary identically, returning an empty string — so a tooling gap reported as a contract violation, and the test passed only on machines that happened to have `rg` on `PATH`. The scan now enumerates tracked files with `git ls-files` and reads them in process, which is also a truer reading of "repository-owned" than a recursive walk: it is exactly the tracked set, and `.omo` is untracked so it drops out without a glob. Binary files are skipped on a NUL-byte probe, as ripgrep does.

- **`tests/harness/native-discovery/ue-shim/CoreMinimal.h`** was missing surface the plugin sources now use, so `build.sh` failed to compile and took both native-discovery contract suites with it. Added `INDEX_NONE`, `FString::FindLastChar`, `FString::RightChop` (used by `McpCapabilityPublicAction`), plus `TPair` and `TArray::Emplace` (used by the canonical JSON writer, which now carries key and value together because `FJsonObject`'s key type became `UE::FSharedString` in 5.8, so a `TArray<FString>` of keys can no longer index back into the map).

Shim semantics follow the engine rather than the nearest standard-library equivalent, which is this file's stated contract — it is "never more forgiving than the engine". `FindLastChar` reports `INDEX_NONE` in its out-parameter when absent, `RightChop` clamps instead of throwing, and `Emplace` returns the new index rather than a reference, since that is `Emplace_GetRef`. `TPair` spells its members `Key`/`Value`, not `first`/`second`.

## Related Issues

Unblocks #587, which is red only because of these two pre-existing failures.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration/build change
- [ ] ♻️ Refactoring (no functional changes)
- [x] 🧪 Test addition/update

## Testing

- [ ] Tested with Unreal Engine (version: ___)
- [ ] Tested MCP client integration (client: ___)
- [ ] Added/updated tests

- `unrealagent-removal-contract.test.ts` — 3 passed locally, and passing for the right reason rather than vacuously: 2813 tracked files scanned, exactly one match, and it is the intentional statement at `docs/protocol.md:206`.
- `type-check` — 0. `eslint --max-warnings=0` on the changed test — 0.
- **The shim change could not be verified locally.** `build.sh` needs a POSIX shell and `g++`, and there is no C++ toolchain on the machine this was written on. CI is the check — the `Lint (TS)` job compiles the harness as part of `test:unit`, so this PR's own run is the verification.

## Pre-Merge Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [ ] Updated relevant documentation (if needed)
- [ ] Added/updated tests (if applicable)
- [ ] CI passes

Worth noting for the reviewer: both of these were invisible because `ci.yml` gated on `main` while every PR targets `dev`, so the suite had not run since 2026-06-05. #587 fixes that trigger. Until it merges, this PR only gets the full gates because it is itself a PR — which is exactly the gap being closed.
