### PR TITLE
fix(summary): render pin linkedTo targets, not just a count

### DIFF
--- a/src/utils/responses/response-content.test.ts
+++ b/src/utils/responses/response-content.test.ts
@@ -45,3 +45,33 @@ describe('buildSummaryText — output field budget', () => {
     expect(text).toContain('output: [a, b] (2)');
   });
 });
+
+describe('pin linkedTo targets', () => {
+  it('renders link targets as 8-hex nodeId prefixes with pin names, plus the total', () => {
+    const text = buildSummaryText('probe', {
+      success: true,
+      pins: [{
+        pinName: 'then', direction: 'Output', pinType: 'exec',
+        linkedTo: [{ nodeId: '5C2E1A9F4D3B41E8A7C6F0B2D9E83714', pinName: 'execute' }],
+      }],
+    });
+    expect(text).toContain('linkedTo=[5C2E1A9F.execute] (1)');
+  });
+
+  it('keeps the compact linkedTo=0 form for unconnected pins', () => {
+    const text = buildSummaryText('probe', {
+      success: true,
+      pins: [{ pinName: 'then', direction: 'Output', pinType: 'exec', linkedTo: [] }],
+    });
+    expect(text).toContain('linkedTo=0');
+  });
+
+  it('caps at five targets and announces the spill with the total', () => {
+    const links = Array.from({ length: 7 }, (_, i) => ({
+      nodeId: `${String(i).padStart(2, '0')}AACCE54817BB6726E95CB9642E51DD`.slice(0, 32), pinName: 'execute',
+    }));
+    const text = buildSummaryText('probe', { success: true, pins: [{ pinName: 'then', linkedTo: links }] });
+    expect(text).toContain(', ...] (7)');
+    expect(text).toContain('00AACCE5.execute');
+  });
+});

--- a/src/utils/responses/response-content.ts
+++ b/src/utils/responses/response-content.ts
@@ -35,7 +35,27 @@ function formatRecordListItem(record: Record<string, unknown>): string {
       const value = scalarToText(record[key]);
       if (value !== undefined) pinParts.push(`${key}=${value}`);
     }
-    if (Array.isArray(record.linkedTo)) pinParts.push(`linkedTo=${record.linkedTo.length}`);
+    if (Array.isArray(record.linkedTo)) {
+      const links = record.linkedTo;
+      if (links.length === 0) {
+        pinParts.push('linkedTo=0');
+      } else {
+        // Render the link TARGETS, not just a count: the target nodeId is the argument every follow-up
+        // graph call takes (connect/delete/get_node_details), and a bare count forces clients that only
+        // read the text channel to re-query per node. 8-hex GUID prefixes are directly consumable —
+        // FindNode resolves unique prefixes of >=8 hex chars (BlueprintGraphHandlersContextEditor.cpp).
+        const shown = links.slice(0, 5).map(link => {
+          if (isRecord(link)) {
+            const nodeId = typeof link.nodeId === 'string' ? link.nodeId.slice(0, 8) : '';
+            const pin = scalarToText(link.pinName);
+            if (nodeId !== '') return pin !== undefined && pin !== '' ? `${nodeId}.${pin}` : nodeId;
+          }
+          return '?';
+        });
+        const spill = links.length > 5 ? ', ...' : '';
+        pinParts.push(`linkedTo=[${shown.join(', ')}${spill}] (${links.length})`);
+      }
+    }
     return `{ ${pinParts.join(', ')} }`;
   }
 


### PR DESCRIPTION
The text summary collapses a pin's `linkedTo` array to `linkedTo=<count>`, so a client reading only the text channel cannot learn WHICH node a pin connects to — the exact value every follow-up graph call (`connect_pins`, `delete_node`, `get_node_details`) takes as an argument. Measured in the field: an agent needing the downstream node of an exec pin burned 26 `get_node_details` calls (each returning another count) before reporting the capability as missing.

Targets now render as 8-hex GUID prefixes with the target pin name — directly consumable, since `FindNode` resolves unique prefixes of >=8 hex chars (BlueprintGraphHandlersContextEditor.cpp) — capped at five with the spill and total announced: `linkedTo=[5C2E1A9F.execute] (1)`. Unconnected pins keep the compact `linkedTo=0` form, so existing consumers of that shape are untouched.

Tests added in `response-content.test.ts` (targets render, zero-link form, five-target cap); response suites green. The 6 pre-existing `tests/unit/plugin` baseline failures on a Windows CRLF checkout are unrelated and fail identically on a pristine `dev` checkout.