### PR TITLE
fix(gas): manage_gas mutations now compile, save, and verify what they authored (+ blueprint_get crash fix)

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/GAS/McpAutomationBridge_GASHandlersAbilityBasics.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/GAS/McpAutomationBridge_GASHandlersAbilityBasics.cpp
@@ -3,6 +3,7 @@
 #include "Domains/GAS/McpAutomationBridge_GASEffectClassResolution.h"
 #include "Domains/GAS/McpAutomationBridge_GASPayloadFields.h"
 #include "Domains/GAS/McpAutomationBridge_GASRequestContext.h"
+#include "Foundation/BridgeHelpers/Blueprints/McpAutomationBridgeHelpersBlueprintCompilation.h"
 #include "Foundation/BridgeHelpers/Security/McpAutomationBridgeHelpersSafeOperationsFacade.h"
 #include "McpAutomationBridgeSubsystem.h"
 #include "Foundation/HandlerUtils/McpHandlerUtils.h"
@@ -87,101 +88,169 @@ bool HandleGASAbilityBasics(const FGASRequestContext& Context, const FString& Su
             return true;
         }
 
-        TArray<FString> TagsAdded;
-
-        const TArray<TSharedPtr<FJsonValue>>* AbilityTagsArray = nullptr;
-        if (Payload->TryGetArrayField(TEXT("abilityTags"), AbilityTagsArray))
+        // ---- Phase 1: resolve EVERYTHING before writing ANYTHING. -------------------------------
+        // Two defects lived here. First, only the abilityTags array detected unregistered tags -- the
+        // four other containers (and their singular aliases) silently dropped them and the handler still
+        // answered "Ability tags set", which is the exact silent-success class this change exists to end.
+        // Second, validation ran AFTER the writes, so a refused mixed call left half-applied tags on the
+        // in-memory CDO for a later unrelated save to quietly persist. Resolving everything up front
+        // makes the refusal side-effect-free and covers every container equally.
+        struct FReflectionTagWrite
         {
-            for (const auto& TagValue : *AbilityTagsArray)
+            FName ContainerProp;
+            FGameplayTag Tag;
+            FString Requested;
+        };
+        TArray<FString> TagsUnresolved;
+        TArray<FString> TagsAdded;
+        TArray<TPair<FString, FGameplayTag>> AssetTagWrites;
+        TArray<FReflectionTagWrite> ReflectionWrites;
+
+        auto ResolveArray = [&](const TCHAR* Primary, const TCHAR* SingularAlias, const FName& ContainerProp)
+        {
+            const TArray<TSharedPtr<FJsonValue>>* Arr = nullptr;
+            if (!Payload->TryGetArrayField(Primary, Arr) && SingularAlias != nullptr)
             {
-                FString TagStr = TagValue->AsString();
-                FGameplayTag Tag = GetOrRequestTag(TagStr);
-                if (Tag.IsValid())
+                Payload->TryGetArrayField(SingularAlias, Arr);
+            }
+            if (!Arr)
+            {
+                return;
+            }
+            for (const auto& TagValue : *Arr)
+            {
+                const FString TagStr = TagValue->AsString();
+                const FGameplayTag Tag = GetOrRequestTag(TagStr);
+                if (!Tag.IsValid())
                 {
-                    // UE 5.7+: AbilityTags is deprecated, use GetAssetTags() for read, but for write we use the container directly with version guard
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 7
-                    FGameplayTagContainer CurrentTags = AbilityCDO->GetAssetTags();
-                    CurrentTags.AddTag(Tag);
-                    // Note: SetAssetTags only works in constructor. For runtime modification, we must use deprecated API with warning suppression
-                    PRAGMA_DISABLE_DEPRECATION_WARNINGS
-                    AbilityCDO->AbilityTags = CurrentTags;
-                    PRAGMA_ENABLE_DEPRECATION_WARNINGS
-#else
-                    // UE 5.6 and earlier: AbilityTags is deprecated, suppress warning
-                    PRAGMA_DISABLE_DEPRECATION_WARNINGS
-                    AbilityCDO->AbilityTags.AddTag(Tag);
-                    PRAGMA_ENABLE_DEPRECATION_WARNINGS
-#endif
+                    // GetOrRequestTag does NOT create a tag that is not in the project's registry;
+                    // an unregistered tag used to be skipped in silence here.
+                    TagsUnresolved.Add(TagStr);
+                    continue;
+                }
+                if (ContainerProp.IsNone())
+                {
+                    AssetTagWrites.Emplace(TagStr, Tag);
                     TagsAdded.Add(TagStr);
                 }
-            }
-        }
-
-        // Cancel abilities with tags - use reflection to access protected member
-        const TArray<TSharedPtr<FJsonValue>>* CancelTagsArray = nullptr;
-        if (!Payload->TryGetArrayField(TEXT("cancelAbilitiesWithTags"), CancelTagsArray))
-        {
-            Payload->TryGetArrayField(TEXT("cancelAbilitiesWithTag"), CancelTagsArray);
-        }
-        if (CancelTagsArray)
-        {
-            for (const auto& TagValue : *CancelTagsArray)
-            {
-                FGameplayTag Tag = GetOrRequestTag(TagValue->AsString());
-                if (Tag.IsValid())
+                else
                 {
-                    // Use string literal - GET_MEMBER_NAME_CHECKED doesn't work for protected members
-                    AddTagToAbilityContainer(AbilityCDO, FName(TEXT("CancelAbilitiesWithTag")), Tag);
+                    ReflectionWrites.Add({ContainerProp, Tag, TagStr});
                 }
             }
+        };
+
+        ResolveArray(TEXT("abilityTags"), nullptr, NAME_None);
+        ResolveArray(TEXT("cancelAbilitiesWithTags"), TEXT("cancelAbilitiesWithTag"), FName(TEXT("CancelAbilitiesWithTag")));
+        ResolveArray(TEXT("blockAbilitiesWithTags"), TEXT("blockAbilitiesWithTag"), FName(TEXT("BlockAbilitiesWithTag")));
+        ResolveArray(TEXT("activationRequiredTags"), nullptr, FName(TEXT("ActivationRequiredTags")));
+        ResolveArray(TEXT("activationBlockedTags"), nullptr, FName(TEXT("ActivationBlockedTags")));
+
+        if (TagsUnresolved.Num() > 0)
+        {
+            // Refuse BEFORE any write, so the CDO is exactly as it was. The remedy names the project's
+            // own tag registry rather than any particular tool.
+            Bridge->SendAutomationError(RequestingSocket, RequestId,
+                FString::Printf(TEXT("Gameplay tag(s) not registered in this project: %s. Register them in the project's GameplayTags settings (e.g. DefaultGameplayTags.ini) first, then retry. Nothing was changed."),
+                    *FString::Join(TagsUnresolved, TEXT(", "))),
+                TEXT("GAMEPLAY_TAG_NOT_REGISTERED"));
+            return true;
         }
 
-        // Block abilities with tags - use reflection to access protected member
-        const TArray<TSharedPtr<FJsonValue>>* BlockTagsArray = nullptr;
-        if (!Payload->TryGetArrayField(TEXT("blockAbilitiesWithTags"), BlockTagsArray))
+        // ---- Phase 2: write. --------------------------------------------------------------------
+        if (AssetTagWrites.Num() > 0)
         {
-            Payload->TryGetArrayField(TEXT("blockAbilitiesWithTag"), BlockTagsArray);
-        }
-        if (BlockTagsArray)
-        {
-            for (const auto& TagValue : *BlockTagsArray)
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 7
+            // UE 5.7+: AbilityTags is deprecated for direct use; read via GetAssetTags, write the
+            // container back under deprecation suppression (SetAssetTags only works in constructors).
+            FGameplayTagContainer CurrentTags = AbilityCDO->GetAssetTags();
+            for (const auto& Pair : AssetTagWrites)
             {
-                FGameplayTag Tag = GetOrRequestTag(TagValue->AsString());
-                if (Tag.IsValid())
-                {
-                    // Use string literal - GET_MEMBER_NAME_CHECKED doesn't work for protected members
-                    AddTagToAbilityContainer(AbilityCDO, FName(TEXT("BlockAbilitiesWithTag")), Tag);
-                }
+                CurrentTags.AddTag(Pair.Value);
             }
-        }
-
-        const TArray<TSharedPtr<FJsonValue>>* ActivationRequiredTagsArray = nullptr;
-        if (Payload->TryGetArrayField(TEXT("activationRequiredTags"), ActivationRequiredTagsArray))
-        {
-            for (const auto& TagValue : *ActivationRequiredTagsArray)
+            PRAGMA_DISABLE_DEPRECATION_WARNINGS
+            AbilityCDO->AbilityTags = CurrentTags;
+            PRAGMA_ENABLE_DEPRECATION_WARNINGS
+#else
+            PRAGMA_DISABLE_DEPRECATION_WARNINGS
+            for (const auto& Pair : AssetTagWrites)
             {
-                FGameplayTag Tag = GetOrRequestTag(TagValue->AsString());
-                if (Tag.IsValid())
-                {
-                    AddTagToAbilityContainer(AbilityCDO, FName(TEXT("ActivationRequiredTags")), Tag);
-                }
+                AbilityCDO->AbilityTags.AddTag(Pair.Value);
             }
+            PRAGMA_ENABLE_DEPRECATION_WARNINGS
+#endif
         }
-
-        const TArray<TSharedPtr<FJsonValue>>* ActivationBlockedTagsArray = nullptr;
-        if (Payload->TryGetArrayField(TEXT("activationBlockedTags"), ActivationBlockedTagsArray))
+        for (const FReflectionTagWrite& Write : ReflectionWrites)
         {
-            for (const auto& TagValue : *ActivationBlockedTagsArray)
-            {
-                FGameplayTag Tag = GetOrRequestTag(TagValue->AsString());
-                if (Tag.IsValid())
-                {
-                    AddTagToAbilityContainer(AbilityCDO, FName(TEXT("ActivationBlockedTags")), Tag);
-                }
-            }
+            AddTagToAbilityContainer(AbilityCDO, Write.ContainerProp, Write.Tag);
         }
 
+        // ---- Phase 3: compile, VERIFY on the recompiled CDO, and only then save. ----------------
+        // Compilation reinstances the CDO, so every read below re-fetches. Whether hand-written CDO
+        // container values survive reinstancing is MEASURED here, not assumed; and the compile/save
+        // results are consulted rather than discarded -- a Blueprint whose graph has unrelated compile
+        // errors, or a file source control holds read-only, must not produce success:true.
         FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
+        const bool bCompiled = McpSafeCompileBlueprint(Blueprint);
+
+        TArray<FString> TagsVerified;
+        TArray<FString> OtherTagsVerified;
+        TArray<FString> TagsLost;
+        if (UClass* CompiledClass = Blueprint->GeneratedClass)
+        {
+            if (UGameplayAbility* CompiledCDO = Cast<UGameplayAbility>(CompiledClass->GetDefaultObject()))
+            {
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 7
+                const FGameplayTagContainer PersistedAssetTags = CompiledCDO->GetAssetTags();
+#else
+                PRAGMA_DISABLE_DEPRECATION_WARNINGS
+                const FGameplayTagContainer PersistedAssetTags = CompiledCDO->AbilityTags;
+                PRAGMA_ENABLE_DEPRECATION_WARNINGS
+#endif
+                for (const auto& Pair : AssetTagWrites)
+                {
+                    if (PersistedAssetTags.HasTagExact(Pair.Value))
+                    {
+                        TagsVerified.Add(Pair.Key);
+                    }
+                    else
+                    {
+                        TagsLost.Add(Pair.Key);
+                    }
+                }
+                for (const FReflectionTagWrite& Write : ReflectionWrites)
+                {
+                    FGameplayTagContainer Persisted;
+                    if (GetAbilityPropertyValue<FGameplayTagContainer>(CompiledCDO, Write.ContainerProp, Persisted) &&
+                        Persisted.HasTagExact(Write.Tag))
+                    {
+                        OtherTagsVerified.Add(Write.ContainerProp.ToString() + TEXT(":") + Write.Requested);
+                    }
+                    else
+                    {
+                        TagsLost.Add(Write.ContainerProp.ToString() + TEXT(":") + Write.Requested);
+                    }
+                }
+            }
+        }
+
+        if (!bCompiled || TagsLost.Num() > 0)
+        {
+            Bridge->SendAutomationError(RequestingSocket, RequestId,
+                FString::Printf(TEXT("Ability tags did not persist onto the compiled class%s: %s. The asset was NOT saved."),
+                    bCompiled ? TEXT("") : TEXT(" (the Blueprint failed to compile - it may have unrelated graph errors)"),
+                    TagsLost.Num() > 0 ? *FString::Join(TagsLost, TEXT(", ")) : TEXT("(compile failure)")),
+                TEXT("ABILITY_TAGS_NOT_APPLIED"));
+            return true;
+        }
+
+        if (!McpSafeAssetSave(Blueprint))
+        {
+            Bridge->SendAutomationError(RequestingSocket, RequestId,
+                TEXT("Ability tags verified on the compiled class but the asset could NOT be written to disk (file may be read-only or held by source control). The change exists only in this editor session."),
+                TEXT("SAVE_FAILED"));
+            return true;
+        }
 
         TSharedPtr<FJsonObject> Result = McpHandlerUtils::CreateResultObject();
         Result->SetStringField(TEXT("blueprintPath"), BlueprintPath);
@@ -191,6 +260,21 @@ bool HandleGASAbilityBasics(const FGASRequestContext& Context, const FString& Su
             TagsJsonArray.Add(MakeShared<FJsonValueString>(Tag));
         }
         Result->SetArrayField(TEXT("tagsAdded"), TagsJsonArray);
+        // Read back from the compiled class rather than echoing what we were asked to write.
+        TArray<TSharedPtr<FJsonValue>> VerifiedJsonArray;
+        for (const FString& Tag : TagsVerified)
+        {
+            VerifiedJsonArray.Add(MakeShared<FJsonValueString>(Tag));
+        }
+        Result->SetArrayField(TEXT("tagsVerified"), VerifiedJsonArray);
+        TArray<TSharedPtr<FJsonValue>> OtherVerifiedJsonArray;
+        for (const FString& Entry : OtherTagsVerified)
+        {
+            OtherVerifiedJsonArray.Add(MakeShared<FJsonValueString>(Entry));
+        }
+        Result->SetArrayField(TEXT("otherTagsVerified"), OtherVerifiedJsonArray);
+        Result->SetBoolField(TEXT("verifiedOnCompiledClass"), true);
+        Result->SetBoolField(TEXT("savedToDisk"), true);
         Bridge->SendAutomationResponse(RequestingSocket, RequestId, true, TEXT("Ability tags set"), Result);
         return true;
     }

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/GAS/McpAutomationBridge_GASHandlersAttributes.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/GAS/McpAutomationBridge_GASHandlersAttributes.cpp
@@ -90,23 +90,88 @@ bool HandleGASAttributes(const FGASRequestContext& Context, const FString& SubAc
 
         float DefaultValue = static_cast<float>(GetJsonNumberField(Payload, TEXT("defaultValue"), 0.0));
 
+        // Add FGameplayAttributeData member variable.
         FEdGraphPinType PinType;
         PinType.PinCategory = UEdGraphSchema_K2::PC_Struct;
         PinType.PinSubCategoryObject = FGameplayAttributeData::StaticStruct();
 
-        bool bSuccess = FBlueprintEditorUtils::AddMemberVariable(Blueprint, FName(*AttributeName), PinType);
+        // defaultValue used to be read, echoed back in the response, and never applied: every attribute
+        // authored through this action landed with BaseValue 0 while the caller was told its value had
+        // been set. AddMemberVariable takes the default as a 4th argument; the struct-literal spelling is
+        // the one this very file already uses for the same struct (set_attribute_base_value's
+        // FBPVariableDescription fallback below), so both paths now agree on one format.
+        const FString AttributeDefault = FString::Printf(
+            TEXT("(BaseValue=%s,CurrentValue=%s)"),
+            *FString::SanitizeFloat(DefaultValue),
+            *FString::SanitizeFloat(DefaultValue));
+
+        bool bSuccess = FBlueprintEditorUtils::AddMemberVariable(Blueprint, FName(*AttributeName), PinType, AttributeDefault);
         if (!bSuccess)
         {
             Bridge->SendAutomationError(RequestingSocket, RequestId, TEXT("Failed to add attribute"), TEXT("ADD_FAILED"));
             return true;
         }
 
+        // Structural change -> compile, VERIFY, and only then persist. Without the compile the variable
+        // exists only on the skeleton class, so the generated-class CDO (what the game and every
+        // reflection reader see) does not have the attribute at all; without the save the whole edit dies
+        // with the editor session. The save deliberately comes AFTER the read-back below: saving first
+        // and then reporting failure would leave the failed state on disk while the error text denies it.
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(Blueprint);
+        const bool bCompiled = McpSafeCompileBlueprint(Blueprint);
+
+        // Read back from the COMPILED generated class before answering. Compilation reinstances the CDO,
+        // so this has to re-fetch rather than reuse anything captured earlier. Reporting success for an
+        // attribute that is not actually on the class is the failure this whole change exists to end.
+        bool bVerified = false;
+        float VerifiedBaseValue = 0.0f;
+        if (UClass* CompiledClass = Blueprint->GeneratedClass)
+        {
+            if (UObject* CompiledCDO = CompiledClass->GetDefaultObject())
+            {
+                if (FProperty* AddedProp = CompiledClass->FindPropertyByName(FName(*AttributeName)))
+                {
+                    if (void* AttrDataPtr = AddedProp->ContainerPtrToValuePtr<void>(CompiledCDO))
+                    {
+                        bVerified = true;
+                        UScriptStruct* AttrStruct = FGameplayAttributeData::StaticStruct();
+                        if (FNumericProperty* BaseValueProp = CastField<FNumericProperty>(AttrStruct->FindPropertyByName(TEXT("BaseValue"))))
+                        {
+                            VerifiedBaseValue = static_cast<float>(
+                                BaseValueProp->GetFloatingPointPropertyValue(BaseValueProp->ContainerPtrToValuePtr<void>(AttrDataPtr)));
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!bCompiled || !bVerified)
+        {
+            Bridge->SendAutomationError(RequestingSocket, RequestId,
+                FString::Printf(TEXT("Attribute '%s' was added to the Blueprint but is not present on the compiled class%s. The asset was NOT saved."),
+                    *AttributeName,
+                    bCompiled ? TEXT("") : TEXT(" (the Blueprint failed to compile - it may have unrelated graph errors)")),
+                TEXT("ATTRIBUTE_NOT_APPLIED"));
+            return true;
+        }
+
+        if (!McpSafeAssetSave(Blueprint))
+        {
+            Bridge->SendAutomationError(RequestingSocket, RequestId,
+                TEXT("Attribute verified on the compiled class but the asset could NOT be written to disk (file may be read-only or held by source control). The change exists only in this editor session."),
+                TEXT("SAVE_FAILED"));
+            return true;
+        }
 
         TSharedPtr<FJsonObject> Result = McpHandlerUtils::CreateResultObject();
         Result->SetStringField(TEXT("blueprintPath"), BlueprintPath);
         Result->SetStringField(TEXT("attributeName"), AttributeName);
         Result->SetNumberField(TEXT("defaultValue"), DefaultValue);
+        // Read back from the compiled class, not echoed from the request: if these two disagree the
+        // caller can see it instead of being told the value landed.
+        Result->SetNumberField(TEXT("baseValue"), VerifiedBaseValue);
+        Result->SetBoolField(TEXT("verifiedOnCompiledClass"), true);
+        Result->SetBoolField(TEXT("savedToDisk"), true);
         Bridge->SendAutomationResponse(RequestingSocket, RequestId, true, TEXT("Attribute added"), Result);
         return true;
     }

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/GAS/McpAutomationBridge_GASHandlersEffectsMagnitude.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/GAS/McpAutomationBridge_GASHandlersEffectsMagnitude.cpp
@@ -1,13 +1,16 @@
 #include "Domains/GAS/McpAutomationBridge_GASBlueprintCreation.h"
 #include "Domains/GAS/McpAutomationBridge_GASPayloadFields.h"
 #include "Domains/GAS/McpAutomationBridge_GASRequestContext.h"
+#include "Foundation/BridgeHelpers/Blueprints/McpAutomationBridgeHelpersBlueprintCompilation.h"
 #include "Foundation/BridgeHelpers/Security/McpAutomationBridgeHelpersSafeOperationsFacade.h"
 #include "McpAutomationBridgeSubsystem.h"
 #include "Foundation/HandlerUtils/McpHandlerUtils.h"
 
 #if WITH_EDITOR && MCP_HAS_GAS
 #include "Engine/Blueprint.h"
+#include "AttributeSet.h"
 #include "GameplayEffect.h"
+#include "UObject/UObjectIterator.h"
 #include "Kismet2/BlueprintEditorUtils.h"
 #endif
 
@@ -64,6 +67,25 @@ bool HandleGASEffectsMagnitude(const FGASRequestContext& Context, const FString&
                     else if (DurationTypeToken == TEXT("hasduration"))
                     {
                         EffectCDO->DurationPolicy = EGameplayEffectDurationType::HasDuration;
+                    }
+
+                    // duration and period were accepted by the schema and silently dropped here: the
+                    // caller could ask for a 5-second effect ticking every second, be told the effect
+                    // was created, and get an effect with no duration and no tick. Applying them at
+                    // creation means the common one-call case authors a complete effect; the separate
+                    // set_effect_duration action still exists for changing it afterwards.
+                    if (DurationTypeToken != TEXT("instant"))
+                    {
+                        if (Payload.IsValid() && Payload->HasField(TEXT("duration")))
+                        {
+                            const float CreateDuration = static_cast<float>(GetJsonNumberField(Payload, TEXT("duration"), 0.0));
+                            EffectCDO->DurationMagnitude = FGameplayEffectModifierMagnitude(FScalableFloat(CreateDuration));
+                        }
+                        if (Payload.IsValid() && Payload->HasField(TEXT("period")))
+                        {
+                            const float CreatePeriod = static_cast<float>(GetJsonNumberField(Payload, TEXT("period"), 0.0));
+                            EffectCDO->Period = FScalableFloat(CreatePeriod);
+                        }
                     }
                 }
             }
@@ -127,12 +149,73 @@ bool HandleGASEffectsMagnitude(const FGASRequestContext& Context, const FString&
             EffectCDO->DurationMagnitude = FGameplayEffectModifierMagnitude(FScalableFloat(Duration));
         }
 
+        // Period had NO write path anywhere in the codebase: create_gameplay_effect reads only
+        // durationType, and this handler read only durationType/duration. A "damage over time" effect
+        // authored through these tools therefore had Period 0 and never ticked -- it applied once and
+        // stopped, which is a different effect from the one the caller asked for. Only meaningful for a
+        // non-Instant policy, so it is applied but not invented for Instant.
+        const bool bHasPeriod = Payload.IsValid() && Payload->HasField(TEXT("period"));
+        float Period = static_cast<float>(GetJsonNumberField(Payload, TEXT("period"), 0.0));
+        if (bHasPeriod && DurationTypeToken != TEXT("instant"))
+        {
+            EffectCDO->Period = FScalableFloat(Period);
+        }
+
         FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
+        const bool bCompiled = McpSafeCompileBlueprint(Blueprint);
+
+        // Read back policy AND period from the recompiled CDO rather than echoing the request --
+        // periodApplied used to be computed from the request token, which is a prediction, not a
+        // measurement. Save only after the read-back agrees.
+        FString VerifiedPolicy;
+        float VerifiedPeriod = 0.0f;
+        if (UClass* CompiledClass = Blueprint->GeneratedClass)
+        {
+            if (UGameplayEffect* CompiledCDO = Cast<UGameplayEffect>(CompiledClass->GetDefaultObject()))
+            {
+                switch (CompiledCDO->DurationPolicy)
+                {
+                case EGameplayEffectDurationType::Instant:     VerifiedPolicy = TEXT("Instant");     break;
+                case EGameplayEffectDurationType::Infinite:    VerifiedPolicy = TEXT("Infinite");    break;
+                case EGameplayEffectDurationType::HasDuration: VerifiedPolicy = TEXT("HasDuration"); break;
+                default: break;
+                }
+                VerifiedPeriod = CompiledCDO->Period.GetValueAtLevel(0.0f);
+            }
+        }
+
+        const bool bPeriodVerified = !bHasPeriod || DurationTypeToken == TEXT("instant") ||
+            FMath::IsNearlyEqual(VerifiedPeriod, Period, KINDA_SMALL_NUMBER);
+        if (!bCompiled || VerifiedPolicy.IsEmpty() || !bPeriodVerified)
+        {
+            Bridge->SendAutomationError(RequestingSocket, RequestId,
+                FString::Printf(TEXT("Duration/period could not be verified on the compiled class%s. The asset was NOT saved."),
+                    bCompiled ? TEXT("") : TEXT(" (the Blueprint failed to compile - it may have unrelated graph errors)")),
+                TEXT("DURATION_NOT_APPLIED"));
+            return true;
+        }
+
+        if (!McpSafeAssetSave(Blueprint))
+        {
+            Bridge->SendAutomationError(RequestingSocket, RequestId,
+                TEXT("Duration verified on the compiled class but the asset could NOT be written to disk (file may be read-only or held by source control). The change exists only in this editor session."),
+                TEXT("SAVE_FAILED"));
+            return true;
+        }
 
         TSharedPtr<FJsonObject> Result = McpHandlerUtils::CreateResultObject();
         Result->SetStringField(TEXT("blueprintPath"), BlueprintPath);
         Result->SetStringField(TEXT("durationType"), DurationType);
         Result->SetNumberField(TEXT("duration"), Duration);
+        if (bHasPeriod)
+        {
+            // Read back from the compiled CDO, not echoed from the request.
+            Result->SetNumberField(TEXT("period"), VerifiedPeriod);
+            Result->SetBoolField(TEXT("periodApplied"), DurationTypeToken != TEXT("instant") && VerifiedPeriod > 0.0f);
+        }
+        Result->SetStringField(TEXT("durationPolicy"), VerifiedPolicy);
+        Result->SetBoolField(TEXT("verifiedOnCompiledClass"), true);
+        Result->SetBoolField(TEXT("savedToDisk"), true);
         Bridge->SendAutomationResponse(RequestingSocket, RequestId, true, TEXT("Duration set"), Result);
         return true;
     }
@@ -186,15 +269,183 @@ bool HandleGASEffectsMagnitude(const FGASRequestContext& Context, const FString&
 
         // Note: SetValue doesn't exist in UE 5.6. Use FScalableFloat constructor.
         Modifier.ModifierMagnitude = FGameplayEffectModifierMagnitude(FScalableFloat(Magnitude));
+
+        // ---- Bind the modifier to the attribute it is supposed to modify. -------------------------
+        // This was the whole defect: FGameplayModifierInfo was default-constructed, given an op and a
+        // magnitude, and pushed onto Modifiers with its Attribute left null. The effect then carried a
+        // modifier that modified nothing, while the handler answered success:true with modifierCount:1 --
+        // a real read-back of the wrong thing. Both spellings are accepted because both are advertised:
+        // the native schema documents `targetAttribute` and the TS route lists `attributeName`.
+        const FString TargetAttribute =
+            GetGASStringFieldWithFallback(Payload, TEXT("targetAttribute"), TEXT("attributeName"), TEXT("")).TrimStartAndEnd();
+        if (TargetAttribute.IsEmpty())
+        {
+            Bridge->SendAutomationError(RequestingSocket, RequestId,
+                TEXT("Missing targetAttribute (alias: attributeName) - a modifier with no attribute modifies nothing."),
+                TEXT("INVALID_ARGUMENT"));
+            return true;
+        }
+
+        // Accept both "Health" and "AS_Foo.Health". The part after the last dot is the property name;
+        // the part before it, when present, names the owning AttributeSet class and IS HONORED below --
+        // an accepted-but-ignored qualifier would bind a same-named attribute from the wrong set and
+        // report success, which is this defect class with extra steps.
+        FString AttributeShortName = TargetAttribute;
+        FString ClassQualifier;
+        int32 DotIdx = INDEX_NONE;
+        if (AttributeShortName.FindLastChar(TEXT('.'), DotIdx))
+        {
+            ClassQualifier = AttributeShortName.Left(DotIdx);
+            AttributeShortName = AttributeShortName.Mid(DotIdx + 1);
+        }
+
+        // Resolve against every UAttributeSet subclass, native or Blueprint-generated: the caller's
+        // attribute usually lives in a Blueprint AttributeSet authored moments earlier by add_attribute.
+        FProperty* AttributeProperty = nullptr;
+        UClass* OwningAttributeSetClass = nullptr;
+        TArray<FString> AmbiguousOwners;
+        for (TObjectIterator<UClass> ClassIt; ClassIt; ++ClassIt)
+        {
+            UClass* Candidate = *ClassIt;
+            if (!Candidate || !Candidate->IsChildOf(UAttributeSet::StaticClass()))
+            {
+                continue;
+            }
+
+            // Skip compilation debris. Recompiling a Blueprint leaves REINST_*/SKEL_*/TRASHCLASS_*
+            // classes alive in memory, and they carry the same property names as the real generated
+            // class. Binding an attribute to one of those produces an FGameplayAttribute that looks
+            // valid -- IsValid() is true and GetName() returns the right string -- while pointing at a
+            // class the game never loads. Measured: without this filter, an attribute on a freshly
+            // recompiled Blueprint AttributeSet resolved to its REINST_SKEL_* debris class and the
+            // handler reported success while binding to a class the game never loads.
+            const FString CandidateName = Candidate->GetName();
+            if (Candidate->HasAnyClassFlags(CLASS_NewerVersionExists) ||
+                CandidateName.StartsWith(TEXT("REINST_")) ||
+                CandidateName.StartsWith(TEXT("SKEL_")) ||
+                CandidateName.StartsWith(TEXT("TRASHCLASS_")))
+            {
+                continue;
+            }
+            if (FProperty* Found = Candidate->FindPropertyByName(FName(*AttributeShortName)))
+            {
+                // A gameplay attribute is an FGameplayAttributeData struct property; anything else with a
+                // matching name is a different member and must not be silently accepted.
+                if (const FStructProperty* AsStruct = CastField<FStructProperty>(Found))
+                {
+                    if (AsStruct->Struct == FGameplayAttributeData::StaticStruct())
+                    {
+                        // Honor the qualifier: "AS_Foo.Health" matches the class named AS_Foo (or its
+                        // Blueprint generated form AS_Foo_C) and nothing else.
+                        if (!ClassQualifier.IsEmpty())
+                        {
+                            // CandidateName is the loop-level name computed for the debris filter above.
+                            if (CandidateName != ClassQualifier && CandidateName != ClassQualifier + TEXT("_C"))
+                            {
+                                continue;
+                            }
+                            AttributeProperty = Found;
+                            OwningAttributeSetClass = Candidate;
+                            break;
+                        }
+                        // Unqualified: collect every match. One match binds; several is an ERROR the
+                        // caller resolves with the qualified form -- first-match-wins would bind an
+                        // arbitrary same-named attribute (native classes load first, so the wrong winner
+                        // is even deterministic) and report success.
+                        AmbiguousOwners.Add(Candidate->GetName());
+                        if (!AttributeProperty)
+                        {
+                            AttributeProperty = Found;
+                            OwningAttributeSetClass = Candidate;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!AttributeProperty)
+        {
+            Bridge->SendAutomationError(RequestingSocket, RequestId,
+                FString::Printf(TEXT("Attribute '%s' not found on any loaded AttributeSet. If it was just authored, make sure its Blueprint compiled."), *TargetAttribute),
+                TEXT("ATTRIBUTE_NOT_FOUND"));
+            return true;
+        }
+        if (ClassQualifier.IsEmpty() && AmbiguousOwners.Num() > 1)
+        {
+            Bridge->SendAutomationError(RequestingSocket, RequestId,
+                FString::Printf(TEXT("Attribute '%s' exists on %d different AttributeSet classes (%s). Disambiguate with the qualified form, e.g. '%s.%s'."),
+                    *AttributeShortName, AmbiguousOwners.Num(), *FString::Join(AmbiguousOwners, TEXT(", ")),
+                    *AmbiguousOwners[0], *AttributeShortName),
+                TEXT("AMBIGUOUS_ATTRIBUTE"));
+            return true;
+        }
+
+        Modifier.Attribute.SetUProperty(AttributeProperty);
         EffectCDO->Modifiers.Add(Modifier);
 
         FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
+        const bool bCompiled = McpSafeCompileBlueprint(Blueprint);
+
+        // Read back from the recompiled CDO. Compilation reinstances, so re-fetch rather than trusting
+        // the pointer we mutated: the question being answered is "is the modifier bound on the asset the
+        // engine will load", not "did we write to some object". The save comes AFTER verification --
+        // persisting a state we are about to report as failed would leave a broken asset on disk under
+        // an error message that denies it exists.
+        bool bBindingVerified = false;
+        FString VerifiedAttributeName;
+        if (UClass* CompiledClass = Blueprint->GeneratedClass)
+        {
+            if (UGameplayEffect* CompiledCDO = Cast<UGameplayEffect>(CompiledClass->GetDefaultObject()))
+            {
+                if (CompiledCDO->Modifiers.Num() > 0)
+                {
+                    const FGameplayModifierInfo& Last = CompiledCDO->Modifiers.Last();
+                    VerifiedAttributeName = Last.Attribute.GetName();
+                    // IsValid() alone is NOT enough: it stays true for a property owned by a
+                    // reinstanced/skeleton class, which is exactly the failure this handler used to
+                    // ship. Require a live owner class as well.
+                    const FProperty* BoundProp = Last.Attribute.GetUProperty();
+                    const UClass* BoundOwner = BoundProp ? BoundProp->GetOwner<UClass>() : nullptr;
+                    const FString BoundOwnerName = BoundOwner ? BoundOwner->GetName() : FString();
+                    bBindingVerified =
+                        Last.Attribute.IsValid() && BoundOwner != nullptr &&
+                        !BoundOwner->HasAnyClassFlags(CLASS_NewerVersionExists) &&
+                        !BoundOwnerName.StartsWith(TEXT("REINST_")) &&
+                        !BoundOwnerName.StartsWith(TEXT("SKEL_")) &&
+                        !BoundOwnerName.StartsWith(TEXT("TRASHCLASS_"));
+                }
+            }
+        }
+
+        if (!bCompiled || !bBindingVerified)
+        {
+            Bridge->SendAutomationError(RequestingSocket, RequestId,
+                FString::Printf(TEXT("Modifier was added but its attribute binding could not be verified on the compiled class (attribute '%s')%s - the effect would modify nothing. The asset was NOT saved."),
+                    *TargetAttribute,
+                    bCompiled ? TEXT("") : TEXT(" (the Blueprint failed to compile - it may have unrelated graph errors)")),
+                TEXT("MODIFIER_NOT_BOUND"));
+            return true;
+        }
+
+        if (!McpSafeAssetSave(Blueprint))
+        {
+            Bridge->SendAutomationError(RequestingSocket, RequestId,
+                TEXT("Modifier verified on the compiled class but the asset could NOT be written to disk (file may be read-only or held by source control). The change exists only in this editor session."),
+                TEXT("SAVE_FAILED"));
+            return true;
+        }
 
         TSharedPtr<FJsonObject> Result = McpHandlerUtils::CreateResultObject();
         Result->SetStringField(TEXT("blueprintPath"), BlueprintPath);
         Result->SetStringField(TEXT("operation"), Operation);
         Result->SetNumberField(TEXT("magnitude"), Magnitude);
         Result->SetNumberField(TEXT("modifierCount"), EffectCDO->Modifiers.Num());
+        Result->SetStringField(TEXT("targetAttribute"), TargetAttribute);
+        // Read back from the compiled CDO, not echoed from the request.
+        Result->SetStringField(TEXT("boundAttribute"), VerifiedAttributeName);
+        Result->SetStringField(TEXT("attributeSetClass"), OwningAttributeSetClass ? OwningAttributeSetClass->GetName() : FString());
+        Result->SetBoolField(TEXT("verifiedOnCompiledClass"), true);
+        Result->SetBoolField(TEXT("savedToDisk"), true);
         Bridge->SendAutomationResponse(RequestingSocket, RequestId, true, TEXT("Modifier added"), Result);
         return true;
     }
@@ -236,13 +487,55 @@ bool HandleGASEffectsMagnitude(const FGASRequestContext& Context, const FString&
         // Note: SetValue doesn't exist in UE 5.6. Use FScalableFloat constructor.
         EffectCDO->Modifiers[ModifierIndex].ModifierMagnitude = FGameplayEffectModifierMagnitude(FScalableFloat(Value));
 
+        // Same persistence gap as its siblings: the CDO was edited in memory and the change was never
+        // compiled or written, so it survived only until the editor closed. And like its siblings the
+        // result is read back from the RECOMPILED CDO before success is reported -- this was the one
+        // fixed handler without a read-back, which made the change set's own "every mutation verifies"
+        // record false.
         FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
+        const bool bCompiled = McpSafeCompileBlueprint(Blueprint);
+
+        bool bMagnitudeVerified = false;
+        float VerifiedValue = 0.0f;
+        if (UClass* CompiledClass = Blueprint->GeneratedClass)
+        {
+            if (UGameplayEffect* CompiledCDO = Cast<UGameplayEffect>(CompiledClass->GetDefaultObject()))
+            {
+                if (CompiledCDO->Modifiers.IsValidIndex(ModifierIndex))
+                {
+                    bMagnitudeVerified = CompiledCDO->Modifiers[ModifierIndex].ModifierMagnitude
+                        .GetStaticMagnitudeIfPossible(1.0f, VerifiedValue) &&
+                        FMath::IsNearlyEqual(VerifiedValue, Value, KINDA_SMALL_NUMBER);
+                }
+            }
+        }
+
+        if (!bCompiled || !bMagnitudeVerified)
+        {
+            Bridge->SendAutomationError(RequestingSocket, RequestId,
+                FString::Printf(TEXT("Modifier magnitude could not be verified on the compiled class (index %d)%s. The asset was NOT saved."),
+                    ModifierIndex,
+                    bCompiled ? TEXT("") : TEXT(" (the Blueprint failed to compile - it may have unrelated graph errors)")),
+                TEXT("MAGNITUDE_NOT_APPLIED"));
+            return true;
+        }
+
+        if (!McpSafeAssetSave(Blueprint))
+        {
+            Bridge->SendAutomationError(RequestingSocket, RequestId,
+                TEXT("Magnitude verified on the compiled class but the asset could NOT be written to disk (file may be read-only or held by source control). The change exists only in this editor session."),
+                TEXT("SAVE_FAILED"));
+            return true;
+        }
 
         TSharedPtr<FJsonObject> Result = McpHandlerUtils::CreateResultObject();
         Result->SetStringField(TEXT("blueprintPath"), BlueprintPath);
         Result->SetNumberField(TEXT("modifierIndex"), ModifierIndex);
         Result->SetStringField(TEXT("magnitudeType"), MagnitudeType);
-        Result->SetNumberField(TEXT("value"), Value);
+        // Read back from the compiled CDO, not echoed from the request.
+        Result->SetNumberField(TEXT("value"), VerifiedValue);
+        Result->SetBoolField(TEXT("verifiedOnCompiledClass"), true);
+        Result->SetBoolField(TEXT("savedToDisk"), true);
         Bridge->SendAutomationResponse(RequestingSocket, RequestId, true, TEXT("Magnitude set"), Result);
         return true;
     }

--- a/tests/mcp-tools/gameplay/manage-gas.test.mjs
+++ b/tests/mcp-tools/gameplay/manage-gas.test.mjs
@@ -52,7 +52,12 @@ const testCases = [
     expected: 'success',
     captureResult: { key: 'abilityPath', fromField: 'result.assetPath' }
   },
-  { scenario: 'CONFIG: set_ability_tags', toolName: 'manage_gas', arguments: { action: 'set_ability_tags', abilityPath: '${captured:abilityPath}', abilityTags: [abilityTag], cancelAbilitiesWithTag: [`Ability.Cancel.${ts}`], blockAbilitiesWithTag: [`Ability.Block.${ts}`], activationRequiredTags: [`Ability.Required.${ts}`], activationBlockedTags: [`Ability.Blocked.${ts}`] }, expected: 'success' },
+  // set_ability_tags now VALIDATES tags against the project's GameplayTags registry BEFORE writing
+  // anything: an unregistered tag is refused (GAMEPLAY_TAG_NOT_REGISTERED) with zero side effects.
+  // Previously the same call answered success while silently writing nothing (the tag strings below
+  // are Date.now()-suffixed, so they are never registered) -- the old expectation was asserting the
+  // silent-failure bug. This case now asserts the refusal contract instead.
+  { scenario: 'CONFIG: set_ability_tags refuses unregistered tags before writing', toolName: 'manage_gas', arguments: { action: 'set_ability_tags', abilityPath: '${captured:abilityPath}', abilityTags: [abilityTag], cancelAbilitiesWithTag: [`Ability.Cancel.${ts}`], blockAbilitiesWithTag: [`Ability.Block.${ts}`], activationRequiredTags: [`Ability.Required.${ts}`], activationBlockedTags: [`Ability.Blocked.${ts}`] }, expected: 'error', assertions: [{ path: 'structuredContent.error', includes: 'GAMEPLAY_TAG_NOT_REGISTERED', label: 'unregistered tags refused, nothing written' }] },
   { scenario: 'CONFIG: set_ability_targeting', toolName: 'manage_gas', arguments: { action: 'set_ability_targeting', abilityPath: '${captured:abilityPath}', targetingMode: 'AOE', targetRange: 1200, aoeRadius: 350 }, expected: 'success' },
   { scenario: 'ADD: add_ability_task', toolName: 'manage_gas', arguments: { action: 'add_ability_task', abilityPath: '${captured:abilityPath}', taskType: 'WaitDelay' }, expected: 'success' },
   { scenario: 'CONFIG: set_activation_policy', toolName: 'manage_gas', arguments: { action: 'set_activation_policy', abilityPath: '${captured:abilityPath}', activationPolicy: 'OnInputPressed' }, expected: 'success' },


### PR DESCRIPTION
## The problem

Five `manage_gas` mutation handlers edit the in-memory CDO and return `success:true` without
compiling or saving, so the authored content either never reaches the generated class or dies with
the editor session. Reproduced on UE 5.8 with the standard ability + damage-over-time chain:

| call | reported | actually authored |
|---|---|---|
| `add_attribute` (defaultValue: 100) | success, `defaultValue: 100` | attribute exists, `BaseValue = 0.0` — the value is read and only echoed |
| `add_effect_modifier` | success, `modifierCount: 1` | `Modifier.Attribute` never assigned — `attribute_name = ""`, the modifier modifies **nothing** (the identifier `Attribute` did not occur anywhere in the file; meanwhile the schema advertises `targetAttribute` and the TS route *requires* `attributeName`, so callers are forced to supply an argument that is thrown away) |
| `create_gameplay_effect` / `set_effect_duration` (period: 1) | success | `Period = 0.0` — **no write path for `period` existed anywhere**, so a "damage over time" effect never ticks |
| `set_ability_tags` (unregistered tag) | success, `tagsAdded: []` | nothing — `RequestGameplayTag(..., false)` does not create tags, and the miss was silently skipped |
| `set_modifier_magnitude` | success | in-memory only; lost on editor close |

Two sibling handlers in the same file (`set_attribute_base_value`, `set_attribute_clamping`)
already do the right sequence — the fix largely brings the other five in line with them.

## The fix

Every mutation now runs **mark → compile → verify on the recompiled generated class → save**,
consults the compile AND save results, and reports honestly:

- New error codes: `ATTRIBUTE_NOT_APPLIED`, `MODIFIER_NOT_BOUND`, `ABILITY_TAGS_NOT_APPLIED`,
  `MAGNITUDE_NOT_APPLIED`, `DURATION_NOT_APPLIED`, `GAMEPLAY_TAG_NOT_REGISTERED`, `SAVE_FAILED`
  (read-only / source-control-locked files no longer produce silent success).
- Success payloads carry `verifiedOnCompiledClass` and `savedToDisk`; value fields (`baseValue`,
  `boundAttribute`, `value`, `period`) are **read back from the compiled CDO**, not echoed.
- A verification failure does NOT save — a failed state is no longer persisted to disk under an
  error message that denies it exists.
- Attribute resolution accepts `Health` and the qualified `AS_Foo.Health` (honored, matching the
  class or its `_C` generated form), skips reinstancing debris (`REINST_`/`SKEL_`/`TRASHCLASS_`/
  `CLASS_NewerVersionExists` — without this, an attribute on a freshly recompiled Blueprint
  AttributeSet resolved to its `REINST_SKEL_*` class and "worked"), and reports ambiguity as
  `AMBIGUOUS_ATTRIBUTE` with the candidate list instead of binding an arbitrary first match.
- Tag validation covers all five containers (plural arrays and the existing singular aliases) and
  runs BEFORE any write, so a refusal has zero side effects on the CDO.

Also fixes an editor **hard-kill** in `blueprint_get`: for a variable added but not yet compiled,
`FMcpAutomationBridge_FindProperty` resolves the property on the SKELETON class while the CDO
belongs to the generated class (siblings, not ancestors), and `ContainerPtrToValuePtr`'s `checkf`
is fatal in Development builds. Deterministic 3-call repro: `create_attribute_set` →
`get_blueprint_details` (OK) → `add_attribute` → `get_blueprint_details` (assert). The guard is
the engine's own predicate (`CDO->IsA(Property->GetOwner<UClass>())`); the uncompiled variable
falls through to the existing `NewVariables` default-value fallback, so callers still see the
declared default.

## Test update

`tests/mcp-tools/gameplay/manage-gas.test.mjs`'s `set_ability_tags` case used Date.now()-suffixed
tags (never registered in any project) and asserted `success` — i.e. it asserted the silent-failure
behaviour. It now asserts the refusal contract (`GAMEPLAY_TAG_NOT_REGISTERED`). The other affected
cases (`add_attribute`, `add_effect_modifier`, `set_effect_duration`, `set_modifier_magnitude`)
pass unchanged — and now actually author what they claim.

## Verified

- **Compiles clean at current `dev` HEAD** (this branch is based on it): RunUAT BuildPlugin,
  UE 5.8 / Win64, zero warnings or errors in the touched files.
- Live on UE 5.8: authoring round green (attribute default persisted through an editor restart,
  modifier bound and surviving recompilation, period ticking — a live ASC measured
  `Health 100.0 → 90.0` after applying the authored periodic effect). Additionally a five-way
  mutation matrix: reverting each fix individually turns its corresponding check red.

## Known limitation (pre-existing, not addressed here)

`set_modifier_magnitude` reads `magnitudeType`/`magnitudeCalculationType` but always writes a
ScalableFloat — SetByCaller/AttributeBased magnitudes were never implemented in this action. The
new read-back verifies the ScalableFloat write, so behaviour is unchanged for existing callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
