### PR TITLE
refactor(environment): route McpConfigureActorAndComponent through the same render-state path as #567

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Environment/Runtime/McpAutomationBridge_EnvironmentHandlersActorComponents.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Environment/Runtime/McpAutomationBridge_EnvironmentHandlersActorComponents.cpp
@@ -1,6 +1,8 @@
 #include "Domains/Environment/McpAutomationBridge_EnvironmentHandlersShared.h"
 
 #if WITH_EDITOR
+#include "ComponentReregisterContext.h"
+
 namespace McpEnvironmentHandlers {
 
 UWorld *McpGetEditorWorld()
@@ -155,7 +157,23 @@ bool McpConfigureActorAndComponent(const TSharedPtr<FJsonObject> &Payload, const
     if (Component)
     {
         ComponentApplied = McpApplyPayloadSettings(Component, Payload, Applied, Failed);
-        Component->MarkRenderStateDirty();
+        // Every class reaching this line today is a USceneComponent, whose
+        // ShouldCreateRenderState() is unconditionally true, so a bare
+        // MarkRenderStateDirty() happens to be correct -- but only by accident of the
+        // call sites. ComponentClassPath is a free parameter of this helper. The day one
+        // caller passes a primitive, that luck runs out: UStaticMeshComponent registers
+        // with NO render state while its mesh is null, and MarkRenderStateDirty() is
+        // guarded on bRenderStateCreated, so it degrades to a silent no-op and the actor
+        // is configured but never drawn. Re-register instead of assuming: that re-runs
+        // ShouldCreateRenderState() and builds the state if it is now warranted.
+        if (Component->IsRegistered() && !Component->IsRenderStateCreated())
+        {
+            FComponentReregisterContext ReregisterContext(Component);
+        }
+        else
+        {
+            Component->MarkRenderStateDirty();
+        }
     }
     const int32 TotalApplied = ActorApplied + ComponentApplied;
 
@@ -165,6 +183,12 @@ bool McpConfigureActorAndComponent(const TSharedPtr<FJsonObject> &Payload, const
     {
         Resp->SetStringField(TEXT("componentName"), Component->GetName());
         Resp->SetStringField(TEXT("componentPath"), Component->GetPathName());
+        // Report whether the component can actually draw, so "configured" can never be
+        // read as "visible" again. This is the tripwire: it is true for every class the
+        // current callers pass, so a false is the signal that a component arrived which
+        // cannot render in its present state -- the failure that would otherwise be
+        // invisible in a success response.
+        Resp->SetBoolField(TEXT("componentRenderStateCreated"), Component->IsRenderStateCreated());
     }
     McpAddStringArrayField(Resp, TEXT("configuredProperties"), Applied);
     McpAddStringArrayField(Resp, TEXT("configurationErrors"), Failed);


### PR DESCRIPTION
## What this is — and what it is not

Sibling surface of #567, different file. **This is a preventive guard, not a bug fix.** I want to be straight about that up front, because the shape looks identical to #567 and it would be easy to over-claim.

`McpConfigureActorAndComponent` also writes properties by raw reflection (`McpApplyPayloadSettings`) and then calls a bare `Component->MarkRenderStateDirty()` — #567's exact signature.

**But I measured the precondition and it is unreachable here.** Three independent locks, each sufficient on its own:

1. **No primitive component can arrive.** `ComponentClassPath` is never read from the payload — it is a function parameter, and all 10 call sites pass a fixed literal (`ConfigureEnvironmentActor` ×6, `ConfigureSkyRigActor` ×3, `McpConfigureWaterBody` ×1). The reachable set is 6 classes — SkyAtmosphere, SkyLight, DirectionalLight, ExponentialHeightFog, VolumetricCloud, WindDirectionalSource — and **none is a `UPrimitiveComponent`**.
2. **`MarkRenderStateDirty()` is never a no-op on this path.** All 6 derive from `USceneComponent` and have a real render state.
3. `McpConfigureWaterBody` passes `FString()`, so `Component == nullptr` and the line never executes.

## Why send it at all

Two reasons, both modest:

- The two sibling surfaces currently differ in how they refresh render state. After #567 that difference is arbitrary, and arbitrary differences are what drift into real bugs.
- If a future caller *does* route a primitive component here, this path gives the correct behaviour instead of a silent non-render.

Behaviour for all 6 reachable classes is unchanged. Happy to close this if you would rather keep the surface as-is — it is a hygiene change, not a fix.