### PR TITLE
fix(security): report why a path was refused instead of always blaming traversal

### DIFF
--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/Context/McpAutomationBridge_BlueprintGraphHandlersContextShared.cpp
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Domains/BlueprintGraph/Context/McpAutomationBridge_BlueprintGraphHandlersContextShared.cpp
@@ -1,5 +1,32 @@
 #include "Domains/BlueprintGraph/McpAutomationBridge_BlueprintGraphHandlersPrivate.h"
 
+namespace {
+/** Turn a refusal into a message that names the ACTUAL reason instead of always blaming traversal. */
+FString McpDescribePathRejection(const TCHAR *FieldName, const FString &InPath,
+                                 EMcpPathRejection Reason,
+                                 const FText &Detail)
+{
+    const FString Because = Detail.IsEmpty() ? FString() : FString::Printf(TEXT(" %s"), *Detail.ToString());
+    switch (Reason)
+    {
+    case EMcpPathRejection::WindowsAbsolutePath:
+        return FString::Printf(
+            TEXT("Invalid %s '%s': absolute filesystem paths are not accepted; use an asset path such as /Game/...."),
+            FieldName, *InPath);
+    case EMcpPathRejection::Traversal:
+        return FString::Printf(TEXT("Invalid %s '%s': the path contains a '..' traversal segment."), FieldName, *InPath);
+    case EMcpPathRejection::NotAMountedRoot:
+        return FString::Printf(
+            TEXT("Invalid %s '%s': not under a mounted content root.%s"), FieldName, *InPath, *Because);
+    case EMcpPathRejection::Empty:
+        return FString::Printf(TEXT("Invalid %s: the path is empty."), FieldName);
+    default:
+        return FString::Printf(TEXT("Invalid %s '%s'."), FieldName, *InPath);
+    }
+}
+} // namespace
+
+
 namespace McpBlueprintGraphHandlers
 {
 
@@ -30,24 +57,32 @@ bool ValidateProvidedPaths(const FActionContext& Context)
 {
     FString AssetPath;
     if (Context.Payload->TryGetStringField(TEXT("assetPath"), AssetPath) &&
-        !AssetPath.IsEmpty() &&
-        SanitizeProjectRelativePath(AssetPath).IsEmpty())
+        !AssetPath.IsEmpty())
     {
-        Context.SendError(
-            TEXT("Invalid assetPath: contains traversal sequences or invalid characters."),
-            TEXT("INVALID_PATH"));
-        return false;
+        EMcpPathRejection Reason = EMcpPathRejection::None;
+        FText Detail;
+        if (SanitizeProjectRelativePath(AssetPath, &Reason, &Detail).IsEmpty())
+        {
+            Context.SendError(
+                McpDescribePathRejection(TEXT("assetPath"), AssetPath, Reason, Detail),
+                TEXT("INVALID_PATH"));
+            return false;
+        }
     }
 
     FString BlueprintPath;
     if (Context.Payload->TryGetStringField(TEXT("blueprintPath"), BlueprintPath) &&
-        !BlueprintPath.IsEmpty() &&
-        SanitizeProjectRelativePath(BlueprintPath).IsEmpty())
+        !BlueprintPath.IsEmpty())
     {
-        Context.SendError(
-            TEXT("Invalid blueprintPath: contains traversal sequences or invalid characters."),
-            TEXT("INVALID_PATH"));
-        return false;
+        EMcpPathRejection Reason = EMcpPathRejection::None;
+        FText Detail;
+        if (SanitizeProjectRelativePath(BlueprintPath, &Reason, &Detail).IsEmpty())
+        {
+            Context.SendError(
+                McpDescribePathRejection(TEXT("blueprintPath"), BlueprintPath, Reason, Detail),
+                TEXT("INVALID_PATH"));
+            return false;
+        }
     }
 
     return true;

--- a/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Foundation/BridgeHelpers/Security/McpAutomationBridgeHelpersProjectPaths.h
+++ b/plugins/McpAutomationBridge/Source/McpAutomationBridge/Private/Foundation/BridgeHelpers/Security/McpAutomationBridgeHelpersProjectPaths.h
@@ -25,9 +25,40 @@
 #include "Misc/PackageName.h"
 #include "Misc/Paths.h"
 
-static inline FString SanitizeProjectRelativePath(const FString &InPath) {
-  if (InPath.IsEmpty())
+/** Why SanitizeProjectRelativePath refused a path. */
+enum class EMcpPathRejection : uint8 {
+  None,
+  Empty,
+  WindowsAbsolutePath,
+  Traversal,
+  NotAMountedRoot,
+};
+
+/**
+ * Normalize a project-relative asset path, or return an empty string if it must be refused.
+ *
+ * Pass OutReason/OutDetail to learn WHY. Without them the four refusal paths are indistinguishable to the
+ * caller, so an unmounted content root (a plugin that is not enabled, a typo'd root) gets reported to the user
+ * as a path-traversal violation. OutDetail carries the engine's own explanation for the mount case, which was
+ * previously computed and then dropped at the return.
+ */
+static inline FString SanitizeProjectRelativePath(
+    const FString &InPath, EMcpPathRejection *OutReason = nullptr,
+    FText *OutDetail = nullptr) {
+  const auto Refuse = [OutReason, OutDetail](EMcpPathRejection Reason,
+                                             const FText &Detail) -> FString {
+    if (OutReason)
+      *OutReason = Reason;
+    if (OutDetail)
+      *OutDetail = Detail;
     return FString();
+  };
+  if (OutReason)
+    *OutReason = EMcpPathRejection::None;
+
+  if (InPath.IsEmpty())
+    return Refuse(EMcpPathRejection::Empty,
+                  NSLOCTEXT("Mcp", "PathEmpty", "The path is empty."));
 
   FString CleanPath = InPath;
 
@@ -37,7 +68,11 @@ static inline FString SanitizeProjectRelativePath(const FString &InPath) {
         LogMcpAutomationBridgeSubsystem, Warning,
         TEXT("SanitizeProjectRelativePath: Rejected Windows absolute path: %s"),
         *InPath);
-    return FString();
+    return Refuse(
+        EMcpPathRejection::WindowsAbsolutePath,
+        NSLOCTEXT("Mcp", "PathWindowsAbsolute",
+                  "The path is an absolute filesystem path; an asset path such "
+                  "as /Game/... is required."));
   }
 
   FPaths::NormalizeFilename(CleanPath);
@@ -57,7 +92,9 @@ static inline FString SanitizeProjectRelativePath(const FString &InPath) {
         LogMcpAutomationBridgeSubsystem, Warning,
         TEXT("SanitizeProjectRelativePath: Rejected path containing '..': %s"),
         *InPath);
-    return FString();
+    return Refuse(EMcpPathRejection::Traversal,
+                  NSLOCTEXT("Mcp", "PathTraversal",
+                            "The path contains a '..' traversal segment."));
   }
 
   // Ensure path starts with a slash
@@ -81,7 +118,7 @@ static inline FString SanitizeProjectRelativePath(const FString &InPath) {
           LogMcpAutomationBridgeSubsystem, Warning,
           TEXT("SanitizeProjectRelativePath: Rejected path '%s': %s"),
           *InPath, *MountReason.ToString());
-      return FString();
+      return Refuse(EMcpPathRejection::NotAMountedRoot, MountReason);
     }
   }
 


### PR DESCRIPTION
## The problem

`SanitizeProjectRelativePath` refuses a path for **four** different reasons — empty, Windows absolute path, `..` traversal, and not-a-mounted-root — and returns a bare `FString()` for every one of them. Callers cannot tell them apart, so they all print the same message.

The concrete user-visible bug: a path under a content root that simply **is not mounted** (a plugin that is not enabled, a typo'd root) is reported as a **path-traversal / invalid-character violation** — i.e. the tool tells the user they attempted something that looks like a security probe, when they only referenced a root that is not loaded.

The real reason is already computed, logged, and then discarded:

```cpp
FText MountReason;
if (!FPackageName::IsValidLongPackageName(CleanPath, true, &MountReason)) {
  UE_LOG(LogMcpAutomationBridgeSubsystem, Warning, TEXT("... Rejected path '%s': %s"), *InPath, *MountReason.ToString());
  return FString();          // MountReason dies here — it never reaches the MCP response
}
```

So today the shared BlueprintGraph validator can only say:

```
Invalid assetPath: contains traversal sequences or invalid characters.
```

which is wrong for three of the four refusal paths.

## The fix

Two **optional** out-parameters on the existing function:

```cpp
enum class EMcpPathRejection : uint8 { None, Empty, WindowsAbsolutePath, Traversal, NotAMountedRoot };

static inline FString SanitizeProjectRelativePath(
    const FString& InPath,
    EMcpPathRejection* OutReason = nullptr,
    FText* OutDetail = nullptr);
```

`OutDetail` carries the engine's own `MountReason` for the mount case.

**Nothing is forced to migrate.** The defaults keep the signature source-compatible: all **201 call sites across 144 files** compile and behave exactly as before. Callers opt in when they want a better message.

BlueprintGraph's shared context validator is migrated as the worked example, so an unmounted root now reads:

```
Invalid assetPath '/NotMounted/Thing': not under a mounted content root. <engine's reason>
```

and only a real `..` segment is reported as traversal.

## Verification

Compiled for UE 5.8 via `RunUAT BuildPlugin` — `BUILD SUCCESSFUL`, no new warnings. Confirmed the source that was actually compiled contains the change (`EMcpPathRejection` ×8, `McpDescribePathRejection` ×3) rather than assuming the build picked it up.

Natural companion to #603, which fixed the TS half of this same "plugin content mounts are not a security violation" story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)