### PR TITLE
fix(actor): set_component_property must not report success for values it dropped

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/ControlActor/McpAutomationBridge_ControlActorComponentProperties.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/ControlActor/McpAutomationBridge_ControlActorComponentProperties.cpp
@@ -202,7 +202,43 @@ bool UMcpAutomationBridgeSubsystem::HandleControlActorSetComponentProperties(
     Data->SetArrayField(TEXT("applied"), PropsArray);
   }
 
+  // PropertyWarnings was collected above and then thrown away: a value the
+  // converter could not handle came back as "Component properties updated",
+  // success:true, just with no `applied` entry -- so the caller had to diff the
+  // property afterwards to discover nothing happened.
+  if (PropertyWarnings.Num() > 0) {
+    TArray<TSharedPtr<FJsonValue>> WarnArray;
+    for (const FString &Warning : PropertyWarnings)
+      WarnArray.Add(MakeShared<FJsonValueString>(Warning));
+    Data->SetArrayField(TEXT("warnings"), WarnArray);
+  }
+
 	McpHandlerUtils::AddVerification(Data, Found);
+
+  // Nothing asked for could be written: that is a failure, not an update.
+  if (AppliedProperties.Num() == 0 && PropertyWarnings.Num() > 0) {
+    SendAutomationResponse(
+        Socket, RequestId, false,
+        FString::Printf(TEXT("No component properties were applied: %s"),
+                        *FString::Join(PropertyWarnings, TEXT("; "))),
+        Data, TEXT("PROPERTY_CONVERSION_FAILED"));
+    return true;
+  }
+
+  // A PARTIAL apply used to look identical to a clean one: success:true, the same message, and a `warnings`
+  // array the model will not read. Put the shortfall where it cannot be missed.
+  if (PropertyWarnings.Num() > 0) {
+    Data->SetBoolField(TEXT("partial"), true);
+    SendAutomationResponse(
+        Socket, RequestId, true,
+        FString::Printf(TEXT("Applied %d of %d component properties (%d failed): %s"),
+                        AppliedProperties.Num(),
+                        AppliedProperties.Num() + PropertyWarnings.Num(),
+                        PropertyWarnings.Num(),
+                        *FString::Join(PropertyWarnings, TEXT("; "))),
+        Data);
+    return true;
+  }
 
 	SendAutomationResponse(Socket, RequestId, true, TEXT("Component properties updated"), Data);
   return true;


### PR DESCRIPTION
Three related silences on the same path.

## 1. Warnings were collected and thrown away

`PropertyWarnings` was filled in and then never returned. A value the converter could not handle came back as:

```
success: true
message: "Component properties updated"
```

with simply no entry in `applied` — so the caller had to diff the property afterwards to discover nothing happened. The warnings are now returned.

## 2. Nothing applied is a failure, not an update

If *none* of the requested properties could be written, the response still claimed an update. It now answers with `PROPERTY_CONVERSION_FAILED` and names what went wrong.

## 3. A partial apply looked identical to a clean one

Same `success: true`, same message, and a `warnings` array that is easy to miss. It now says how many of how many were applied and sets `partial: true`, so the shortfall is where it cannot be overlooked.

## Measured

On UE 5.8: `LightColor` set to UE export text `(B=0,G=128,R=255,A=255)` returned success and left the value untouched, while the same value as JSON returned `applied: ["LightColor"]` and did change it.

#604 fixes the converter side of that specific case — this PR fixes the reporting, which is the part that made it invisible.