### PR TITLE
fix(property): accept the export text the tool itself emits

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Foundation/BridgeHelpers/Properties/McpAutomationBridgeHelpersPropertyApplyArrays.h
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Foundation/BridgeHelpers/Properties/McpAutomationBridgeHelpersPropertyApplyArrays.h
@@ -1,5 +1,14 @@
 #pragma once
 
+#include "CoreMinimal.h"
+#include "Dom/JsonValue.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+
+// Include it rather than forward-declaring: relying on McpAutomationBridgeHelpersPropertyApply.h
+// listing Objects before Arrays makes a build break out of swapping two include lines.
+#include "Foundation/BridgeHelpers/Properties/McpAutomationBridgeHelpersPropertyApplyObjects.h"
+
 static inline bool ApplyJsonArrayValueToProperty(void *TargetContainer, FProperty *Property,
                                                  const TSharedPtr<FJsonValue> &ValueField,
                                                  FString &OutError) {
@@ -7,7 +16,34 @@ static inline bool ApplyJsonArrayValueToProperty(void *TargetContainer, FPropert
   // types will return an error to avoid relying on ImportText-like APIs.
   if (FArrayProperty *AP = CastField<FArrayProperty>(Property)) {
     if (ValueField->Type != EJson::Array) {
-      OutError = TEXT("Expected array for array property");
+      // Callers commonly hand us an array that is *already* serialized: either
+      // a double-encoded JSON array ("[1, 2, 3]") or UE export text
+      // ("((Animation=\"...\",SampleValue=...))"), which is what get_property
+      // returns for array properties. Accept both before failing.
+      if (ValueField->Type == EJson::String) {
+        const FString Txt = ValueField->AsString();
+
+        TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Txt);
+        TArray<TSharedPtr<FJsonValue>> ParsedArray;
+        if (FJsonSerializer::Deserialize(Reader, ParsedArray)) {
+          const TSharedPtr<FJsonValue> Reparsed =
+              MakeShared<FJsonValueArray>(ParsedArray);
+          return ApplyJsonArrayValueToProperty(TargetContainer, Property,
+                                               Reparsed, OutError);
+        }
+
+        if (ImportExportTextIntoValue(
+                AP->ContainerPtrToValuePtr<void>(TargetContainer), AP, Txt)) {
+          return true;
+        }
+      }
+
+      OutError = FString::Printf(
+          TEXT("Expected a JSON array for array property '%s'. Accepted forms: "
+               "a JSON array ([1, 2, 3]), the same array as a JSON string "
+               "(\"[1, 2, 3]\"), or UE export text ((A=1,B=2)) -- the form "
+               "get_property returns."),
+          *AP->GetName());
       return false;
     }
     FScriptArrayHelper Helper(
@@ -77,9 +113,25 @@ static inline bool ApplyJsonArrayValueToProperty(void *TargetContainer, FPropert
         continue;
       }
 
-      // Unsupported inner type -> fail explicitly
-      OutError =
-          TEXT("Unsupported array inner property type for JSON assignment");
+      // Last resort for element types the JSON path cannot express: let the
+      // engine parse the element's export text.
+      if (V->Type == EJson::String &&
+          ImportExportTextIntoValue(ElemPtr, Inner, V->AsString())) {
+        continue;
+      }
+
+      // Still no: say which element failed, what it is, and what we accept --
+      // "Unsupported array inner property type" told the caller nothing.
+      OutError = FString::Printf(
+          TEXT("Could not convert element %d of array property '%s' (element "
+               "type '%s'%s). Directly supported element types: string, name, "
+               "bool, float, double, int32, int64, byte, object reference, "
+               "soft object/class reference, and struct (as a JSON object or "
+               "UE export text)."),
+          i, *AP->GetName(),
+          Inner ? *Inner->GetClass()->GetName() : TEXT("<unknown>"),
+          InnerError.IsEmpty() ? TEXT("")
+                               : *FString::Printf(TEXT(": %s"), *InnerError));
       return false;
     }
     return true;

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Foundation/BridgeHelpers/Properties/McpAutomationBridgeHelpersPropertyApplyObjects.h
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Foundation/BridgeHelpers/Properties/McpAutomationBridgeHelpersPropertyApplyObjects.h
@@ -1,10 +1,65 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Misc/ScopeExit.h"
 #include "Dom/JsonObject.h"
 #include "JsonObjectConverter.h"
 #include "Serialization/JsonReader.h"
 #include "Serialization/JsonSerializer.h"
+
+/**
+ * Import a UE export-text value into an already-resolved property value slot.
+ *
+ * Export text is the `(Key=Value,...)` form that ExportTextItem produces --
+ * and it is exactly what `get_property` hands back to callers. Without an
+ * import path for it, a caller could not feed our own output back into
+ * `set_property`: reading `LayoutData` returned
+ * `(Offsets=(Left=-48.000000,...))`, and passing that same string back failed
+ * with PROPERTY_CONVERSION_FAILED. Accepting it closes that read/write
+ * asymmetry.
+ *
+ * @param ValuePtr Pointer to the property's value (NOT the container).
+ */
+static inline bool ImportExportTextIntoValue(void *ValuePtr, FProperty *Property,
+                                             const FString &Text) {
+  if (!ValuePtr || !Property || Text.IsEmpty()) {
+    return false;
+  }
+
+  // Parse into SCRATCH, not into the live property. ImportText writes struct members as it parses, so on
+  // malformed input it returns nullptr having ALREADY written whatever it managed to read:
+  // "(Offsets=(Left=10,Top=NOTANUMBER))" would leave Left=10 on the real object while the caller is told the
+  // conversion failed. That is the same "the report disagrees with the object" class this batch exists to
+  // remove, just inverted — and 0067 now turns it into a hard success:false, which would make the lie louder.
+  // Honour the property's REQUIRED alignment: TArray<uint8> only guarantees the default allocator alignment,
+  // and FProperty::GetMinAlignment() exists because that is not always enough. FTransform/FQuat/FVector4/
+  // FMatrix are alignas(16), and InitializeValue/ImportText on an under-aligned buffer for an SSE type is
+  // undefined behaviour. UE's binned allocator happens to return 16-aligned blocks for sizes >= 16, which is
+  // exactly why getting this wrong would surface as a rare crash rather than a failing test.
+  const int32 ScratchSize = Property->GetSize();
+  const int32 ScratchAlign = Property->GetMinAlignment();
+  void *Scratch = FMemory::Malloc(ScratchSize, ScratchAlign);
+  if (!Scratch) {
+    return false;
+  }
+  Property->InitializeValue(Scratch);
+  ON_SCOPE_EXIT {
+    Property->DestroyValue(Scratch);
+    FMemory::Free(Scratch);
+  };
+
+  const TCHAR *Result = nullptr;
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
+  Result = Property->ImportText_Direct(*Text, Scratch, nullptr, PPF_None, nullptr);
+#else
+  Result = Property->ImportText(*Text, Scratch, PPF_None, nullptr);
+#endif
+  if (!Result) {
+    return false;
+  }
+  Property->CopyCompleteValue(ValuePtr, Scratch);
+  return true;
+}
 
 static inline bool ApplyJsonObjectValueToProperty(void *TargetContainer, FProperty *Property,
                                                   const TSharedPtr<FJsonValue> &ValueField,
@@ -137,12 +192,15 @@ static inline bool ApplyJsonObjectValueToProperty(void *TargetContainer, FProper
 					}
 				}
 
-				// NOTE: ImportText-based struct parsing is intentionally omitted
-				// because engine textual import signatures differ across engine
-				// revisions and can produce fragile compilation failures. If a
-				// non-JSON textual import format is required in the future we
-				// can implement a safe parser here or add an explicit engine
-				// compatibility shim guarded by a feature macro.
+				// The string was not JSON. Fall back to UE's own textual import,
+				// which accepts the export-text form `get_property` emits. The
+				// engine-revision differences that previously kept this out are
+				// handled by the same ENGINE_MINOR_VERSION guard already used by
+				// McpPropertyReflectionUtilities and the widget/AI handlers.
+				if (ImportExportTextIntoValue(
+						SP->ContainerPtrToValuePtr<void>(TargetContainer), SP, Txt)) {
+					return true;
+				}
 			}
 		}
 
@@ -157,7 +215,13 @@ static inline bool ApplyJsonObjectValueToProperty(void *TargetContainer, FProper
 			}
 		}
 
-		OutError = TEXT("Unsupported JSON type for struct property");
+		OutError = FString::Printf(
+				TEXT("Could not convert value to struct property of type '%s'. "
+						 "Accepted forms: a JSON object ({\"Left\": -48, \"Top\": -64}), "
+						 "UE export text ((Left=-48.000000,Top=-64.000000)) -- the form "
+						 "get_property returns -- or, for Vector/Rotator, a 3-element "
+						 "JSON array ([0, 0, 90])."),
+				TypeName.IsEmpty() ? TEXT("<unknown>") : *TypeName);
     return false;
   }
   return false;


### PR DESCRIPTION
## Problem — the tool could not eat its own output

`get_property` returns **UE export text** for struct properties:

```
(Offsets=(Right=100.000000,Bottom=30.000000))
```

Feeding that exact string back to `set_property` fails:

```
PROPERTY_CONVERSION_FAILED: Unsupported JSON type for struct property
```

Same root cause on arrays — a `SampleData` value read back as `"[(Animation=...)]"` fails with *Expected array for array property*.

Measured as three consecutive calls: read at 17:57:22 → write back **FAILED** at 17:57:36 → the same value as JSON **OK** at 17:57:46.

So the obvious loop — read, modify, write back — hits a wall, and it only works if the caller happens to know to reshape into JSON first.

## Fix

The existing comment said `ImportText` was deliberately left out because its signature moves between engine versions. **That reason no longer holds:** this repo already calls `ImportText` elsewhere behind the same compatibility layer.

The struct and array appliers now fall back to `ImportText` when the incoming value is a string. JSON input is unchanged — this only adds the previously-rejected form.

Verified on UE 5.8.