### PR TITLE
fix(blueprint): route bare remove_variable/rename_variable on native transport

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Blueprint/Variables/McpAutomationBridge_BlueprintHandlersVariableRemovalRename.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Blueprint/Variables/McpAutomationBridge_BlueprintHandlersVariableRemovalRename.cpp
@@ -14,7 +14,9 @@ namespace McpBlueprintHandlers {
 bool HandleBlueprintRemoveRenameVariable(const FBlueprintActionContext &Context) {
   MCP_BLUEPRINT_ACTION_LOCALS(Context);
   if (ActionMatchesPattern(TEXT("blueprint_remove_variable")) ||
-      AlphaNumLower.Contains(TEXT("blueprintremovevariable"))) {
+      ActionMatchesPattern(TEXT("remove_variable")) ||
+      AlphaNumLower.Contains(TEXT("blueprintremovevariable")) ||
+      AlphaNumLower.Contains(TEXT("removevariable"))) {
     UE_LOG(LogMcpAutomationBridgeSubsystem, Verbose,
            TEXT("Entered blueprint_remove_variable handler: RequestId=%s"),
            *RequestId);
@@ -101,7 +103,9 @@ bool HandleBlueprintRemoveRenameVariable(const FBlueprintActionContext &Context)
   }
 
   if (ActionMatchesPattern(TEXT("blueprint_rename_variable")) ||
-      AlphaNumLower.Contains(TEXT("blueprintrenamevariable"))) {
+      ActionMatchesPattern(TEXT("rename_variable")) ||
+      AlphaNumLower.Contains(TEXT("blueprintrenamevariable")) ||
+      AlphaNumLower.Contains(TEXT("renamevariable"))) {
     UE_LOG(LogMcpAutomationBridgeSubsystem, Verbose,
            TEXT("Entered blueprint_rename_variable handler: RequestId=%s"),
            *RequestId);


### PR DESCRIPTION
## Summary

Fixes the native-transport half of **Flopsstuff/uemcp#6** — `manage_blueprint action=remove_variable` and `action=rename_variable` returning `Error [UNKNOWN_ACTION]` even though the handlers exist.

## Root cause (static trace, file:line)

The native MCP transport calls the `manage_blueprint` tool directly with `{action: "remove_variable"|"rename_variable", ...}` (no `blueprint_` prefix). The dispatch path:

1. `RegisterBlueprintAndDomainHandlers` — `remove_variable`/`rename_variable` are neither widget-authoring nor graph sub-actions, so it calls `HandleBlueprintAction(R, "manage_blueprint", P, S)` (`McpAutomationBridgeSubsystemBlueprintDomainRegistration.cpp:37`).
2. `BuildBlueprintActionContext` → `ExtractNestedManageAction` reads the nested `action` field and stores it **verbatim** as the bare form: `Lower="remove_variable"`, `AlphaNumLower="removevariable"` (`McpAutomationBridge_BlueprintHandlersShared.cpp:38-61`).
3. `HandleBlueprintRemoveRenameVariable` only matched `blueprint_remove_variable` / `blueprint_rename_variable` (`McpAutomationBridge_BlueprintHandlersVariableRemovalRename.cpp:16-17,103-104`), so neither the exact nor the alphanum check hit → handler returns `false` → no route consumes the request → `UNKNOWN_ACTION`.

The `blueprint_`-prefixed spelling is what the **TypeScript bridge** emits; the native path never applies that normalization, so it delivers the bare form the handler never matched.

**Why only these two actions:** every sibling handler already matches *both* the bare and prefixed forms — `add_variable` (`…AddVariable.cpp:21-24`), `remove_event`, `remove_function`, `modify_scs`, `get`, `compile`, etc. `HandleBlueprintRemoveRenameVariable` was the sole exception.

## Fix

Add the bare-form matchers (`remove_variable` / `removevariable`, `rename_variable` / `renamevariable`) alongside the existing prefixed ones, mirroring `HandleBlueprintAddVariable`. Trust-the-boundary: the bare form is the canonical shape the manage-wrapper extraction hands to the handler. No change to the already-working prefixed/TS path.

```
-  if (ActionMatchesPattern(TEXT("blueprint_remove_variable")) ||
-      AlphaNumLower.Contains(TEXT("blueprintremovevariable"))) {
+  if (ActionMatchesPattern(TEXT("blueprint_remove_variable")) ||
+      ActionMatchesPattern(TEXT("remove_variable")) ||
+      AlphaNumLower.Contains(TEXT("blueprintremovevariable")) ||
+      AlphaNumLower.Contains(TEXT("removevariable"))) {
```
(same shape for `rename_variable`).

Swept the other routed blueprint handlers — no other action has this bare-form gap.

## Verification

⚠️ **Needs in-editor verification by a maintainer.** This ARM64 host has no Unreal Engine, so the plugin cannot be compiled or run in-editor. This is a static-analysis fix only; I have **not** claimed it builds or runs.

Manual checks for the maintainer (from the original issue acceptance):
- `manage_blueprint action=remove_variable blueprintPath=<BP> variableName=TmpVar` over the **native** transport → removes only `TmpVar`, blueprint recompiles clean, other variables untouched.
- `manage_blueprint action=rename_variable blueprintPath=<BP> oldName=X newName=Y` over the **native** transport → renames X→Y and updates references, blueprint recompiles clean.
- Confirm the existing TS-bridge path (prefixed `blueprint_remove_variable`) still works — no regression expected.

Fixes Flopsstuff/uemcp#6 (upstream target: `dev`).
