### PR TITLE
fix(material): stop writing opaque white when the vector value is an array

### DIFF
--- a/src/tools/handlers/foundation/arguments/argument-helper.ts
+++ b/src/tools/handlers/foundation/arguments/argument-helper.ts
@@ -123,6 +123,34 @@ export function extractOptionalObject(params: Record<string, unknown>, key: stri
   return undefined;
 }
 
+/**
+ * Extract an optional vector-like value ({ r, g, b, a } / { x, y, z } object, or a 3-or-4 element numeric
+ * array) from normalized args, normalizing the array form to the object the bridge expects.
+ *
+ * Absent (undefined/null) yields undefined so the caller can apply its own optional default. A value that IS
+ * present but cannot be read as a vector THROWS rather than resolving to undefined: the alternative is a
+ * caller-side `?? someDefault`, which silently substitutes a different colour for the one that was asked for
+ * and still reports success.
+ */
+export function extractOptionalVector(params: Record<string, unknown>, key: string): Record<string, unknown> | undefined {
+  const val = params[key];
+  if (val === undefined || val === null) return undefined;
+
+  if (Array.isArray(val)) {
+    const nums = val.filter((n): n is number => typeof n === 'number' && Number.isFinite(n));
+    if (nums.length !== val.length || (val.length !== 3 && val.length !== 4)) {
+      throw new Error(
+        `Expected 3 or 4 finite numbers for '${key}', got ${JSON.stringify(val)}`,
+      );
+    }
+    return { r: nums[0], g: nums[1], b: nums[2], a: nums.length === 4 ? nums[3] : 1 };
+  }
+
+  if (typeof val === 'object') return val as Record<string, unknown>;
+
+  throw new Error(`Expected an object or a numeric array for '${key}', got ${typeof val}`);
+}
+
 /** Response from actor findByName */
 interface FindByNameResult {
   success?: boolean;

--- a/src/tools/handlers/material/material-authoring-instances.ts
+++ b/src/tools/handlers/material/material-authoring-instances.ts
@@ -4,7 +4,7 @@ import type { AutomationResponse } from '../../../types/automation/automation-re
 import { executeAutomationRequest } from '../foundation/dispatch/common-handlers.js';
 import { ResponseFactory } from '../../../utils/responses/response-factory.js';
 import { TOOL_ACTIONS } from '../../../utils/commands/action-constants.js';
-import { normalizeArgs, extractString, extractOptionalString, extractOptionalBoolean, extractOptionalObject } from '../foundation/arguments/argument-helper.js';
+import { normalizeArgs, extractString, extractOptionalString, extractOptionalBoolean, extractOptionalVector } from '../foundation/arguments/argument-helper.js';
 import { normalizeAssetPath, parseMaterialPath } from './material-authoring-common.js';
 import { toFiniteNumber } from '../../../utils/validation/normalize.js';
 
@@ -120,7 +120,7 @@ export async function handleMaterialInstanceAction(
 
         const assetPath = extractString(params, 'assetPath');
         const parameterName = extractString(params, 'parameterName');
-        const value = extractOptionalObject(params, 'value') ?? { r: 1, g: 1, b: 1, a: 1 };
+        const value = extractOptionalVector(params, 'value') ?? { r: 1, g: 1, b: 1, a: 1 };
         const save = extractOptionalBoolean(params, 'save') ?? true;
 
         const res = (await executeAutomationRequest(tools, TOOL_ACTIONS.MANAGE_MATERIAL_AUTHORING, {

--- a/src/tools/handlers/material/material-authoring-parameters.ts
+++ b/src/tools/handlers/material/material-authoring-parameters.ts
@@ -4,7 +4,7 @@ import type { AutomationResponse } from '../../../types/automation/automation-re
 import { executeAutomationRequest } from '../foundation/dispatch/common-handlers.js';
 import { ResponseFactory } from '../../../utils/responses/response-factory.js';
 import { TOOL_ACTIONS } from '../../../utils/commands/action-constants.js';
-import { normalizeArgs, extractString, extractOptionalString, extractOptionalNumber, extractOptionalBoolean, extractOptionalObject } from '../foundation/arguments/argument-helper.js';
+import { normalizeArgs, extractString, extractOptionalString, extractOptionalNumber, extractOptionalBoolean, extractOptionalVector } from '../foundation/arguments/argument-helper.js';
 
 export async function handleMaterialParameterAction(
   action: string,
@@ -126,7 +126,7 @@ export async function handleMaterialParameterAction(
 
         const assetPath = extractString(params, 'assetPath');
         const parameterName = extractString(params, 'parameterName');
-        const defaultValue = extractOptionalObject(params, 'defaultValue') ?? { r: 1, g: 1, b: 1, a: 1 };
+        const defaultValue = extractOptionalVector(params, 'defaultValue') ?? { r: 1, g: 1, b: 1, a: 1 };
         const group = extractOptionalString(params, 'group') ?? 'None';
         const x = extractOptionalNumber(params, 'x') ?? 0;
         const y = extractOptionalNumber(params, 'y') ?? 0;

--- a/tests/unit/tools/vector-parameter-value-normalization.test.ts
+++ b/tests/unit/tools/vector-parameter-value-normalization.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { extractOptionalVector } from '../../../src/tools/handlers/foundation/arguments/argument-helper.js';
+
+// Regression cover for material.set_vector_parameter_value / material.add_vector_parameter.
+//
+// Before this fix both handlers read the colour with extractOptionalObject(), which returns undefined for an
+// ARRAY, and then fell back to `?? { r: 1, g: 1, b: 1, a: 1 }`. The registry's own worked example for
+// set_vector_parameter_value ("Tint an instance rust-orange") passes value: [0.55, 0.27, 0.1, 1], so following
+// the documentation wrote opaque white and still answered success: true.
+describe('extractOptionalVector', () => {
+  it('accepts the documented array form and normalizes it to the bridge payload', () => {
+    // The exact input from the registry example.
+    expect(extractOptionalVector({ value: [0.55, 0.27, 0.1, 1] }, 'value')).toEqual({
+      r: 0.55, g: 0.27, b: 0.1, a: 1,
+    });
+  });
+
+  it('defaults alpha to 1 for a 3-element array', () => {
+    expect(extractOptionalVector({ value: [0.2, 0.4, 0.6] }, 'value')).toEqual({
+      r: 0.2, g: 0.4, b: 0.6, a: 1,
+    });
+  });
+
+  it('passes an object through unchanged', () => {
+    const obj = { r: 0.1, g: 0.2, b: 0.3, a: 0.4 };
+    expect(extractOptionalVector({ value: obj }, 'value')).toEqual(obj);
+  });
+
+  it('returns undefined only when the key is absent, so optional callers keep their own default', () => {
+    expect(extractOptionalVector({}, 'value')).toBeUndefined();
+    expect(extractOptionalVector({ value: null }, 'value')).toBeUndefined();
+  });
+
+  it('THROWS on a present-but-unusable value instead of silently resolving to a default colour', () => {
+    // This is the whole point: a caller-side `?? white` must never be reachable for a value the user did send.
+    expect(() => extractOptionalVector({ value: 'red' }, 'value')).toThrow();
+    expect(() => extractOptionalVector({ value: [1, 2] }, 'value')).toThrow();
+    expect(() => extractOptionalVector({ value: [1, 2, 3, 4, 5] }, 'value')).toThrow();
+    expect(() => extractOptionalVector({ value: [0.1, 'x', 0.3] }, 'value')).toThrow();
+    expect(() => extractOptionalVector({ value: [0.1, NaN, 0.3] }, 'value')).toThrow();
+  });
+});


### PR DESCRIPTION
## The bug

`set_vector_parameter_value` and `add_vector_parameter` read the colour with `extractOptionalObject()`, which returns `undefined` for an array:

```ts
// argument-helper.ts
if (typeof val === 'object' && !Array.isArray(val)) return val as Record<string, unknown>;
return undefined;
```

…and then fall back to `?? { r: 1, g: 1, b: 1, a: 1 }`. A caller who passes an array gets **opaque white** written to the material, and the response still reports `success: true`.

## This is your own documented example

From `canonical-registry.generated.ts`, `material.set_vector_parameter_value`:

```json
"title": "Tint an instance rust-orange",
"input": {
  "assetPath": "/Game/Materials/MI_Base_Rusty",
  "parameterName": "BaseTint",
  "value": [0.55, 0.27, 0.1, 1]
},
"output": { "success": true }
```

The schema does not catch it either — `value` is declared as `{ "description": "Vector value." }` with **no `type`**, so an array validates cleanly and is converted to white in TS before the bridge is ever called.

So: follow the documentation, ask for rust-orange, get white, and be told it worked.

## The fix

A new `extractOptionalVector()`:

- accepts the documented **array** form (3 or 4 finite numbers; alpha defaults to 1) and normalizes it to the `{ r, g, b, a }` object the bridge expects
- passes an object through unchanged
- returns `undefined` **only** when the key is absent — so `add_vector_parameter`, whose `defaultValue` is genuinely optional (`required: [materialPath, parameterName]`), keeps its white default
- **throws** on a value that is present but unusable, so a caller-side `?? white` can never silently substitute a colour the user did not ask for

`set_vector_parameter_value` lists `value` as required, so the throw is the behaviour that matters there.

## Tests

`tests/unit/tools/vector-parameter-value-normalization.test.ts` — 5 cases: the registry example verbatim, the 3-element alpha default, object pass-through, absent-vs-present, and each unusable shape.

Verified by mutation: reverting the array branch turns 3 of the 5 red; restoring it returns 5/5. `tsc --noEmit` clean.

This is the same class you have already taken in #610 (set_component_property must not report success for values it dropped) and #568 (set_camera discarded the requested position and still reported success).

🤖 Generated with [Claude Code](https://claude.com/claude-code)