### PR TITLE
fix(build): make the plugin compile under clang on UE 5.8

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Core/Security/McpPrequeueDemand.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Core/Security/McpPrequeueDemand.cpp
@@ -104,7 +104,7 @@ bool DeclaresPathParameter(const FMcpCapabilityRecord& Record)
 	{
 		return true;
 	}
-	for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : (*Properties)->Values)
+	for (const TPair<FString, TSharedPtr<FJsonValue>> Pair : (*Properties)->Values)
 	{
 		if (McpCapabilityAuthorization::IsPathParameterKey(Pair.Key))
 		{

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Core/Security/McpPrequeueGate.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Core/Security/McpPrequeueGate.cpp
@@ -52,7 +52,7 @@ bool ObjectHasBlockedCommand(
 		State.bTruncated = true;
 		return false;
 	}
-	for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : Object->Values)
+	for (const TPair<FString, TSharedPtr<FJsonValue>> Pair : Object->Values)
 	{
 		if (State.NodeBudget <= 0)
 		{

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/AssetWorkflow/Operations/McpAutomationBridge_AssetWorkflowFabLibrary.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/AssetWorkflow/Operations/McpAutomationBridge_AssetWorkflowFabLibrary.cpp
@@ -105,7 +105,7 @@ bool UMcpAutomationBridgeSubsystem::HandleListFabLibrary(
   // columns IS the filter: only rows carrying all of them match.
   Select Builder;
   for (const UScriptStruct *Column : Columns) {
-    Builder.ReadOnly({Column});
+    Builder.ReadOnly(Column);
   }
   FQueryDescription Description = Builder.Compile();
   const QueryHandle Handle = Storage->RegisterQuery(MoveTemp(Description));

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Render/McpAutomationBridge_RenderSupportSettings.h
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Render/McpAutomationBridge_RenderSupportSettings.h
@@ -58,7 +58,7 @@ inline bool ApplyJsonSettings(
     {
         return true;
     }
-    for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : Settings->Values)
+    for (const TPair<FString, TSharedPtr<FJsonValue>> Pair : Settings->Values)
     {
         FProperty* Property = StructType->FindPropertyByName(FName(*Pair.Key));
         if (!Property)

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Sequence/Media/McpAutomationBridge_SequenceMediaSources.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Sequence/Media/McpAutomationBridge_SequenceMediaSources.cpp
@@ -91,7 +91,7 @@ bool ResolveSourceConfig(const TSharedPtr<FJsonObject> &Payload,
   if (!Payload->TryGetObjectField(TEXT("platformSources"), Sources) || !Sources ||
       !Sources->IsValid())
     return true;
-  for (const TPair<FString, TSharedPtr<FJsonValue>> &Entry : (*Sources)->Values) {
+  for (const TPair<FString, TSharedPtr<FJsonValue>> Entry : (*Sources)->Values) {
     if (!Entry.Value.IsValid() || Entry.Value->Type != EJson::String) {
       OutCode = TEXT("INVALID_PLATFORM_SOURCE");
       OutError = TEXT("Every platformSources value must be an asset path");

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Sequence/MovieRender/McpAutomationBridge_SequenceMovieRenderSettings.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/Sequence/MovieRender/McpAutomationBridge_SequenceMovieRenderSettings.cpp
@@ -199,7 +199,7 @@ bool HandleConfigureConsoleVariables(UMcpAutomationBridgeSubsystem *Subsystem,
       if (Entry.bIsEnabled)
         ParsedValues.Add(Entry.Name, Entry.Value);
   }
-  for (const TPair<FString, TSharedPtr<FJsonValue>> &Entry : (*Object)->Values) {
+  for (const TPair<FString, TSharedPtr<FJsonValue>> Entry : (*Object)->Values) {
     float Value = 0.0f;
     if (Entry.Key.TrimStartAndEnd().IsEmpty() ||
         !JsonToFloat(Entry.Value, Value) || !FMath::IsFinite(Value))

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Foundation/McpCapabilityPathScan.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Foundation/McpCapabilityPathScan.cpp
@@ -81,7 +81,7 @@ void ScanObject(const TSharedPtr<FJsonObject>& Object, int32 Depth, FScanState& 
 		State.Out->bTruncated = true;
 		return;
 	}
-	for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : Object->Values)
+	for (const TPair<FString, TSharedPtr<FJsonValue>> Pair : Object->Values)
 	{
 		if (State.NodeBudget <= 0)
 		{

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Foundation/McpLiveStateRevisions.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Foundation/McpLiveStateRevisions.cpp
@@ -147,7 +147,7 @@ FMcpExpectedRevisionsParseResult FMcpLiveStateRevisions::ParseExpectedRevisions(
 		return Result;
 	}
 
-	for (const TPair<FString, TSharedPtr<FJsonValue>>& Entry : (*Pins)->Values)
+	for (const TPair<FString, TSharedPtr<FJsonValue>> Entry : (*Pins)->Values)
 	{
 		EMcpStateKind Kind = EMcpStateKind::Selection;
 		if (!KindFor(Entry.Key, Kind))

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Execute/McpNativeGatewayExecuteRequest.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Execute/McpNativeGatewayExecuteRequest.cpp
@@ -50,7 +50,7 @@ bool McpValidateExecutionOptions(
 		return true;
 	}
 	const TArray<FString>& Supported = McpExecutionOptionKeys();
-	for (const TPair<FString, TSharedPtr<FJsonValue>>& Entry : Options->Values)
+	for (const TPair<FString, TSharedPtr<FJsonValue>> Entry : Options->Values)
 	{
 		if (!Supported.Contains(Entry.Key))
 		{

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Execute/McpNativeGatewayPreview.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Execute/McpNativeGatewayPreview.cpp
@@ -47,7 +47,7 @@ const TArray<FString>& UnimplementedExecutionOptionKeys()
 bool FindUnimplementedOption(const TSharedPtr<FJsonObject>& Options, FString& OutKey)
 {
 	const TArray<FString>& Supported = McpExecutionOptionKeys();
-	for (const TPair<FString, TSharedPtr<FJsonValue>>& Entry : Options->Values)
+	for (const TPair<FString, TSharedPtr<FJsonValue>> Entry : Options->Values)
 	{
 		if (!Supported.Contains(Entry.Key))
 		{
@@ -92,7 +92,7 @@ TSharedPtr<FJsonObject> PreviewFreeNextCall(
 		Params.IsValid() ? Params : MakeShared<FJsonObject>());
 
 	TSharedPtr<FJsonObject> Remaining = MakeShared<FJsonObject>();
-	for (const TPair<FString, TSharedPtr<FJsonValue>>& Entry : Options->Values)
+	for (const TPair<FString, TSharedPtr<FJsonValue>> Entry : Options->Values)
 	{
 		if (Entry.Key != TEXT("preview"))
 		{

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Execute/McpNativeGatewayReceipt.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Execute/McpNativeGatewayReceipt.cpp
@@ -214,7 +214,7 @@ TSharedPtr<FJsonObject> McpBuildErrorReceipt(
 
 	if (Guidance.IsValid())
 	{
-		for (const TPair<FString, TSharedPtr<FJsonValue>>& Field : Guidance->Values)
+		for (const TPair<FString, TSharedPtr<FJsonValue>> Field : Guidance->Values)
 		{
 			if (!Receipt->HasField(Field.Key))
 			{

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Execute/McpNativeGatewaySchemaValidation.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Execute/McpNativeGatewaySchemaValidation.cpp
@@ -50,7 +50,7 @@ bool McpValidateAgainstCanonicalSchema(
 	}
 
 	const FString Pointer = OutViolation.Pointer;
-	for (const TPair<FString, TSharedPtr<FJsonValue>>& Keyword : Schema->Values)
+	for (const TPair<FString, TSharedPtr<FJsonValue>> Keyword : Schema->Values)
 	{
 		if (!McpSchemaKeywords::IsSupportedKeyword(Keyword.Key))
 		{
@@ -183,7 +183,7 @@ bool ValidateObjectBody(
 		!bAdditionalProperties;
 	if (bClosed && bHasProperties)
 	{
-		for (const TPair<FString, TSharedPtr<FJsonValue>>& Entry : Object->Values)
+		for (const TPair<FString, TSharedPtr<FJsonValue>> Entry : Object->Values)
 		{
 			if (!(*Properties)->HasField(Entry.Key))
 			{
@@ -197,7 +197,7 @@ bool ValidateObjectBody(
 
 	if (bHasProperties)
 	{
-		for (const TPair<FString, TSharedPtr<FJsonValue>>& Entry : Object->Values)
+		for (const TPair<FString, TSharedPtr<FJsonValue>> Entry : Object->Values)
 		{
 			const TSharedPtr<FJsonObject>* PropertySchema = nullptr;
 			if (!(*Properties)->TryGetObjectField(Entry.Key, PropertySchema) || !PropertySchema)
@@ -246,7 +246,7 @@ TSharedPtr<FJsonObject> McpApplyCanonicalSchemaDefaults(
 	{
 		return WithDefaults;
 	}
-	for (const TPair<FString, TSharedPtr<FJsonValue>>& Property : (*Properties)->Values)
+	for (const TPair<FString, TSharedPtr<FJsonValue>> Property : (*Properties)->Values)
 	{
 		if (WithDefaults->HasField(Property.Key) || !Property.Value.IsValid() ||
 			Property.Value->Type != EJson::Object)

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Execute/McpNativeReceiptSecretKeys.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Execute/McpNativeReceiptSecretKeys.cpp
@@ -306,7 +306,7 @@ bool McpNamesCredentialBySibling(const TSharedPtr<FJsonObject>& Object)
 	{
 		return false;
 	}
-	for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : Object->Values)
+	for (const TPair<FString, TSharedPtr<FJsonValue>> Pair : Object->Values)
 	{
 		if (!NameBearingKeys().Contains(Pair.Key.ToLower()))
 		{

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Transport/McpNativeTransportPrimitives.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/MCP/Transport/McpNativeTransportPrimitives.cpp
@@ -209,7 +209,7 @@ bool FMcpNativeTransport::HandlePrimitiveMethod(
 		const TSharedPtr<FJsonObject>* ArgsObj = nullptr;
 		if (Params.IsValid() && Params->TryGetObjectField(TEXT("arguments"), ArgsObj) && ArgsObj)
 		{
-			for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : (*ArgsObj)->Values)
+			for (const TPair<FString, TSharedPtr<FJsonValue>> Pair : (*ArgsObj)->Values)
 			{
 				FString Val;
 				if (Pair.Value.IsValid() && Pair.Value->TryGetString(Val))


### PR DESCRIPTION
Two unrelated clang rejections, both silent under MSVC. 14 files, 18 lines, no behaviour change.

## 1. Range-for over `FJsonObject::Values` binds a mismatched reference

UE 5.8 flipped `UE_JSONOBJECT_LEGACY_STRING_KEYS` to 0:

```cpp
// Dom/JsonObject.h
using FStringType = UE::FSharedString;                        // :99
TMap<FStringType, TSharedPtr<FJsonValue>> Values;             // :237
```

So the element type is `TPair<FSharedString, TSharedPtr<FJsonValue>>`. The loops declare

```cpp
for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : Object->Values)
```

which no longer names the element type — the reference binds to a per-iteration temporary, and clang's `-Wrange-loop-construct` refuses it.

**Fix:** drop the `&`, making the conversion an explicit copy.

**Why not `const auto&`?** It would avoid the copy, but it also retypes `Pair.Key` to `FSharedString`, which has no implicit conversion to `FString` — every loop body using `Pair.Key` as a string would need changing too. Keeping the declared `TPair<FString, ...>` confines this PR to the loop headers. Happy to switch to `const auto&` plus the body fixes if you prefer that direction.

## 2. `Builder.ReadOnly({Column})` is ambiguous

`Select::ReadOnly` has both overloads:

```cpp
Select& ReadOnly(const UScriptStruct* Target);                      // TypedElementQueryBuilder.h:493
Select& ReadOnly(TConstArrayView<const UScriptStruct*> Targets);    // :495
```

A braced `{Column}` can initialise either, so clang reports the ambiguity. Passing `Column` directly selects the single-target overload — which is what the surrounding loop (`for (const UScriptStruct* Column : Columns)`, one column per iteration) already means.

## Verification

Compiles clean; both changes are behaviour-preserving by construction — they remove an ambiguity and an implicit temporary, not a code path. Found while building the plugin with clang (the toolchain Fab's submission review uses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)