### PR TITLE
fix(inspect): resolve native inherited components by their UPROPERTY name

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Property/McpAutomationBridge_PropertyHandlersCdoComponentNames.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Property/McpAutomationBridge_PropertyHandlersCdoComponentNames.cpp
@@ -1,0 +1,73 @@
+#include "Core/Compatibility/McpVersionCompatibility.h"
+
+#include "Domains/Property/McpAutomationBridge_PropertyHandlersCdoComponents.h"
+
+#if WITH_EDITOR
+#include "Components/ActorComponent.h"
+#include "Engine/Blueprint.h"
+#include "Engine/SCS_Node.h"
+#include "Engine/SimpleConstructionScript.h"
+#include "GameFramework/Actor.h"
+#include "UObject/UnrealType.h"
+
+namespace McpPropertyCdoComponents
+{
+TArray<FString> CollectResolvableComponentNames(UBlueprint* Blueprint, UObject* CDO)
+{
+    TArray<FString> Names;
+    TSet<FString> Seen;
+    auto AddName = [&Names, &Seen](const FString& Name)
+    {
+        if (!Name.IsEmpty() && !Seen.Contains(Name))
+        {
+            Seen.Add(Name);
+            Names.Add(Name);
+        }
+    };
+
+    if (AActor* DefaultActor = Cast<AActor>(CDO))
+    {
+        TInlineComponentArray<UActorComponent*> Components;
+        DefaultActor->GetComponents(Components);
+        for (UActorComponent* Comp : Components)
+        {
+            if (Comp)
+            {
+                AddName(Comp->GetName());
+            }
+        }
+
+        // The UPROPERTY aliases FindCdoComponent() also accepts (ACharacter's
+        // `Mesh` for CharacterMesh0). Listing both spellings is the point:
+        // callers reach for the alias first.
+        for (TFieldIterator<FObjectProperty> It(DefaultActor->GetClass()); It; ++It)
+        {
+            FObjectProperty* ObjProp = *It;
+            if (ObjProp && ObjProp->PropertyClass &&
+                ObjProp->PropertyClass->IsChildOf(UActorComponent::StaticClass()))
+            {
+                AddName(ObjProp->GetName());
+            }
+        }
+    }
+
+    for (UBlueprint* Bp = Blueprint; Bp != nullptr;)
+    {
+        if (Bp->SimpleConstructionScript)
+        {
+            for (USCS_Node* Node : Bp->SimpleConstructionScript->GetAllNodes())
+            {
+                if (Node && Node->ComponentTemplate)
+                {
+                    AddName(Node->GetVariableName().ToString());
+                }
+            }
+        }
+        UClass* ParentClass = Bp->ParentClass;
+        Bp = ParentClass ? Cast<UBlueprint>(ParentClass->ClassGeneratedBy) : nullptr;
+    }
+
+    return Names;
+}
+}
+#endif

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Property/McpAutomationBridge_PropertyHandlersCdoComponents.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Property/McpAutomationBridge_PropertyHandlersCdoComponents.cpp
@@ -149,6 +149,35 @@ UActorComponent* FindCdoComponent(
                 return Comp;
             }
         }
+
+        // Native components are usually referred to by the UPROPERTY that holds
+        // them, not by their object name: ACharacter's skeletal mesh is declared
+        // as `Mesh` but is constructed as `CharacterMesh0`, and
+        // ACharacter::CapsuleComponent is `CollisionCylinder`. Matching only the
+        // object name above made the documented, discoverable name fail with
+        // COMPONENT_NOT_FOUND. Resolve the property name too.
+        for (TFieldIterator<FObjectProperty> It(DefaultActor->GetClass()); It; ++It)
+        {
+            FObjectProperty* ObjProp = *It;
+            if (!ObjProp || !ObjProp->PropertyClass ||
+                !ObjProp->PropertyClass->IsChildOf(UActorComponent::StaticClass()))
+            {
+                continue;
+            }
+            if (!ObjProp->GetName().Equals(ComponentName, ESearchCase::IgnoreCase))
+            {
+                continue;
+            }
+            if (UActorComponent* Comp = Cast<UActorComponent>(
+                    ObjProp->GetObjectPropertyValue_InContainer(DefaultActor)))
+            {
+                if (bOutFoundComponent)
+                {
+                    *bOutFoundComponent = true;
+                }
+                return Comp;
+            }
+        }
     }
 
     UBlueprintGeneratedClass* ActualBPGC = Blueprint

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Property/McpAutomationBridge_PropertyHandlersCdoComponents.h
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Property/McpAutomationBridge_PropertyHandlersCdoComponents.h
@@ -20,6 +20,14 @@ TSharedPtr<FJsonObject> BuildComponentSummary(
 
 TMap<FString, FString> BuildScsSourceMap(UBlueprint* Blueprint);
 
+/**
+ * Every name FindCdoComponent() would accept, in a stable order: native object
+ * names, the UPROPERTY aliases that point at them (ACharacter's `Mesh`), and
+ * SCS variable names from this Blueprint and its parents. Used to turn a bare
+ * COMPONENT_NOT_FOUND into a one-round-trip fix.
+ */
+TArray<FString> CollectResolvableComponentNames(UBlueprint* Blueprint, UObject* CDO);
+
 UActorComponent* FindCdoComponent(
     UBlueprint* Blueprint,
     UObject* CDO,

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Property/McpAutomationBridge_PropertyHandlersCdoInspection.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Property/McpAutomationBridge_PropertyHandlersCdoInspection.cpp
@@ -113,9 +113,27 @@ bool UMcpAutomationBridgeSubsystem::HandleInspectCdoAction(
         UActorComponent* FoundComp = McpPropertyCdoComponents::FindCdoComponent(Blueprint, CDO, ComponentNameFilter, false);
         if (!FoundComp)
         {
-            SendAutomationError(RequestingSocket, RequestId,
-                                FString::Printf(TEXT("Component not found: %s"), *ComponentNameFilter),
-                                TEXT("COMPONENT_NOT_FOUND"));
+            // Name the candidates so the caller can correct in one round trip
+            // instead of guessing (native components are often reachable under
+            // both an object name and a UPROPERTY alias).
+            const TArray<FString> Available =
+                McpPropertyCdoComponents::CollectResolvableComponentNames(Blueprint, CDO);
+            TArray<TSharedPtr<FJsonValue>> AvailableJson;
+            for (const FString& Name : Available)
+            {
+                AvailableJson.Add(MakeShared<FJsonValueString>(Name));
+            }
+
+            TSharedPtr<FJsonObject> ErrData = McpHandlerUtils::CreateResultObject();
+            ErrData->SetArrayField(TEXT("availableComponents"), AvailableJson);
+
+            SendAutomationResponse(
+                RequestingSocket, RequestId, false,
+                FString::Printf(TEXT("Component not found: %s. Available components: %s"),
+                                *ComponentNameFilter,
+                                Available.Num() > 0 ? *FString::Join(Available, TEXT(", "))
+                                                    : TEXT("<none>")),
+                ErrData, TEXT("COMPONENT_NOT_FOUND"));
             return true;
         }
 

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/SCS/McpAutomationBridge_SCSHandlersSetProperty.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/SCS/McpAutomationBridge_SCSHandlersSetProperty.cpp
@@ -7,6 +7,7 @@
 #include "Foundation/HandlerUtils/McpHandlerUtils.h"
 
 #if WITH_EDITOR
+#include "Domains/Property/McpAutomationBridge_PropertyHandlersCdoComponents.h"
 #include "Engine/Blueprint.h"
 #include "Engine/SCS_Node.h"
 #include "Engine/SimpleConstructionScript.h"
@@ -48,16 +49,66 @@ TSharedPtr<FJsonObject> FSCSHandlers::SetSCSComponentProperty(
 
   USimpleConstructionScript *SCS = Blueprint->SimpleConstructionScript;
 
-  USCS_Node *ComponentNode = FindSCSNodeByVariableName(SCS, ComponentName);
+  // Resolve through the shared component resolver instead of scanning only this Blueprint's own
+  // SCS. The local-only scan missed three whole families: components inherited from a parent
+  // Blueprint, native components on the CDO, and the UPROPERTY aliases native components are
+  // normally referred to by (ACharacter's `Mesh`). bCreateInheritedOverride=true so that editing an
+  // inherited component writes an override template on *this* Blueprint rather than mutating the
+  // parent's archetype.
+  UObject *CDO = Blueprint->GeneratedClass
+                     ? Blueprint->GeneratedClass->GetDefaultObject()
+                     : nullptr;
+  bool bFoundComponent = false;
+  // bCreateInheritedOverride=true has a SIDE EFFECT: for an inherited component it calls Blueprint->Modify()
+  // and CreateOverridenComponentTemplate(), i.e. it permanently adds an ICH override and dirties the package
+  // BEFORE we know whether the property name or value is even valid. Every early return below must therefore
+  // undo it, or a *failed* call (one typo in propertyName) silently stops the child inheriting future parent
+  // edits to that component — and the next successful bridge call on the Blueprint saves that to disk. Same
+  // shape as upstream's own McpPropertyCdoComponents caller in ...\Domains\Property\...ObjectSet.cpp.
+  UInheritableComponentHandler *CreatedInheritedOverrideHandler = nullptr;
+  FComponentKey CreatedInheritedOverrideKey;
+  auto RemoveCreatedInheritedOverride = [&]() {
+    if (CreatedInheritedOverrideHandler && CreatedInheritedOverrideKey.IsValid()) {
+      CreatedInheritedOverrideHandler->RemoveOverridenComponentTemplate(
+          CreatedInheritedOverrideKey);
+      CreatedInheritedOverrideHandler = nullptr;
+      CreatedInheritedOverrideKey = FComponentKey();
+    }
+  };
+  UObject *ComponentTemplate = McpPropertyCdoComponents::FindCdoComponent(
+      Blueprint, CDO, ComponentName, /*bCreateInheritedOverride=*/true,
+      &CreatedInheritedOverrideHandler, &CreatedInheritedOverrideKey,
+      &bFoundComponent);
 
-  if (!ComponentNode || !ComponentNode->ComponentTemplate) {
+  if (!ComponentTemplate) {
     Result->SetBoolField(TEXT("success"), false);
-    Result->SetStringField(
-        TEXT("error"),
-        FString::Printf(TEXT("Component or template not found: %s"),
-                        *ComponentName));
     Result->SetStringField(TEXT("errorCode"),
                            TEXT("SCS_COMPONENT_TEMPLATE_NOT_FOUND"));
+    if (bFoundComponent) {
+      // Exists, but this Blueprint may not legally override it.
+      Result->SetStringField(
+          TEXT("error"),
+          FString::Printf(
+              TEXT("Component '%s' is inherited and cannot be overridden on "
+                   "this Blueprint. Set the property on the owning parent "
+                   "Blueprint instead."),
+              *ComponentName));
+      return Result;
+    }
+    const TArray<FString> Available =
+        McpPropertyCdoComponents::CollectResolvableComponentNames(Blueprint, CDO);
+    TArray<TSharedPtr<FJsonValue>> AvailableJson;
+    for (const FString &Name : Available) {
+      AvailableJson.Add(MakeShared<FJsonValueString>(Name));
+    }
+    Result->SetArrayField(TEXT("availableComponents"), AvailableJson);
+    Result->SetStringField(
+        TEXT("error"),
+        FString::Printf(
+            TEXT("Component or template not found: %s. Available components: %s"),
+            *ComponentName,
+            Available.Num() > 0 ? *FString::Join(Available, TEXT(", "))
+                                : TEXT("<none>")));
     return Result;
   }
 
@@ -68,7 +119,7 @@ TSharedPtr<FJsonObject> FSCSHandlers::SetSCSComponentProperty(
     FString FailureCode;
     bool bAppliedValue = false;
     FProperty *TargetProp =
-        ResolveNestedPropertyPath(ComponentNode->ComponentTemplate,
+        ResolveNestedPropertyPath(ComponentTemplate,
                                   PropertyName, ContainerPtr, ResolveError);
 
     if (!TargetProp || !ContainerPtr) {
@@ -79,6 +130,7 @@ TSharedPtr<FJsonObject> FSCSHandlers::SetSCSComponentProperty(
               ? FString::Printf(TEXT("Property not found: %s"), *PropertyName)
               : ResolveError);
       Result->SetStringField(TEXT("errorCode"), TEXT("SCS_PROPERTY_NOT_FOUND"));
+      RemoveCreatedInheritedOverride();
       return Result;
     }
 
@@ -98,6 +150,7 @@ TSharedPtr<FJsonObject> FSCSHandlers::SetSCSComponentProperty(
       if (!FailureCode.IsEmpty()) {
         Result->SetStringField(TEXT("errorCode"), FailureCode);
       }
+      RemoveCreatedInheritedOverride();
       return Result;
     }
   } else {
@@ -105,6 +158,7 @@ TSharedPtr<FJsonObject> FSCSHandlers::SetSCSComponentProperty(
     Result->SetStringField(TEXT("error"), TEXT("Property value is invalid"));
     Result->SetStringField(TEXT("errorCode"),
                            TEXT("SCS_PROPERTY_INVALID_VALUE"));
+    RemoveCreatedInheritedOverride();
     return Result;
   }
 
@@ -113,8 +167,16 @@ TSharedPtr<FJsonObject> FSCSHandlers::SetSCSComponentProperty(
   bool bSaved = false;
   FinalizeBlueprintSCSChange(Blueprint, bCompiled, bSaved);
 
+  // Re-resolve through the same resolver: an inherited or native component has no SCS node on this
+  // Blueprint, so looking one up here would fail verification for exactly the cases the fix above
+  // just enabled. The node lookup is kept only to enrich the response when one happens to exist.
   USCS_Node *VerifiedNode = FindSCSNodeByVariableName(SCS, ComponentName);
-  if (!VerifiedNode || !VerifiedNode->ComponentTemplate) {
+  UObject *VerifiedTemplate = McpPropertyCdoComponents::FindCdoComponent(
+      Blueprint,
+      Blueprint->GeneratedClass ? Blueprint->GeneratedClass->GetDefaultObject()
+                                : nullptr,
+      ComponentName, /*bCreateInheritedOverride=*/false);
+  if (!VerifiedTemplate) {
     Result->SetBoolField(TEXT("success"), false);
     Result->SetStringField(
         TEXT("error"),
@@ -130,7 +192,7 @@ TSharedPtr<FJsonObject> FSCSHandlers::SetSCSComponentProperty(
   void *VerifiedContainerPtr = nullptr;
   FString VerifiedResolveError;
   FProperty *VerifiedProp = ResolveNestedPropertyPath(
-      VerifiedNode->ComponentTemplate, PropertyName, VerifiedContainerPtr,
+      VerifiedTemplate, PropertyName, VerifiedContainerPtr,
       VerifiedResolveError);
   if (!VerifiedProp || !VerifiedContainerPtr) {
     Result->SetBoolField(TEXT("success"), false);


### PR DESCRIPTION
## Problem

`inspect_cdo` on an `ACharacter` subclass:

```
COMPONENT_NOT_FOUND: Mesh
```

`FindCdoComponent` matched only:
1. the component's **object name**, and
2. the class's **own SCS** variable names.

`ACharacter`'s skeletal mesh is known to every caller as the `Mesh` **UPROPERTY** — but its object name is `CharacterMesh0`. So the documented, discoverable name is precisely the one that failed, while an internal name nobody would guess is the one that worked.

## Fix

The lookup additionally scans the CDO class's `FObjectProperty`s that point at a `UActorComponent` — which is how native inherited components are actually named.

Object-name and SCS matching are unchanged and still take precedence; this only adds a fallback for names that previously resolved to nothing.

The same resolution is applied to `set_scs_property`, which had the matching gap on the write side.

> Note for review: this adds one new translation unit (`...PropertyHandlersCdoComponentNames.cpp`) holding the shared name-collection helper, so the two call sites do not each grow a copy.

Verified on UE 5.8.