### PR TITLE
fix(blueprint): honor posX/posY on native create_node/reroute

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersNodeCreation.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersNodeCreation.cpp
@@ -208,8 +208,21 @@ bool HandleNodeCreationAction(FActionContext& Context)
     Context.Payload->TryGetStringField(TEXT("nodeType"), NodeType);
     float X = 0.0f;
     float Y = 0.0f;
-    Context.Payload->TryGetNumberField(TEXT("x"), X);
-    Context.Payload->TryGetNumberField(TEXT("y"), Y);
+    // The TS bridge maps posX->x / posY->y before dispatch (graph-handlers.ts),
+    // but the native transport delivers the payload unnormalized, so a caller's
+    // posX/posY reach this handler verbatim. Read x first, then fall back to the
+    // tool-facing posX/posY names — mirroring the PCG graph handler and add_node,
+    // which already accept posX/posY. Without this, native callers that send
+    // posX/posY (the documented alias in the manage_blueprint schema) land every
+    // node at (0,0).
+    if (!Context.Payload->TryGetNumberField(TEXT("x"), X))
+    {
+        Context.Payload->TryGetNumberField(TEXT("posX"), X);
+    }
+    if (!Context.Payload->TryGetNumberField(TEXT("y"), Y))
+    {
+        Context.Payload->TryGetNumberField(TEXT("posY"), Y);
+    }
 
     if (TryCreateCommonFunctionNode(Context, NodeType, X, Y) ||
         TryCreateVariableNode(Context, NodeType, X, Y) ||

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersNodeMutations.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersNodeMutations.cpp
@@ -67,8 +67,16 @@ static bool CreateRerouteNode(FActionContext& Context)
 
     float X = 0.0f;
     float Y = 0.0f;
-    Context.Payload->TryGetNumberField(TEXT("x"), X);
-    Context.Payload->TryGetNumberField(TEXT("y"), Y);
+    // Match create_node: accept the tool-facing posX/posY names, which reach the
+    // native transport unnormalized (the TS bridge's posX->x mapping is bypassed).
+    if (!Context.Payload->TryGetNumberField(TEXT("x"), X))
+    {
+        Context.Payload->TryGetNumberField(TEXT("posX"), X);
+    }
+    if (!Context.Payload->TryGetNumberField(TEXT("y"), Y))
+    {
+        Context.Payload->TryGetNumberField(TEXT("posY"), Y);
+    }
 
     FGraphNodeCreator<UK2Node_Knot> NodeCreator(*Context.TargetGraph);
     UK2Node_Knot* RerouteNode = NodeCreator.CreateNode(false);


### PR DESCRIPTION
## Fixes Flopsstuff/uemcp#8 (upstream target: `dev`)

`manage_blueprint action=create_node ... posX=600 posY=6300` places every node at **(0,0)** on the **native MCP transport** (claude-code WebSocket/HTTP → C++ `McpAutomationBridge`, no TS bridge in the loop).

### Root cause — parameter-name mismatch (not a pin-allocation-order bug)

The C++ `create_node` handler reads only the **`x`/`y`** payload fields:

```cpp
// McpAutomationBridge_BlueprintGraphHandlersNodeCreation.cpp:211-212 (before)
Context.Payload->TryGetNumberField(TEXT("x"), X);
Context.Payload->TryGetNumberField(TEXT("y"), Y);
```

But callers send **`posX`/`posY`** (the aliases declared on the `manage_blueprint` schema — `McpTool_ManageBlueprint.cpp:74-75`). On the **TypeScript** path these are normalized to `x`/`y` before dispatch:

```ts
// src/tools/handlers/graph/graph-handlers.ts:153-158
if (processedRecord.x === undefined && typeof processedRecord.posX === 'number') processedRecord.x = processedRecord.posX;
if (processedRecord.y === undefined && typeof processedRecord.posY === 'number') processedRecord.y = processedRecord.posY;
```

The **native transport does not run that normalization** — it forwards the payload verbatim (`McpNativeTransportJsonRpc.cpp` only maps `action`→`subAction`, lines 245-252). So `posX`/`posY` reach the handler untouched, `TryGetNumberField("x")` finds nothing, `X`/`Y` stay `0.0f`, and `NodePosX/Y` are set to 0.

The values *are* applied to the node on every code path (`FinalizeNode` sets them before `NodeCreator.Finalize()`; the generic path sets them after `AllocateDefaultPins()` — both fine). The reporter's guessed "assigned before `AllocateDefaultPins`" theory is **not** the cause — the position is simply always read as 0. This also explains why the node is otherwise created correctly (`nodeType`/`memberName`/`memberClass` all arrive at the payload root fine — the payload is flat, not nested).

### Fix

Read `x`/`y` first, fall back to `posX`/`posY` — mirroring the pattern the repo already uses for exactly this alias in the PCG graph handler (`McpAutomationBridge_PCGHandlersGraph.cpp:201-202`) and in the working `add_node` handler (which reads `posX`/`posY` directly). Applied at the single point where each handler extracts position (values are then threaded to every node-type branch as params):

- `create_node` — `McpAutomationBridge_BlueprintGraphHandlersNodeCreation.cpp`
- `create_reroute_node` — `McpAutomationBridge_BlueprintGraphHandlersNodeMutations.cpp` (identical latent bug in the same domain/tool; fixed here to avoid an immediate follow-up report)

With none of the four fields present, position defaults to `0` exactly as before — **no regression**.

### ⚠️ Needs in-editor verification by a maintainer

This host is **Raspberry Pi / ARM64 with no Unreal Engine** — the plugin cannot be compiled or run in-editor here. This is a **static-analysis fix only**; it has **not** been build- or editor-verified. Please confirm against issue #8's acceptance checks:

- [ ] `create_node ... posX=600 posY=6300` (native transport) → `get_node_details` reports `x:600, y:6300`.
- [ ] Multiple created nodes appear at their requested positions, not overlapping at the origin.
- [ ] No regression: nodes created without `posX`/`posY` still get a sane default (0,0) position.
- [ ] (Bonus) `create_reroute_node` with `posX`/`posY` lands at the requested position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)