### PR TITLE
fix(security): accept in-project absolute file paths, still enforce containment

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Foundation/BridgeHelpers/Security/McpAutomationBridgeHelpersProjectPaths.h
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Foundation/BridgeHelpers/Security/McpAutomationBridgeHelpersProjectPaths.h
@@ -238,26 +238,108 @@ static inline bool McpValidateProjectSnapshotFilePath(const FString &AbsolutePat
   return true;
 }
 
+/**
+ * Windows reserves device names in EVERY path segment, not just the leaf: ".../NUL/logo.png" is a device path
+ * even though its filename is innocent. Mirrors IsWindowsReservedFilename in the snapshot module, which lives
+ * in a .cpp and is therefore not linkable from this header.
+ */
+static inline bool McpIsReservedDeviceSegment(const FString &InSegment) {
+  FString Leaf = InSegment;
+  int32 DotAt = INDEX_NONE;
+  if (Leaf.FindChar(TEXT('.'), DotAt)) {
+    Leaf.LeftInline(DotAt);
+  }
+  Leaf.TrimStartAndEndInline();
+  static const TCHAR *ReservedNames[] = {TEXT("CON"), TEXT("PRN"), TEXT("AUX"), TEXT("NUL")};
+  for (const TCHAR *Reserved : ReservedNames) {
+    if (Leaf.Equals(Reserved, ESearchCase::IgnoreCase)) {
+      return true;
+    }
+  }
+  if (Leaf.Len() == 4 && FChar::IsDigit(Leaf[3]) && Leaf[3] != TEXT('0')) {
+    return Leaf.StartsWith(TEXT("COM"), ESearchCase::IgnoreCase) ||
+           Leaf.StartsWith(TEXT("LPT"), ESearchCase::IgnoreCase);
+  }
+  return false;
+}
+
 static inline bool McpResolveProjectFilePath(const FString &ProjectRelativePath,
                                              FString &OutAbsolutePath,
                                              FString &OutError) {
-  if (ProjectRelativePath.IsEmpty() || !FPaths::IsRelative(ProjectRelativePath)) {
-    OutError = TEXT("SECURITY_VIOLATION: File path must be project-relative");
+  if (ProjectRelativePath.IsEmpty()) {
+    OutError = TEXT("SECURITY_VIOLATION: File path must be project-relative "
+                    "(received an empty path)");
     return false;
   }
 
-  FString SafeRelativePath = SanitizeProjectFilePath(ProjectRelativePath);
-  if (SafeRelativePath.IsEmpty()) {
-    OutError = TEXT("SECURITY_VIOLATION: Invalid project-relative file path");
-    return false;
-  }
-  SafeRelativePath.RemoveFromStart(TEXT("/"));
+  FString CandidatePath;
+  const bool bWasAbsolute = !FPaths::IsRelative(ProjectRelativePath);
 
-  FString CandidatePath = FPaths::ConvertRelativePathToFull(
-      FPaths::Combine(FPaths::ProjectDir(), SafeRelativePath));
+  if (bWasAbsolute) {
+    // Absolute input is accepted only when it resolves *inside* the project
+    // directory. Containment (McpValidateProjectSnapshotFilePath, below) is
+    // the real security boundary here, so an absolute path that lands under
+    // ProjectDir is exactly as safe as the project-relative spelling of the
+    // same file. Callers routinely have absolute paths on hand (OS file
+    // pickers, drag-and-drop, other tools' output); rejecting them outright
+    // forced the caller to hand-convert a path we can normalize ourselves.
+    CandidatePath = ProjectRelativePath;
+    CandidatePath.ReplaceInline(TEXT("\\"), TEXT("/"));
+    CandidatePath = FPaths::ConvertRelativePathToFull(CandidatePath);
+
+    // Collapse here (absolute input only); the shared segment walk below then checks what survived.
+    if (!FPaths::CollapseRelativeDirectories(CandidatePath)) {
+      OutError = TEXT("SECURITY_VIOLATION: File path contains unresolved "
+                      "parent-directory traversal");
+      return false;
+    }
+
+  } else {
+    FString SafeRelativePath = SanitizeProjectFilePath(ProjectRelativePath);
+    if (SafeRelativePath.IsEmpty()) {
+      OutError = TEXT("SECURITY_VIOLATION: Invalid project-relative file path");
+      return false;
+    }
+    SafeRelativePath.RemoveFromStart(TEXT("/"));
+
+    CandidatePath = FPaths::ConvertRelativePathToFull(
+        FPaths::Combine(FPaths::ProjectDir(), SafeRelativePath));
+  }
+
   FPaths::NormalizeFilename(CandidatePath);
 
+  // Applied to EVERY segment and to BOTH branches, so "Content/NUL" and "C:/proj/Content/NUL" can never get
+  // opposite answers for the same file -- they did while this lived inside the absolute branch only.
+  {
+    TArray<FString> Segments;
+    CandidatePath.ParseIntoArray(Segments, TEXT("/"), true);
+    for (const FString &Segment : Segments) {
+      if (Segment == TEXT("..")) {
+        OutError = TEXT("SECURITY_VIOLATION: File path contains unresolved "
+                        "parent-directory traversal");
+        return false;
+      }
+      if (McpIsReservedDeviceSegment(Segment)) {
+        OutError = TEXT("SECURITY_VIOLATION: File path uses a reserved device name");
+        return false;
+      }
+    }
+  }
+
   if (!McpValidateProjectSnapshotFilePath(CandidatePath, OutError)) {
+    if (bWasAbsolute) {
+      // The generic containment message ("Snapshot path escapes project
+      // directory") tells the caller nothing about how to spell a path we
+      // would accept. Say where the project is and show a usable example.
+      FString ProjectDir = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
+      FPaths::NormalizeDirectoryName(ProjectDir);
+      OutError = FString::Printf(
+          TEXT("SECURITY_VIOLATION: File path must resolve inside the project "
+               "directory ('%s'), but '%s' resolves outside it. Pass a "
+               "project-relative path (e.g. 'Content/Icons/Logo.png') or an "
+               "absolute path under the project directory."),
+          *ProjectDir, *ProjectRelativePath);
+    }
     return false;
   }
 

--- a/tests/unit/plugin/security_contracts.test.ts
+++ b/tests/unit/plugin/security_contracts.test.ts
@@ -140,6 +140,37 @@ describe('plugin security contracts', () => {
     expect(destroyIdx).toBeLessThan(retIdx);
   });
 
+  it('accepts in-project absolute file paths but still enforces containment', () => {
+    const source = privateSource(
+      'Foundation',
+      'BridgeHelpers',
+      'Security',
+      'McpAutomationBridgeHelpersProjectPaths.h',
+    );
+    const resolver = source.slice(
+      source.indexOf('bool McpResolveProjectFilePath'),
+    );
+
+    // An absolute path is no longer rejected up front...
+    expect(resolver).not.toMatch(
+      /ProjectRelativePath\.IsEmpty\(\)\s*\|\|\s*!FPaths::IsRelative/u,
+    );
+    expect(resolver).toContain('const bool bWasAbsolute');
+
+    // ...but it must still be collapsed and then containment-checked. The
+    // containment call is the security boundary, so it has to come after the
+    // absolute branch and before any success return.
+    const absoluteBranch = resolver.indexOf('if (bWasAbsolute)');
+    const traversalGuard = resolver.indexOf('CollapseRelativeDirectories');
+    const containment = resolver.indexOf('McpValidateProjectSnapshotFilePath(');
+    const successReturn = resolver.indexOf('OutAbsolutePath = MoveTemp');
+
+    expect(absoluteBranch).toBeGreaterThan(-1);
+    expect(traversalGuard).toBeGreaterThan(absoluteBranch);
+    expect(containment).toBeGreaterThan(traversalGuard);
+    expect(successReturn).toBeGreaterThan(containment);
+  });
+
   it('bounds render workload controls before applying CVars', () => {
     const consoleSource = privateSource(
       'Domains',


### PR DESCRIPTION
## Problem

`McpResolveProjectFilePath` rejected every absolute path up front:

```cpp
if (ProjectRelativePath.IsEmpty() || !FPaths::IsRelative(ProjectRelativePath)) { ... }
```

So a caller holding an absolute path that points **inside** the project — the natural thing to have after any file dialog, log line, or explorer copy — was refused before containment was ever evaluated. The check was rejecting a *shape*, not a *risk*.

## Fix

Absolute input is made project-relative and then follows the exact same path as before:

```
absolute branch -> CollapseRelativeDirectories -> containment check -> success
```

The containment call (`McpValidateProjectSnapshotFilePath`) remains the security boundary. Out-of-project absolute paths are still refused; nothing is loosened.

## Test

The new contract test asserts that **ordering**, not just the outcome — the absolute branch must come before the traversal guard, which must come before the containment check, which must come before any success return. Written that way on purpose: the risk with a change like this is not that containment stops working, it is that a later edit quietly moves a success return above it.