### PR TITLE
fix(inspect): stop leaking the raw automation envelope on PROPERTY_NOT_FOUND

### DIFF
--- a/src/tools/handlers/inspect/inspect-property-actions.ts
+++ b/src/tools/handlers/inspect/inspect-property-actions.ts
@@ -92,10 +92,17 @@ async function tryComponentProperties(
       });
     }
 
+    // Surface *why* the component sweep could not run, but never the raw
+    // automation envelope: it carries transport internals (type,
+    // requestId) that mean nothing to the caller and cannot be acted on.
+    const lookupReason = compsRes.success
+      ? 'returned success but no component list'
+      : `failed: ${typeof compsRes.error === 'string' ? compsRes.error : JSON.stringify(compsRes.error) || 'unknown error'}${
+        compsRes.message ? ` (${String(compsRes.message)})` : ''}`;
+
     return cleanObject({
       ...res,
-      message: `${res.message as string} (Smart Lookup failed: get_components returned ${compsRes.success ? 'success but no list' : `failure: ${compsRes.error}`} | Name: ${shortName} Path: ${actorName})`,
-      smartLookupGetComponentsError: compsRes
+      message: `${res.message as string} (Smart Lookup could not enumerate components: get_components ${lookupReason}. Looked for '${shortName}' under '${actorName}'. Verify the actor/Blueprint path, then retry with an explicit component path.)`
     });
   } catch (error: unknown) {
     const errorMsg = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Problem

When Smart Lookup could not enumerate components, `get_property`'s `PROPERTY_NOT_FOUND` response embedded the **raw automation envelope** in its message:

```
smartLookupGetComponentsError: {type=automation_response, requestId=..., ...}
```

That exposes internal transport shape to the caller and tells them nothing they can act on.

## Fix

`cleanObject` is a cycle/depth guard, not a redactor — so the fix belongs at the leak site rather than there.

The raw object is replaced with one sentence answering what the caller actually needs:
- **why** `get_components` could not run (and its message, when there is one),
- **which** name/path was tried,
- **what to do next** (verify the actor/Blueprint path, then retry with an explicit component path).

Observed in the field on UE 5.8.