### PR TITLE
fix(animation): accept schema-documented montagePath in montage actions; pre-validate the notify union

### DIFF
--- a/src/tools/handlers/animation/authoring/animation-authoring-montage-assets.ts
+++ b/src/tools/handlers/animation/authoring/animation-authoring-montage-assets.ts
@@ -44,7 +44,7 @@ export async function handleMontageAssetAction(
 
   case 'add_montage_section': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: true },
+      { key: 'assetPath', aliases: ['montagePath'], required: true },
       { key: 'sectionName', required: true },
       { key: 'startTime', required: true },
       { key: 'save', default: true },
@@ -76,7 +76,7 @@ export async function handleMontageAssetAction(
 
   case 'add_montage_slot': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: true },
+      { key: 'assetPath', aliases: ['montagePath'], required: true },
       { key: 'animationPath', required: true },
       { key: 'slotName', default: 'DefaultSlot' },
       { key: 'startTime', default: 0 },
@@ -116,7 +116,7 @@ export async function handleMontageAssetAction(
 
   case 'set_section_timing': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: true },
+      { key: 'assetPath', aliases: ['montagePath'], required: true },
       { key: 'sectionName', required: true },
       { key: 'startTime' },
       { key: 'length' },
@@ -151,7 +151,7 @@ export async function handleMontageAssetAction(
 
   case 'add_montage_notify': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: true },
+      { key: 'assetPath', aliases: ['montagePath'], required: true },
       { key: 'notifyClass', required: false },
       { key: 'time', required: true },
       { key: 'trackIndex', default: 0 },
@@ -170,6 +170,11 @@ export async function handleMontageAssetAction(
     const trackIndex = nonNegativeIntegerOrDefault(params['trackIndex'], 0);
     const notifyName = extractOptionalString(params, 'notifyName');
     const save = extractOptionalBoolean(params, 'save') ?? true;
+    if (!notifyClass && !notifyName) {
+      // The authoring handler rejects the empty/empty pair with MISSING_NOTIFY_PARAMS; fail here so
+      // the doomed call does not burn a bridge round-trip. Either key alone is a valid call shape.
+      return ResponseFactory.errorWithCode('MISSING_NOTIFY_PARAMS', "add_montage_notify requires at least one of 'notifyName' or 'notifyClass'");
+    }
 
     const res = (await executeAutomationRequest(tools, 'manage_animation_authoring', {
       subAction: 'add_montage_notify',

--- a/src/tools/handlers/animation/authoring/animation-authoring-montage-blending.ts
+++ b/src/tools/handlers/animation/authoring/animation-authoring-montage-blending.ts
@@ -15,7 +15,7 @@ export async function handleMontageBlendAction(
 
   case 'set_blend_in': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: true },
+      { key: 'assetPath', aliases: ['montagePath'], required: true },
       { key: 'blendTime', default: 0.25 },
       { key: 'blendOption', default: 'Linear' },
       { key: 'save', default: true },
@@ -47,7 +47,7 @@ export async function handleMontageBlendAction(
 
   case 'set_blend_out': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: true },
+      { key: 'assetPath', aliases: ['montagePath'], required: true },
       { key: 'blendTime', default: 0.25 },
       { key: 'blendOption', default: 'Linear' },
       { key: 'save', default: true },
@@ -79,7 +79,7 @@ export async function handleMontageBlendAction(
 
   case 'link_sections': {
     const params = normalizeArgs(args, [
-      { key: 'assetPath', required: true },
+      { key: 'assetPath', aliases: ['montagePath'], required: true },
       { key: 'fromSection', required: true },
       { key: 'toSection', required: true },
       { key: 'save', default: true },


### PR DESCRIPTION
## Problem

The `animation_physics` input schema publishes a tool-wide `montagePath` property (described as *"Animation montage path."*), and the `play_anim_montage` handler accepts it — but seven montage cases only accept `assetPath`:

- `add_montage_section`, `add_montage_slot`, `set_section_timing`, `add_montage_notify` (montage-assets)
- `set_blend_in`, `set_blend_out`, `link_sections` (montage-blending)

A call carrying only `montagePath` dies in `normalizeArgs` with `Missing required argument: assetPath` and never reaches the engine. An agent that reads the schema picks `montagePath` legitimately for a montage action — we observed this repeatedly in live sessions (every occurrence followed by a successful `assetPath` retry, i.e. one wasted round-trip each time). Same argument-DX class as the merged `connect_pins` alias fixes (#530/#531).

## Fix

- `aliases: ['montagePath']` on the `assetPath` ArgConfig in all seven cases — following the existing `blendSpacePath` precedent in the same folder (`animation-authoring-blend-space-assets.ts`). `normalizeArgs` already advertises aliases, so the missing-arg error now teaches both names: `Missing required argument: assetPath (or montagePath)`.
- `add_montage_notify`: an up-front union check mirroring the handler contract in `McpAutomationBridge_AnimationAuthoringHandlersMontageNotifyBlend.cpp` (*at least one of* `notifyClass`/`notifyName`) — a call with neither key now fails in TypeScript with the engine's own `MISSING_NOTIFY_PARAMS` code instead of spending a bridge round-trip. Class-only notifies (`AnimNotify_PlaySound` etc.) are untouched.

## Compatibility

- `tsc` clean on `dev` HEAD (`a4570fd`).
- `tests/mcp-tools/gameplay/animation-physics.test.mjs` needs no changes: every montage scenario uses `assetPath` (unaffected), and the *'ADD: add_montage_notify via notifyClass'* scenario still passes as written — the union guard deliberately preserves the class-only call shape.
- No behavior change for any currently-working call; the only calls that change outcome are ones that failed anyway, and they now fail earlier with a more instructive message (or succeed, in the `montagePath` case).

Verified with a unit harness driving the built handlers through a stubbed automation bridge: `montagePath`-only reaches the bridge with `assetPath` filled for all seven actions; `assetPath` behavior unchanged; neither-key notify → `MISSING_NOTIFY_PARAMS` with zero bridge traffic.