### PR TITLE
fix(summary): the array preview tail now says where the full list lives

### DIFF
--- a/src/utils/responses/response-content.test.ts
+++ b/src/utils/responses/response-content.test.ts
@@ -75,3 +75,20 @@ describe('pin linkedTo targets', () => {
     expect(text).toContain('00AACCE5.execute');
   });
 });
+
+
+describe('array preview marker', () => {
+  it('announces where the elided tail lives, with the true total', () => {
+    const text = buildSummaryText('probe', {
+      success: true,
+      nodes: Array.from({ length: 56 }, (_, i) => ({ nodeId: `node-${i}` })),
+    });
+    expect(text).toContain('(+26 more - full list in structuredContent)');
+    expect(text).toContain('(56)');
+  });
+
+  it('adds no marker when the array fits the preview', () => {
+    const text = buildSummaryText('probe', { success: true, nodes: [{ nodeId: 'a' }, { nodeId: 'b' }] });
+    expect(text).not.toContain('more - full list');
+  });
+});

--- a/src/utils/responses/response-content.ts
+++ b/src/utils/responses/response-content.ts
@@ -79,6 +79,9 @@ function formatRecordListItem(record: Record<string, unknown>): string {
  */
 const OUTPUT_SUMMARY_LIMIT = 2000;
 
+/** Array items shown in a summary before the tail is elided (the full array stays in structuredContent). */
+const ARRAY_PREVIEW_LIMIT = 30;
+
 function formatOutputValue(val: unknown): string {
   if (typeof val !== 'string') return formatValue(val);
   if (val.length <= OUTPUT_SUMMARY_LIMIT) return val;
@@ -92,8 +95,13 @@ function formatValue(val: unknown): string {
 
   if (Array.isArray(val)) {
     if (val.length === 0) return '[] (0)';
-    const items = val.slice(0, 30).map(v => isRecord(v) ? formatRecordListItem(v) : String(v));
-    const suffix = val.length > 30 ? `, ... (+${val.length - 30} more)` : '';
+    const items = val.slice(0, ARRAY_PREVIEW_LIMIT).map(v => isRecord(v) ? formatRecordListItem(v) : String(v));
+    // Point at where the tail actually lives — mirroring the string branch, whose truncation marker
+    // already says 'full text in structuredContent'. A bare '(+N more)' reads as data loss and sends
+    // text-only clients into re-query loops for a tail that was never going to appear.
+    const suffix = val.length > ARRAY_PREVIEW_LIMIT
+      ? `, ... (+${val.length - ARRAY_PREVIEW_LIMIT} more - full list in structuredContent)`
+      : '';
     return `[${items.join(', ')}${suffix}] (${val.length})`;
   }
 


### PR DESCRIPTION
The string branch already marks its truncation with an explicit pointer ('full text in structuredContent'); the array branch says only `(+N more)`, which reads as data loss. Measured in the field: a client shown 30/56 nodes prepared to re-query in a loop for a tail the text was never going to carry — while the full array sat in `structuredContent` the whole time.

The tail marker now reads `(+N more - full list in structuredContent)`, and the preview limit is hoisted to a named constant (`ARRAY_PREVIEW_LIMIT`). Arrays within the preview render exactly as before.

Tests added in `response-content.test.ts`; response suites green.