### PR TITLE
fix(build): guard bCompileForEdit so UE 5.5 compiles

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/NiagaraAuthoring/McpAutomationBridge_NiagaraAuthoringHandlersStackIssues.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/NiagaraAuthoring/McpAutomationBridge_NiagaraAuthoringHandlersStackIssues.cpp
@@ -73,7 +73,12 @@ void CollectNiagaraSystemStackIssues(
         Options.bCanAutoCompile = false;
         Options.bCanModifyEmittersFromTimeline = false;
         Options.bCanSimulate = false;
+        // bCompileForEdit landed in 5.6; it is absent on 5.5 (measured 2026-08-04). We set it FALSE,
+        // and on 5.5 the concept simply does not exist -- skipping the assignment is the same
+        // behavior, not a degradation.
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6)
         Options.bCompileForEdit = false;
+#endif
         Options.bIsForDataProcessingOnly = false;
         Options.EditMode = ENiagaraSystemViewModelEditMode::SystemAsset;
         // Initialize() -> RefreshAll() subscribes to the Niagara message manager keyed by this GUID;


### PR DESCRIPTION
## Problem

`FNiagaraSystemViewModelOptions::bCompileForEdit` was added in UE **5.6** (`NiagaraSystemViewModel.h:105`) — it does not exist in **5.5**. The assignment setting it to `false` is unconditional, so the 5.5 build fails.

## Fix

Guard the assignment on engine version. The concept does not exist on 5.5, so it is skipped rather than emulated.

## Behaviour

- **5.5:** assignment skipped; no behaviour difference (nothing to compile-for-edit).
- **5.6+:** bit-identical.

Sibling of the `bUseLosslessCompression` guard in #599 — both found while building a 5.5–5.8 packaging matrix.