### PR TITLE
fix(asset): unhang get_source_control_state and forward assetPaths

### DIFF
--- a/src/tools/handlers/asset/asset-query-actions.ts
+++ b/src/tools/handlers/asset/asset-query-actions.ts
@@ -158,19 +158,42 @@ export async function handleSimpleQueryAction(action: string, context: AssetHand
     return assetSuccessResponse(await executeAutomationRequest(context.tools, 'fixup_redirectors', payload), 'Redirectors fixed up successfully', 'FIXUP_REDIRECTORS_FAILED', 'Redirector fixup failed');
   }
 
-  const params = normalizeArgs(context.args, [{ key: 'assetPath', required: action !== 'analyze_graph' }, { key: 'recursive' }, { key: 'maxDepth' }]);
-  const assetPath = extractString(params, 'assetPath');
+  // The manage_asset schema advertises an `assetPaths` array for get_source_control_state,
+  // and the handler this routes to reads it (AssetWorkflow/...SourceControlState.cpp takes
+  // assetPath OR assetPaths). This wrapper still required the singular assetPath
+  // unconditionally and never forwarded the array, so an array-only call failed with
+  // "Missing required argument: assetPath" before it could reach that handler.
+  const assetPathsRaw = action === 'get_source_control_state' ? context.args.assetPaths : undefined;
+  const assetPaths = Array.isArray(assetPathsRaw)
+    ? assetPathsRaw.filter((p): p is string => typeof p === 'string' && p.trim().length > 0).map(p => p.trim())
+    : [];
+  const params = normalizeArgs(context.args, [
+    { key: 'assetPath', required: action !== 'analyze_graph' && assetPaths.length === 0 },
+    { key: 'recursive' },
+    { key: 'maxDepth' }
+  ]);
+  const assetPath = assetPaths.length > 0
+    ? (extractOptionalString(params, 'assetPath') ?? '')
+    : extractString(params, 'assetPath');
   const payload = action === 'analyze_graph'
     ? { assetPath, maxDepth: extractOptionalNumber(params, 'maxDepth') }
-    : { assetPath, recursive: extractOptionalBoolean(params, 'recursive'), subAction: action };
-  // Task 21: get_source_control_state routes to the canonical manage_asset
-  // action (array-capable, disabled-SC-tolerant, richer envelope) rather than
-  // the weaker asset_query subAction handler. analyze_graph keeps its existing
-  // get_asset_graph (dependency-graph) mapping.
+    : {
+      assetPath,
+      recursive: extractOptionalBoolean(params, 'recursive'),
+      subAction: action,
+      ...(assetPaths.length > 0 ? { assetPaths } : {})
+    };
+  // get_source_control_state goes to its own registered action, not through
+  // manage_asset. Routing it as a manage_asset subAction reaches
+  // HandleAssetAction, which resolves the subAction but passes the RAW action
+  // name down; HandleGetSourceControlState then re-checks that name, does not
+  // match, and returns false without answering -- the caller just waits out the
+  // 30s timeout. The direct action reaches the same array-capable handler and
+  // answers. analyze_graph keeps its existing get_asset_graph mapping.
   const requestAction = action === 'analyze_graph'
     ? 'get_asset_graph'
     : action === 'get_source_control_state'
-      ? 'manage_asset'
+      ? 'get_source_control_state'
       : action === 'exists'
         ? 'exists'
         : 'manage_asset';


### PR DESCRIPTION
## 1. Routing it through `manage_asset` never answers

`get_source_control_state` currently routes to the `manage_asset` action with a `subAction`. On the plugin side, `HandleAssetAction` resolves that subAction into its local `Lower` — but calls the leaf handler with the **raw action name**:

```cpp
if (Lower == TEXT("get_source_control_state"))
  return HandleGetSourceControlState(RequestId, Action, Payload, RequestingSocket);
//                                              ^^^^^^ still "manage_asset"
```

and the leaf re-checks the name it was handed:

```cpp
// AssetWorkflow/...SourceControlState.cpp
const FString Lower = Action.ToLower();                              // "manage_asset"
if (!Lower.Equals(TEXT("get_source_control_state"), ESearchCase::IgnoreCase)) {
  return false;                                                       // always taken
}
```

`return false` sends **no response at all**, so the caller sits until its 30 s timeout. Nothing is logged, which makes it read as a hang rather than a refusal.

### Measured, single variable changed, same asset and editor session (UE 5.8)

| `requestAction` | result |
|---|---|
| `asset_query` | success |
| **`manage_asset`** | **timed out after 30000 ms** (reproduced twice) |
| `get_source_control_state` | success |

Routing to the registered action reaches the same array-capable handler and answers.

## 2. `assetPaths` was advertised but never forwarded

The schema advertises an `assetPaths` array, and the handler reads it (`AssetWorkflow/...SourceControlState.cpp` accepts `assetPath` **or** `assetPaths`). But the wrapper required the singular `assetPath` unconditionally and never passed the array through, so an array-only call failed with `Missing required argument: assetPath`.

`assetPath` is now required only when no usable array was supplied, and the array is forwarded.

Verified: `assetPaths` with two paths returns `states: [...] (2)`, `queriedCount: 2`.

## Worth a separate look

**16 of the 17 handlers `HandleAssetAction` dispatches to with the raw `Action` re-check it the same way.** I spot-checked `HandleBulkDeleteAssets` and it has the identical guard shape. `get_source_control_state` just happens to be the first one routed through `manage_asset` — any other subAction routed that way will hit the same silence.

I did not measure the other 15 individually, so I am not claiming they are broken today, only that the trap is armed. If you would prefer the general fix (pass the resolved action name down, or have the leaves accept the consolidated name), I am happy to do that instead of this narrow one.