### PR TITLE
fix(summary): pair a record's display identity with its addressable sibling

### DIFF
--- a/src/utils/responses/response-content.test.ts
+++ b/src/utils/responses/response-content.test.ts
@@ -75,3 +75,33 @@ describe('pin linkedTo targets', () => {
     expect(text).toContain('00AACCE5.execute');
   });
 });
+
+describe('identity with addressable sibling', () => {
+  it('pairs a display name with the path a follow-up call takes', () => {
+    const text = buildSummaryText('probe', {
+      success: true,
+      assets: [{ name: 'BP_Player', path: '/Game/Blueprints/BP_Player' }],
+    });
+    expect(text).toContain('BP_Player (/Game/Blueprints/BP_Player)');
+  });
+
+  it('renders the identity alone when no addressable sibling exists', () => {
+    const text = buildSummaryText('probe', { success: true, assets: [{ name: 'BP_Solo' }] });
+    expect(text).toContain('BP_Solo');
+    expect(text).not.toContain('BP_Solo (');
+  });
+
+  it('does not duplicate when the chosen key IS the addressable one', () => {
+    const text = buildSummaryText('probe', { success: true, refs: [{ path: '/Game/Only/Path' }] });
+    expect(text).toContain('/Game/Only/Path');
+    expect(text).not.toContain('/Game/Only/Path (');
+  });
+
+  it('pairs sequence-style ids behind names', () => {
+    const text = buildSummaryText('probe', {
+      success: true,
+      bindings: [{ name: 'HeroBinding', id: '8F3A2C11-0000-4000-8000-1234567890AB' }],
+    });
+    expect(text).toContain('HeroBinding (8F3A2C11-0000-4000-8000-1234567890AB)');
+  });
+});

--- a/src/utils/responses/response-content.ts
+++ b/src/utils/responses/response-content.ts
@@ -61,7 +61,19 @@ function formatRecordListItem(record: Record<string, unknown>): string {
 
   for (const key of ['name', 'path', 'id', 'nodeId', 'nodeName', 'className', 'displayName', 'type', 'assetPath', 'objectPath']) {
     const value = scalarToText(record[key]);
-    if (value !== undefined && value.trim() !== '') return value;
+    if (value !== undefined && value.trim() !== '') {
+      // Pair the display identity with its ADDRESSABLE sibling when the record carries both: 'name' wins
+      // the priority list, but the path/id sibling is the value a follow-up call actually takes — and a
+      // short name alone is ambiguous across folders. One render change covers every list that shadows
+      // its path behind a name (asset/blueprint listings, actors, sequence bindings, struct members,
+      // source-control states).
+      for (const addrKey of ['path', 'assetPath', 'objectPath', 'id']) {
+        if (addrKey === key) continue;
+        const addr = scalarToText(record[addrKey]);
+        if (addr !== undefined && addr.trim() !== '' && addr !== value) return `${value} (${addr})`;
+      }
+      return value;
+    }
   }
 
   const entries = Object.entries(record).filter(([, value]) => value !== undefined && value !== null).slice(0, 4);


### PR DESCRIPTION
`formatRecordListItem` prints the first match of its priority list — usually `name` — and drops every sibling, including the `path`/`id` a follow-up call actually takes as an argument; a short name alone is also ambiguous across folders. When a record carries both, it now renders `name (path)`: one change covers every list that shadows its address behind a display name (asset/blueprint listings, actor surveys, sequence bindings, struct members, source-control states). Records without an addressable sibling render exactly as before, and the pin special-case is untouched.

Tests added in `response-content.test.ts` (name+path pairing, no-sibling passthrough, no self-pairing when the chosen key IS the address, id pairing); response suites green.